### PR TITLE
fix: use crypto.randomUUID() for trigger conversationId

### DIFF
--- a/src/core/server.ts
+++ b/src/core/server.ts
@@ -178,7 +178,7 @@ async function handleTrigger(req: Request): Promise<Response> {
 		return Response.json({ status: "error", message: "Missing required field: task" }, { status: 400 });
 	}
 
-	const conversationId = `trigger:${Date.now()}`;
+	const conversationId = `trigger:${crypto.randomUUID()}`;
 	const source = body.source ?? "http";
 
 	try {


### PR DESCRIPTION
## Summary
- Replace `Date.now()` with `crypto.randomUUID()` for trigger endpoint conversationId generation
- `Date.now()` has millisecond precision and can collide when concurrent requests arrive in the same tick, causing session conflicts in the runtime

## Test plan
- [x] All 822 tests pass
- [x] Lint clean
- [ ] Verify conversationId uniqueness: fire two concurrent `POST /trigger` requests and confirm distinct conversation IDs in the response