### PR TITLE
fix: load user-scope skills from ~/.claude/skills

### DIFF
--- a/src/agent/runtime.ts
+++ b/src/agent/runtime.ts
@@ -190,7 +190,7 @@ export class AgentRuntime {
 					model: this.config.model,
 					permissionMode: "bypassPermissions",
 					allowDangerouslySkipPermissions: true,
-					settingSources: ["project"],
+					settingSources: ["project", "user"],
 					systemPrompt: {
 						type: "preset" as const,
 						preset: "claude_code" as const,


### PR DESCRIPTION
## Summary

Flip `settingSources` from `["project"]` to `["project", "user"]` in `src/agent/runtime.ts` so the Claude Agent SDK scans user-scope skill directories on every `query()` init.

## Why

The SDK only reads `SKILL.md` files from directories whose scope is enabled via `settingSources`. Phantom was only enabling project scope, which meant any `SKILL.md` dropped into `~/.claude/skills/<name>/` inside the container (on the persistent volume that survives rebuilds) was silently ignored. This one-character fix unblocks user-authored skills from being picked up by the next message the agent handles, with no restart, no rescan API, no other plumbing.

## Scope

- 1 line changed in `src/agent/runtime.ts`
- Zero test changes
- Zero behavioural change for existing deployments that do not ship user-scope skills
- Additive: operators who want to drop a skill into the mounted volume can now do so

## Test plan

- [x] `bun test` - 978 pass / 0 fail / 10 skip
- [x] `bun run lint` clean
- [x] `bun run typecheck` clean
- [ ] After merge, drop a test `SKILL.md` into the running container's user skill directory and verify it fires on the next message