### PR TITLE
feat: plugins, marketplace browser, curated overlay mechanism

### DIFF
--- a/config/plugins-curated.json
+++ b/config/plugins-curated.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://phantom.ghostwright.dev/plugins-curated.schema.json",
+  "version": 1,
+  "plugins": {}
+}

--- a/public/dashboard/dashboard.css
+++ b/public/dashboard/dashboard.css
@@ -966,3 +966,420 @@ body {
 	flex-direction: column;
 	gap: 8px;
 }
+
+/* ==== Plugins tab ==== */
+.plugins-filters {
+	display: flex;
+	flex-direction: column;
+	gap: var(--space-3);
+	margin-bottom: var(--space-5);
+}
+.plugins-tabs {
+	display: flex;
+	gap: var(--space-2);
+	flex-wrap: wrap;
+}
+.plugins-tab {
+	font-family: Inter, sans-serif;
+	font-size: 12px;
+	font-weight: 500;
+	padding: 7px 14px;
+	border: 1px solid var(--color-base-300);
+	border-radius: var(--radius-pill);
+	background: transparent;
+	color: color-mix(in oklab, var(--color-base-content) 70%, transparent);
+	cursor: pointer;
+	transition: border-color var(--motion-fast) var(--ease-out),
+		background-color var(--motion-fast) var(--ease-out),
+		color var(--motion-fast) var(--ease-out);
+}
+.plugins-tab:hover {
+	border-color: color-mix(in oklab, var(--color-primary) 40%, var(--color-base-300));
+	color: var(--color-base-content);
+}
+.plugins-tab[aria-current="true"] {
+	background: var(--color-primary);
+	color: var(--color-primary-content);
+	border-color: var(--color-primary);
+}
+.plugins-tab:focus-visible {
+	outline: none;
+	box-shadow: 0 0 0 3px color-mix(in oklab, var(--color-primary) 28%, transparent);
+}
+.plugins-cats {
+	display: flex;
+	gap: 6px;
+	flex-wrap: wrap;
+}
+.plugins-cat-chip {
+	font-family: Inter, sans-serif;
+	font-size: 11px;
+	padding: 4px 10px;
+	border: 1px solid var(--color-base-300);
+	border-radius: var(--radius-pill);
+	background: var(--color-base-200);
+	color: color-mix(in oklab, var(--color-base-content) 65%, transparent);
+	cursor: pointer;
+	transition: border-color var(--motion-fast), background-color var(--motion-fast);
+}
+.plugins-cat-chip:hover {
+	border-color: color-mix(in oklab, var(--color-primary) 35%, var(--color-base-300));
+}
+.plugins-cat-chip[data-active="true"] {
+	border-color: var(--color-primary);
+	color: var(--color-primary);
+	background: color-mix(in oklab, var(--color-primary) 6%, var(--color-base-200));
+}
+.plugins-search {
+	position: relative;
+	max-width: 420px;
+}
+.plugins-search input {
+	width: 100%;
+	box-sizing: border-box;
+	font-family: Inter, sans-serif;
+	font-size: 13px;
+	background: var(--color-base-200);
+	color: var(--color-base-content);
+	border: 1px solid var(--color-base-300);
+	border-radius: var(--radius-md);
+	padding: 9px 12px 9px 34px;
+	transition: border-color var(--motion-base) var(--ease-out), box-shadow var(--motion-base) var(--ease-out);
+}
+.plugins-search input:focus {
+	outline: none;
+	border-color: var(--color-primary);
+	box-shadow: 0 0 0 3px color-mix(in oklab, var(--color-primary) 18%, transparent);
+}
+.plugins-search svg {
+	position: absolute;
+	left: 11px;
+	top: 50%;
+	transform: translateY(-50%);
+	width: 14px;
+	height: 14px;
+	color: color-mix(in oklab, var(--color-base-content) 50%, transparent);
+	pointer-events: none;
+}
+
+.plugins-grid {
+	display: grid;
+	grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+	gap: var(--space-4);
+}
+.plugins-stale {
+	font-size: 12px;
+	color: color-mix(in oklab, var(--color-warning) 90%, var(--color-base-content));
+	margin: 0 0 var(--space-3);
+}
+.plugins-hidden-note {
+	font-size: 11px;
+	color: color-mix(in oklab, var(--color-base-content) 50%, transparent);
+	margin: var(--space-4) 0 0;
+}
+
+.plugins-card {
+	display: flex;
+	flex-direction: column;
+	gap: var(--space-3);
+	padding: var(--space-4);
+	border: 1px solid var(--color-base-300);
+	border-radius: var(--radius-lg);
+	background: var(--color-base-200);
+	transition: border-color var(--motion-base) var(--ease-out),
+		transform var(--motion-base) var(--ease-out),
+		box-shadow var(--motion-base) var(--ease-out);
+}
+.plugins-card:hover {
+	border-color: color-mix(in oklab, var(--color-primary) 30%, var(--color-base-300));
+	transform: translateY(-1px);
+	box-shadow: 0 6px 20px rgba(0, 0, 0, 0.05);
+}
+.plugins-card-header {
+	display: flex;
+	align-items: flex-start;
+	justify-content: space-between;
+	gap: var(--space-2);
+}
+.plugins-card-title {
+	font-family: 'JetBrains Mono', monospace;
+	font-size: 13px;
+	font-weight: 600;
+	color: var(--color-base-content);
+	margin: 0;
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+.plugins-card-status {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	flex-shrink: 0;
+}
+.plugins-status-installed {
+	display: inline-flex;
+	align-items: center;
+	gap: 4px;
+	font-size: 10px;
+	font-weight: 500;
+	letter-spacing: 0.03em;
+	text-transform: uppercase;
+	padding: 3px 8px;
+	border-radius: var(--radius-pill);
+	background: color-mix(in oklab, var(--color-success) 12%, transparent);
+	color: var(--color-success);
+}
+.plugins-status-dot {
+	width: 6px;
+	height: 6px;
+	border-radius: 50%;
+	background: var(--color-success);
+}
+.plugins-pin {
+	font-family: 'JetBrains Mono', monospace;
+	font-size: 10px;
+	padding: 3px 8px;
+	border-radius: var(--radius-pill);
+	background: color-mix(in oklab, var(--color-primary) 12%, transparent);
+	color: var(--color-primary);
+}
+.plugins-card-desc {
+	font-size: 12.5px;
+	line-height: 1.5;
+	color: color-mix(in oklab, var(--color-base-content) 65%, transparent);
+	margin: 0;
+	overflow: hidden;
+	display: -webkit-box;
+	-webkit-line-clamp: 3;
+	line-clamp: 3;
+	-webkit-box-orient: vertical;
+}
+.plugins-card-note {
+	font-size: 11.5px;
+	line-height: 1.5;
+	color: color-mix(in oklab, var(--color-primary) 90%, var(--color-base-content));
+	margin: 0;
+	padding: 6px 10px;
+	border-left: 2px solid var(--color-primary);
+	background: color-mix(in oklab, var(--color-primary) 5%, transparent);
+	border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+}
+.plugins-card-badges {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 5px;
+}
+.plugins-source-badge {
+	font-family: 'JetBrains Mono', monospace;
+	font-size: 10px;
+	padding: 3px 7px;
+	border-radius: var(--radius-pill);
+	background: color-mix(in oklab, var(--color-base-content) 6%, transparent);
+	color: color-mix(in oklab, var(--color-base-content) 65%, transparent);
+}
+.plugins-source-url {
+	background: color-mix(in oklab, var(--color-primary) 12%, transparent);
+	color: var(--color-primary);
+}
+.plugins-source-github {
+	background: color-mix(in oklab, var(--color-info) 12%, transparent);
+	color: var(--color-info);
+}
+.plugins-source-local {
+	background: color-mix(in oklab, var(--color-base-content) 8%, transparent);
+	color: color-mix(in oklab, var(--color-base-content) 70%, transparent);
+}
+.plugins-category-badge {
+	font-family: Inter, sans-serif;
+	font-size: 10px;
+	font-weight: 500;
+	letter-spacing: 0.03em;
+	padding: 3px 8px;
+	border-radius: var(--radius-pill);
+	background: color-mix(in oklab, var(--color-base-content) 5%, transparent);
+	color: color-mix(in oklab, var(--color-base-content) 60%, transparent);
+}
+.plugins-curated-tag {
+	font-family: Inter, sans-serif;
+	font-size: 10px;
+	font-weight: 500;
+	letter-spacing: 0.03em;
+	padding: 3px 8px;
+	border-radius: var(--radius-pill);
+}
+.plugins-curated-phantom-recommended {
+	background: color-mix(in oklab, var(--color-primary) 14%, transparent);
+	color: var(--color-primary);
+}
+.plugins-curated-production-tested {
+	background: color-mix(in oklab, var(--color-success) 14%, transparent);
+	color: var(--color-success);
+}
+.plugins-curated-experimental {
+	background: color-mix(in oklab, var(--color-warning) 14%, transparent);
+	color: var(--color-warning);
+}
+.plugins-curated-deprecated {
+	background: color-mix(in oklab, var(--color-base-content) 8%, transparent);
+	color: color-mix(in oklab, var(--color-base-content) 50%, transparent);
+}
+.plugins-card-actions {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: var(--space-2);
+	margin-top: auto;
+	padding-top: var(--space-2);
+}
+.plugins-history-link {
+	background: transparent;
+	border: 0;
+	padding: 6px 4px;
+	font-family: Inter, sans-serif;
+	font-size: 11px;
+	color: color-mix(in oklab, var(--color-base-content) 55%, transparent);
+	cursor: pointer;
+	text-decoration: underline;
+	text-decoration-color: color-mix(in oklab, var(--color-base-content) 25%, transparent);
+	text-underline-offset: 3px;
+	transition: color var(--motion-fast) var(--ease-out);
+}
+.plugins-history-link:hover {
+	color: var(--color-base-content);
+}
+
+/* Plugins modal contents */
+.plugins-modal-key {
+	font-family: 'JetBrains Mono', monospace;
+	font-size: 12px;
+	color: var(--color-primary);
+	margin: 0 0 var(--space-2);
+	padding: 6px 10px;
+	background: color-mix(in oklab, var(--color-primary) 6%, transparent);
+	border-radius: var(--radius-sm);
+}
+.plugins-modal-source {
+	font-size: 11.5px;
+	color: color-mix(in oklab, var(--color-base-content) 60%, transparent);
+	margin: 0 0 var(--space-2);
+	word-break: break-all;
+}
+.plugins-modal-desc {
+	font-size: 13px;
+	line-height: 1.55;
+	color: color-mix(in oklab, var(--color-base-content) 75%, transparent);
+	margin: 0 0 var(--space-3);
+}
+.plugins-modal-warning {
+	border: 1px solid color-mix(in oklab, var(--color-warning) 35%, var(--color-base-300));
+	background: color-mix(in oklab, var(--color-warning) 5%, transparent);
+	border-radius: var(--radius-md);
+	padding: var(--space-3) var(--space-4);
+	margin: 0 0 var(--space-3);
+}
+.plugins-modal-warning-title {
+	font-size: 12px;
+	font-weight: 600;
+	color: color-mix(in oklab, var(--color-warning) 95%, var(--color-base-content));
+	margin: 0 0 6px;
+}
+.plugins-modal-warning ul {
+	margin: 0 0 8px;
+	padding-left: 18px;
+	font-size: 12px;
+	line-height: 1.6;
+	color: color-mix(in oklab, var(--color-base-content) 70%, transparent);
+}
+.plugins-modal-warning-foot {
+	font-size: 11.5px;
+	line-height: 1.5;
+	color: color-mix(in oklab, var(--color-base-content) 65%, transparent);
+	margin: 0;
+}
+.plugins-trust-row {
+	display: flex;
+	align-items: center;
+	gap: var(--space-2);
+	font-size: 13px;
+	color: var(--color-base-content);
+	cursor: pointer;
+	user-select: none;
+}
+.plugins-trust-row input[type="checkbox"] {
+	width: 16px;
+	height: 16px;
+	accent-color: var(--color-primary);
+	cursor: pointer;
+}
+
+/* Audit timeline */
+.plugins-audit-list {
+	display: flex;
+	flex-direction: column;
+	gap: 6px;
+	max-height: 320px;
+	overflow-y: auto;
+}
+.plugins-audit-row {
+	display: grid;
+	grid-template-columns: auto auto auto 1fr;
+	align-items: center;
+	gap: var(--space-2);
+	padding: 8px 10px;
+	font-family: 'JetBrains Mono', monospace;
+	font-size: 11px;
+	border: 1px solid var(--color-base-300);
+	border-radius: var(--radius-sm);
+	background: var(--color-base-100);
+}
+.plugins-audit-time { color: color-mix(in oklab, var(--color-base-content) 55%, transparent); }
+.plugins-audit-action {
+	font-weight: 600;
+	padding: 2px 7px;
+	border-radius: var(--radius-pill);
+	font-size: 10px;
+	letter-spacing: 0.03em;
+	text-transform: uppercase;
+}
+.plugins-audit-install { background: color-mix(in oklab, var(--color-success) 14%, transparent); color: var(--color-success); }
+.plugins-audit-uninstall { background: color-mix(in oklab, var(--color-warning) 14%, transparent); color: var(--color-warning); }
+.plugins-audit-reinstall { background: color-mix(in oklab, var(--color-info) 14%, transparent); color: var(--color-info); }
+.plugins-audit-seed { background: color-mix(in oklab, var(--color-primary) 12%, transparent); color: var(--color-primary); }
+.plugins-audit-actor { color: color-mix(in oklab, var(--color-base-content) 60%, transparent); }
+.plugins-audit-diff { color: color-mix(in oklab, var(--color-base-content) 70%, transparent); }
+
+/* Find modal */
+.plugins-find-eyebrow {
+	font-size: 10px;
+	font-weight: 600;
+	letter-spacing: 0.09em;
+	text-transform: uppercase;
+	color: color-mix(in oklab, var(--color-base-content) 50%, transparent);
+	margin: var(--space-3) 0 var(--space-2);
+}
+.plugins-find-row {
+	padding: 10px 12px;
+	border: 1px solid var(--color-base-300);
+	border-radius: var(--radius-md);
+	background: var(--color-base-100);
+	margin-bottom: 6px;
+}
+.plugins-find-row-head {
+	display: flex;
+	align-items: center;
+	gap: var(--space-2);
+	margin-bottom: 4px;
+}
+.plugins-find-name {
+	font-family: 'JetBrains Mono', monospace;
+	font-size: 12px;
+	font-weight: 600;
+	color: var(--color-base-content);
+}
+.plugins-find-row-desc {
+	font-size: 11.5px;
+	line-height: 1.5;
+	color: color-mix(in oklab, var(--color-base-content) 65%, transparent);
+}

--- a/public/dashboard/dashboard.js
+++ b/public/dashboard/dashboard.js
@@ -246,7 +246,7 @@
 		var name = parsed.route;
 		deactivateAllRoutes();
 
-		var liveRoutes = ["skills", "memory-files"];
+		var liveRoutes = ["skills", "memory-files", "plugins"];
 		var comingSoon = ["sessions", "cost", "scheduler", "evolution", "memory", "settings"];
 
 		if (liveRoutes.indexOf(name) >= 0 && routes[name]) {

--- a/public/dashboard/index.html
+++ b/public/dashboard/index.html
@@ -44,6 +44,10 @@
         <svg class="dash-sidebar-icon" fill="none" viewBox="0 0 24 24" stroke-width="1.6" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m2.25 0H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z"/></svg>
         <span>Memory files</span>
       </a>
+      <a href="#/plugins" class="dash-sidebar-item" data-route="plugins">
+        <svg class="dash-sidebar-icon" fill="none" viewBox="0 0 24 24" stroke-width="1.6" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M14.25 6.087c0-.355.186-.676.401-.959.221-.29.349-.634.349-1.003 0-1.036-1.007-1.875-2.25-1.875s-2.25.84-2.25 1.875c0 .369.128.713.349 1.003.215.283.401.604.401.959v0a.64.64 0 0 1-.657.643 48.39 48.39 0 0 1-4.163-.3c.186 1.613.293 3.25.315 4.907a.656.656 0 0 1-.658.663v0c-.355 0-.676-.186-.959-.401a1.647 1.647 0 0 0-1.003-.349c-1.036 0-1.875 1.007-1.875 2.25s.84 2.25 1.875 2.25c.369 0 .713-.128 1.003-.349.283-.215.604-.401.959-.401v0c.31 0 .555.26.532.57a48.039 48.039 0 0 1-.642 5.056c1.518.19 3.058.309 4.616.354a.64.64 0 0 0 .657-.643v0c0-.355-.186-.676-.401-.959a1.647 1.647 0 0 1-.349-1.003c0-1.035 1.008-1.875 2.25-1.875 1.243 0 2.25.84 2.25 1.875 0 .369-.128.713-.349 1.003-.215.283-.4.604-.4.959v0c0 .333.277.599.61.58a48.1 48.1 0 0 0 5.427-.63 48.05 48.05 0 0 0 .582-4.717.532.532 0 0 0-.533-.57v0c-.355 0-.676.186-.959.401-.29.221-.634.349-1.003.349-1.035 0-1.875-1.007-1.875-2.25s.84-2.25 1.875-2.25c.37 0 .713.128 1.003.349.283.215.604.401.96.401v0a.656.656 0 0 0 .658-.663 48.422 48.422 0 0 0-.37-5.36c-1.886.342-3.81.574-5.766.689a.578.578 0 0 1-.61-.58v0Z"/></svg>
+        <span>Plugins</span>
+      </a>
     </nav>
 
     <div class="dash-sidebar-eyebrow" style="margin-top:var(--space-5);">Coming soon</div>
@@ -89,6 +93,7 @@
   <main class="dash-main" id="dash-main">
     <div id="route-skills" class="dash-route" hidden></div>
     <div id="route-memory-files" class="dash-route" hidden></div>
+    <div id="route-plugins" class="dash-route" hidden></div>
     <div id="route-soon" class="dash-route" hidden></div>
   </main>
 
@@ -99,6 +104,7 @@
 <script src="/ui/dashboard/dashboard.js"></script>
 <script src="/ui/dashboard/skills.js"></script>
 <script src="/ui/dashboard/memory-files.js"></script>
+<script src="/ui/dashboard/plugins.js"></script>
 <script>window.PhantomDashboard.init();</script>
 </body>
 </html>

--- a/public/dashboard/plugins.js
+++ b/public/dashboard/plugins.js
@@ -1,0 +1,501 @@
+// Plugins tab: marketplace browser, trust modal, install, uninstall, audit
+// timeline, find-a-plugin search.
+//
+// Module contract: registers with PhantomDashboard via registerRoute('plugins').
+// mount(container, arg, ctx) is called on hash change. ctx provides esc, api,
+// toast, openModal, navigate, setBreadcrumb, registerDirtyChecker.
+//
+// Plugins is mostly read-only browsing with an install action, so this module
+// does not register a dirty checker (no edit state to lose).
+
+(function () {
+	var state = {
+		catalog: null,
+		filter: "all", // all | installed | recommended
+		category: null,
+		search: "",
+		loading: false,
+		fetchedAt: null,
+		hiddenByTransport: 0,
+		fromStaleCache: false,
+	};
+	var ctx = null;
+	var root = null;
+
+	function esc(s) { return ctx.esc(s); }
+
+	function renderHeader() {
+		return (
+			'<div class="dash-header">' +
+			'<p class="dash-header-eyebrow">Plugins</p>' +
+			'<h1 class="dash-header-title">Plugins</h1>' +
+			'<p class="dash-header-lead">Install plugins from the claude-plugins-official marketplace. Each install runs through a trust modal and lands in your audit log. The agent picks up new plugins on its next message.</p>' +
+			'<div class="dash-header-actions">' +
+			'<button class="dash-btn dash-btn-ghost" id="plugins-find-btn">Ask Phantom what plugin I need</button>' +
+			'<button class="dash-btn dash-btn-ghost" id="plugins-refresh-btn">Refresh marketplace</button>' +
+			'</div>' +
+			'</div>'
+		);
+	}
+
+	function uniqueCategories(plugins) {
+		var set = {};
+		plugins.forEach(function (p) {
+			if (p.category) set[p.category] = true;
+		});
+		return Object.keys(set).sort();
+	}
+
+	function renderFilters() {
+		var plugins = (state.catalog && state.catalog.plugins) || [];
+		var installedCount = plugins.filter(function (p) { return p.enabled; }).length;
+		var recommendedCount = plugins.filter(function (p) {
+			return (p.curated_tags || []).indexOf("phantom-recommended") >= 0;
+		}).length;
+		var cats = uniqueCategories(plugins);
+
+		var parts = [];
+		parts.push('<div class="plugins-filters">');
+		parts.push('<div class="plugins-tabs" role="tablist">');
+		parts.push(filterPill("all", "All " + plugins.length));
+		parts.push(filterPill("installed", "Installed " + installedCount));
+		parts.push(filterPill("recommended", "Recommended " + recommendedCount));
+		parts.push('</div>');
+
+		if (cats.length > 0) {
+			parts.push('<div class="plugins-cats">');
+			parts.push(catChip(null, "All categories"));
+			cats.forEach(function (c) { parts.push(catChip(c, c)); });
+			parts.push('</div>');
+		}
+
+		parts.push('<div class="plugins-search">');
+		parts.push('<svg fill="none" viewBox="0 0 24 24" stroke-width="1.8" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z"/></svg>');
+		parts.push('<input type="search" id="plugins-search" placeholder="Search by name, description, or category" value="' + esc(state.search) + '">');
+		parts.push('</div>');
+		parts.push('</div>');
+		return parts.join("");
+	}
+
+	function filterPill(value, label) {
+		var current = state.filter === value ? ' aria-current="true"' : "";
+		return '<button class="plugins-tab" data-filter="' + esc(value) + '"' + current + '>' + esc(label) + '</button>';
+	}
+
+	function catChip(value, label) {
+		var current = (state.category === value || (value === null && state.category === null)) ? ' data-active="true"' : "";
+		return '<button class="plugins-cat-chip" data-cat="' + esc(value || "") + '"' + current + '>' + esc(label) + '</button>';
+	}
+
+	function filteredPlugins() {
+		if (!state.catalog) return [];
+		var list = state.catalog.plugins.slice();
+		if (state.filter === "installed") {
+			list = list.filter(function (p) { return p.enabled; });
+		} else if (state.filter === "recommended") {
+			list = list.filter(function (p) { return (p.curated_tags || []).indexOf("phantom-recommended") >= 0; });
+		}
+		if (state.category) {
+			list = list.filter(function (p) { return p.category === state.category; });
+		}
+		var q = (state.search || "").trim().toLowerCase();
+		if (q) {
+			list = list.filter(function (p) {
+				return (
+					(p.name || "").toLowerCase().indexOf(q) >= 0 ||
+					(p.description || "").toLowerCase().indexOf(q) >= 0 ||
+					(p.category || "").toLowerCase().indexOf(q) >= 0
+				);
+			});
+		}
+		return list;
+	}
+
+	function renderCard(plugin) {
+		var sourceClass = "plugins-source-" + plugin.source_type;
+		var sourceLabel = plugin.source_type;
+		var actionBtn = plugin.enabled
+			? '<button class="dash-btn dash-btn-ghost dash-btn-sm" data-uninstall="' + esc(plugin.name) + '">Uninstall</button>'
+			: '<button class="dash-btn dash-btn-primary dash-btn-sm" data-install="' + esc(plugin.name) + '">Install</button>';
+		var statusBadge = plugin.enabled
+			? '<span class="plugins-status-installed"><span class="plugins-status-dot"></span>installed</span>'
+			: "";
+		var pinnedBadge = plugin.pinned_version
+			? '<span class="plugins-pin">v' + esc(plugin.pinned_version) + '</span>'
+			: "";
+
+		var curatedTags = (plugin.curated_tags || []).map(function (t) {
+			return '<span class="plugins-curated-tag plugins-curated-' + esc(t) + '">' + esc(t.replace(/-/g, " ")) + '</span>';
+		}).join("");
+
+		var noteHtml = plugin.curated_note
+			? '<p class="plugins-card-note">' + esc(plugin.curated_note) + '</p>'
+			: "";
+
+		return (
+			'<article class="plugins-card" data-plugin="' + esc(plugin.name) + '">' +
+			'<header class="plugins-card-header">' +
+			'<h3 class="plugins-card-title">' + esc(plugin.name) + '</h3>' +
+			'<div class="plugins-card-status">' + statusBadge + pinnedBadge + '</div>' +
+			'</header>' +
+			'<p class="plugins-card-desc">' + esc(plugin.description || "") + '</p>' +
+			noteHtml +
+			'<div class="plugins-card-badges">' +
+			'<span class="plugins-source-badge ' + sourceClass + '">' + esc(sourceLabel) + '</span>' +
+			(plugin.category ? '<span class="plugins-category-badge">' + esc(plugin.category) + '</span>' : "") +
+			curatedTags +
+			'</div>' +
+			'<div class="plugins-card-actions">' +
+			actionBtn +
+			'<button class="plugins-history-link" data-history="' + esc(plugin.name) + '">history</button>' +
+			'</div>' +
+			'</article>'
+		);
+	}
+
+	function renderGrid() {
+		if (state.loading) {
+			return renderSkeletons();
+		}
+		if (!state.catalog) {
+			return (
+				'<div class="dash-empty">' +
+				'<h3 class="dash-empty-title">Marketplace unreachable</h3>' +
+				'<p class="dash-empty-body">We could not fetch the plugin marketplace. Check your connection or try Refresh marketplace above.</p>' +
+				'</div>'
+			);
+		}
+		var plugins = filteredPlugins();
+		if (plugins.length === 0) {
+			return (
+				'<div class="dash-empty">' +
+				'<h3 class="dash-empty-title">No plugins match</h3>' +
+				'<p class="dash-empty-body">Try a different filter, category, or search term.</p>' +
+				'</div>'
+			);
+		}
+		var cards = plugins.map(renderCard).join("");
+		var staleNote = state.fromStaleCache
+			? '<p class="plugins-stale">Showing cached marketplace, latest fetch failed.</p>'
+			: "";
+		var hiddenNote =
+			state.hiddenByTransport > 0
+				? '<p class="plugins-hidden-note">' + state.hiddenByTransport + ' plugin' + (state.hiddenByTransport === 1 ? "" : "s") + ' hidden because they use a transport (git-subdir, npm, pip, file) not supported in this release.</p>'
+				: "";
+		return staleNote + '<div class="plugins-grid">' + cards + '</div>' + hiddenNote;
+	}
+
+	function renderSkeletons() {
+		var n = 6;
+		var parts = ['<div class="plugins-grid">'];
+		for (var i = 0; i < n; i++) {
+			parts.push(
+				'<div class="dash-skeleton-card">' +
+				'<div class="dash-skeleton" style="width:40%;"></div>' +
+				'<div class="dash-skeleton" style="width:90%;"></div>' +
+				'<div class="dash-skeleton" style="width:60%;"></div>' +
+				'</div>',
+			);
+		}
+		parts.push('</div>');
+		return parts.join("");
+	}
+
+	function render() {
+		root.innerHTML = renderHeader() + renderFilters() + '<div id="plugins-grid-wrap">' + renderGrid() + '</div>';
+		wireEvents();
+		ctx.setBreadcrumb("Plugins");
+	}
+
+	function wireEvents() {
+		var refresh = document.getElementById("plugins-refresh-btn");
+		if (refresh) refresh.addEventListener("click", function () { loadCatalog(true); });
+		var find = document.getElementById("plugins-find-btn");
+		if (find) find.addEventListener("click", openFindModal);
+
+		var search = document.getElementById("plugins-search");
+		if (search) {
+			search.addEventListener("input", function () {
+				state.search = search.value || "";
+				rerenderGrid();
+			});
+		}
+
+		Array.prototype.forEach.call(document.querySelectorAll(".plugins-tab"), function (btn) {
+			btn.addEventListener("click", function () {
+				state.filter = btn.getAttribute("data-filter");
+				render();
+			});
+		});
+
+		Array.prototype.forEach.call(document.querySelectorAll(".plugins-cat-chip"), function (btn) {
+			btn.addEventListener("click", function () {
+				var cat = btn.getAttribute("data-cat");
+				state.category = cat || null;
+				render();
+			});
+		});
+
+		Array.prototype.forEach.call(document.querySelectorAll("[data-install]"), function (btn) {
+			btn.addEventListener("click", function () {
+				openInstallModal(btn.getAttribute("data-install"));
+			});
+		});
+
+		Array.prototype.forEach.call(document.querySelectorAll("[data-uninstall]"), function (btn) {
+			btn.addEventListener("click", function () {
+				openUninstallModal(btn.getAttribute("data-uninstall"));
+			});
+		});
+
+		Array.prototype.forEach.call(document.querySelectorAll("[data-history]"), function (btn) {
+			btn.addEventListener("click", function () {
+				openHistoryPanel(btn.getAttribute("data-history"));
+			});
+		});
+	}
+
+	function rerenderGrid() {
+		var wrap = document.getElementById("plugins-grid-wrap");
+		if (!wrap) return;
+		wrap.innerHTML = renderGrid();
+		wireEvents();
+	}
+
+	function findPlugin(name) {
+		if (!state.catalog) return null;
+		for (var i = 0; i < state.catalog.plugins.length; i++) {
+			if (state.catalog.plugins[i].name === name) return state.catalog.plugins[i];
+		}
+		return null;
+	}
+
+	function openInstallModal(name) {
+		var plugin = findPlugin(name);
+		if (!plugin) return;
+
+		var body = document.createElement("div");
+		body.innerHTML = (
+			'<p class="plugins-modal-key">' + esc(plugin.name) + '@' + esc(plugin.marketplace) + '</p>' +
+			'<p class="plugins-modal-source">Source: <span class="phantom-mono">' + esc(plugin.source_type) + (plugin.source_url ? ' &middot; ' + esc(plugin.source_url) : "") + '</span></p>' +
+			'<p class="plugins-modal-desc">' + esc(plugin.description || "") + '</p>' +
+			'<div class="plugins-modal-warning">' +
+			'<p class="plugins-modal-warning-title">This plugin can:</p>' +
+			'<ul>' +
+			'<li>run shell commands via hooks</li>' +
+			'<li>add skills and commands your agent will follow</li>' +
+			'<li>install MCP servers with access to your environment</li>' +
+			'<li>write to your agent\'s memory on first install</li>' +
+			'</ul>' +
+			'<p class="plugins-modal-warning-foot">Phantom loads the plugin on your next message. Review the source before you trust it.</p>' +
+			'</div>' +
+			'<label class="plugins-trust-row">' +
+			'<input type="checkbox" id="plugins-trust-checkbox">' +
+			'<span>I understand and I trust this plugin</span>' +
+			'</label>'
+		);
+
+		var modal = ctx.openModal({
+			title: "Install " + plugin.name + "?",
+			body: body,
+			actions: [
+				{ label: "Cancel", className: "dash-btn-ghost", onClick: function () {} },
+				{
+					label: "Install",
+					className: "dash-btn-primary",
+					onClick: function () {
+						var box = document.getElementById("plugins-trust-checkbox");
+						if (!box || !box.checked) {
+							ctx.toast("error", "Trust required", "Confirm you trust this plugin before installing.");
+							return false;
+						}
+						return installPlugin(plugin);
+					},
+				},
+			],
+		});
+
+		// Disable the install button until the checkbox is checked.
+		setTimeout(function () {
+			var actions = document.querySelectorAll(".dash-modal-actions .dash-btn-primary");
+			var installBtn = actions[actions.length - 1];
+			var box = document.getElementById("plugins-trust-checkbox");
+			if (installBtn && box) {
+				installBtn.disabled = true;
+				box.addEventListener("change", function () {
+					installBtn.disabled = !box.checked;
+				});
+			}
+		}, 60);
+
+		return modal;
+	}
+
+	function installPlugin(plugin) {
+		return ctx.api("POST", "/ui/api/plugins/install", { plugin: plugin.name, marketplace: plugin.marketplace })
+			.then(function (res) {
+				if (res.already_installed) {
+					ctx.toast("success", plugin.name + " already installed", "No changes needed.");
+				} else {
+					ctx.toast("success", plugin.name + " installed", "Your agent picks it up on its next message.");
+				}
+				return loadCatalog(false);
+			})
+			.catch(function (err) {
+				ctx.toast("error", "Install failed", err.message || String(err));
+				return false;
+			});
+	}
+
+	function openUninstallModal(name) {
+		var plugin = findPlugin(name);
+		if (!plugin) return;
+		var body = document.createElement("div");
+		body.innerHTML = (
+			'<p class="plugins-modal-desc">This disables the plugin on your next message. The cached files stay on disk and can be re-enabled with one click.</p>' +
+			'<p class="plugins-modal-key">' + esc(plugin.name) + '@' + esc(plugin.marketplace) + '</p>'
+		);
+		ctx.openModal({
+			title: "Uninstall " + plugin.name + "?",
+			body: body,
+			actions: [
+				{ label: "Cancel", className: "dash-btn-ghost", onClick: function () {} },
+				{
+					label: "Uninstall",
+					className: "dash-btn-danger",
+					onClick: function () {
+						var key = encodeURIComponent(plugin.name + "@" + plugin.marketplace);
+						return ctx.api("DELETE", "/ui/api/plugins/" + key)
+							.then(function () {
+								ctx.toast("success", plugin.name + " uninstalled", "The plugin is disabled on your next message.");
+								return loadCatalog(false);
+							})
+							.catch(function (err) {
+								ctx.toast("error", "Uninstall failed", err.message || String(err));
+								return false;
+							});
+					},
+				},
+			],
+		});
+	}
+
+	function openHistoryPanel(name) {
+		var plugin = findPlugin(name);
+		if (!plugin) return;
+		var key = plugin.name + "@" + plugin.marketplace;
+		ctx.api("GET", "/ui/api/plugins/" + encodeURIComponent(key) + "/audit").then(function (res) {
+			var rows = res.audit || [];
+			var body = document.createElement("div");
+			if (rows.length === 0) {
+				body.innerHTML = '<p class="plugins-modal-desc">No audit entries yet.</p>';
+			} else {
+				var lines = rows.map(function (r) {
+					return (
+						'<div class="plugins-audit-row">' +
+						'<span class="plugins-audit-time">' + esc(r.created_at) + '</span>' +
+						'<span class="plugins-audit-action plugins-audit-' + esc(r.action) + '">' + esc(r.action) + '</span>' +
+						'<span class="plugins-audit-actor">' + esc(r.actor) + '</span>' +
+						'<span class="plugins-audit-diff">' +
+						(r.previous_value ? esc(r.previous_value) : "absent") +
+						' &rarr; ' +
+						(r.new_value ? esc(r.new_value) : "absent") +
+						'</span>' +
+						'</div>'
+					);
+				}).join("");
+				body.innerHTML = '<div class="plugins-audit-list">' + lines + '</div>';
+			}
+			ctx.openModal({
+				title: name + " audit timeline",
+				body: body,
+				actions: [{ label: "Close", className: "dash-btn-ghost", onClick: function () {} }],
+			});
+		}).catch(function (err) {
+			ctx.toast("error", "Failed to load audit", err.message || String(err));
+		});
+	}
+
+	function openFindModal() {
+		var body = document.createElement("div");
+		body.innerHTML = (
+			'<p class="plugins-modal-desc">Describe what you want a plugin to help with. Phantom searches the catalog for matches.</p>' +
+			'<div class="dash-field">' +
+			'<textarea class="dash-textarea" id="plugins-find-input" placeholder="Track customer support tickets across channels" style="min-height:90px;"></textarea>' +
+			'</div>' +
+			'<div id="plugins-find-results"></div>'
+		);
+		ctx.openModal({
+			title: "Find a plugin",
+			body: body,
+			actions: [
+				{ label: "Close", className: "dash-btn-ghost", onClick: function () {} },
+				{
+					label: "Search",
+					className: "dash-btn-primary",
+					onClick: function () {
+						var input = document.getElementById("plugins-find-input");
+						var query = (input.value || "").trim();
+						if (!query) {
+							ctx.toast("error", "Empty query", "Type what you are looking for first.");
+							return false;
+						}
+						return ctx.api("POST", "/ui/api/plugins/find", { query: query }).then(function (res) {
+							renderFindResults(res.results || []);
+							return false;
+						}).catch(function (err) {
+							ctx.toast("error", "Find failed", err.message || String(err));
+							return false;
+						});
+					},
+				},
+			],
+		});
+	}
+
+	function renderFindResults(results) {
+		var wrap = document.getElementById("plugins-find-results");
+		if (!wrap) return;
+		if (results.length === 0) {
+			wrap.innerHTML = '<p class="plugins-modal-desc">No matches. Try different words.</p>';
+			return;
+		}
+		wrap.innerHTML = '<p class="plugins-find-eyebrow">Top matches</p>' + results.map(function (r) {
+			var status = r.enabled ? '<span class="plugins-status-installed"><span class="plugins-status-dot"></span>installed</span>' : "";
+			return (
+				'<div class="plugins-find-row">' +
+				'<div class="plugins-find-row-head"><span class="plugins-find-name">' + esc(r.name) + '</span>' + status + '</div>' +
+				'<div class="plugins-find-row-desc">' + esc(r.description || "") + '</div>' +
+				'</div>'
+			);
+		}).join("");
+	}
+
+	function loadCatalog(forceRefresh) {
+		state.loading = true;
+		render();
+		var path = "/ui/api/plugins/marketplace" + (forceRefresh ? "?refresh=1" : "");
+		return ctx.api("GET", path).then(function (res) {
+			state.catalog = { marketplace: res.marketplace, plugins: res.plugins };
+			state.fetchedAt = res.fetched_at;
+			state.hiddenByTransport = res.hidden_by_transport || 0;
+			state.fromStaleCache = !!res.from_stale_cache;
+			state.loading = false;
+			render();
+		}).catch(function (err) {
+			state.loading = false;
+			state.catalog = null;
+			render();
+			ctx.toast("error", "Failed to load marketplace", err.message || String(err));
+		});
+	}
+
+	function mount(container, _arg, dashCtx) {
+		ctx = dashCtx;
+		root = container;
+		ctx.setBreadcrumb("Plugins");
+		return loadCatalog(false);
+	}
+
+	window.PhantomDashboard.registerRoute("plugins", { mount: mount });
+})();

--- a/public/dashboard/plugins.js
+++ b/public/dashboard/plugins.js
@@ -203,11 +203,18 @@
 
 	function render() {
 		root.innerHTML = renderHeader() + renderFilters() + '<div id="plugins-grid-wrap">' + renderGrid() + '</div>';
-		wireEvents();
+		// Persistent listeners (header, search, tabs, category chips) bind once
+		// per render. Grid listeners (install, uninstall, history) re-bind on
+		// every rerenderGrid because the cards get replaced. Keeping them split
+		// prevents the quadratic listener leak that fires when the user types
+		// in the search box, since rerenderGrid only touches grid-internal
+		// elements and never re-attaches listeners on persistent controls.
+		wirePersistentEvents();
+		wireGridEvents();
 		ctx.setBreadcrumb("Plugins");
 	}
 
-	function wireEvents() {
+	function wirePersistentEvents() {
 		var refresh = document.getElementById("plugins-refresh-btn");
 		if (refresh) refresh.addEventListener("click", function () { loadCatalog(true); });
 		var find = document.getElementById("plugins-find-btn");
@@ -235,7 +242,9 @@
 				render();
 			});
 		});
+	}
 
+	function wireGridEvents() {
 		Array.prototype.forEach.call(document.querySelectorAll("[data-install]"), function (btn) {
 			btn.addEventListener("click", function () {
 				openInstallModal(btn.getAttribute("data-install"));
@@ -259,7 +268,7 @@
 		var wrap = document.getElementById("plugins-grid-wrap");
 		if (!wrap) return;
 		wrap.innerHTML = renderGrid();
-		wireEvents();
+		wireGridEvents();
 	}
 
 	function findPlugin(name) {

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -25,6 +25,16 @@ if [ -d /app/skills-builtin ]; then
   done
 fi
 
+# Seed Phantom's four default plugins into the user-scope settings.json on
+# first run. The seeder preserves operator choices: any plugin key that is
+# already mentioned (true or false) is left alone. Only missing keys are
+# added with value true. Other settings.json fields are preserved untouched.
+if [ -f /app/src/plugins/seed.ts ]; then
+  mkdir -p /home/phantom/.claude
+  echo "[phantom] Seeding default plugins..."
+  bun run /app/src/plugins/seed.ts --apply || echo "[phantom] WARNING: plugin seeding failed (continuing)"
+fi
+
 # Determine service URLs from environment (with Docker Compose defaults)
 QDRANT_URL="${QDRANT_URL:-http://qdrant:6333}"
 OLLAMA_URL="${OLLAMA_URL:-http://ollama:11434}"

--- a/skills-builtin/list-plugins/SKILL.md
+++ b/skills-builtin/list-plugins/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: list-plugins
+x-phantom-source: built-in
+description: List the Claude Code plugins currently enabled for the agent, read straight from settings.json.
+when_to_use: Use when the operator asks "what plugins are installed", "which plugins are active", "show plugins", "list plugins", "show me the marketplace state", or any narrow question specifically about the current plugin set.
+allowed-tools:
+  - Read
+context: inline
+---
+
+# List plugins
+
+## Goal
+
+Tell the operator which plugins are currently active for this agent, with their marketplace ids and a short description, in under 100 words.
+
+## Steps
+
+### 1. Read settings.json
+
+Use Read on `/home/phantom/.claude/settings.json`. Parse it as JSON.
+
+If the file does not exist, return: "No settings.json yet. The dashboard plugins tab is at /ui/dashboard/#/plugins."
+
+If the file exists but has no `enabledPlugins` field, return: "No plugins enabled yet. Browse the marketplace at /ui/dashboard/#/plugins."
+
+**Success criteria**: you have either a parsed `enabledPlugins` map or a clear empty-state message ready.
+
+### 2. Filter active entries
+
+For each `key: value` in `enabledPlugins`, treat the entry as active when value is `true`, a non-empty array, or a non-empty object. Treat `false` and missing entries as inactive.
+
+**Success criteria**: you have a list of `plugin@marketplace` keys for active plugins only.
+
+### 3. Render the list
+
+Format the response like this:
+
+> You have N plugins enabled:
+>
+> - **linear** at claude-plugins-official - Linear issue tracking
+> - **notion** at claude-plugins-official - Notion workspace
+> - **slack** at claude-plugins-official - Slack workspace messages
+> - **claude-md-management** at claude-plugins-official - CLAUDE.md maintenance
+>
+> Manage plugins at /ui/dashboard/#/plugins.
+
+For each row, the descriptor after the dash is a short fallback string based on the plugin name. If you do not recognize a plugin id, use just the marketplace id as the descriptor.
+
+**Success criteria**: the response shows the real current keys, the descriptors are honest (no fabricated descriptions for unknown plugins), and the dashboard URL is included.
+
+## Rules
+
+- Never fabricate a plugin that is not in settings.json.
+- Never use em dashes in the response. Regular hyphens are fine.
+- Always include the dashboard URL.
+- Keep the response under 100 words.

--- a/skills-builtin/show-my-tools/SKILL.md
+++ b/skills-builtin/show-my-tools/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: show-my-tools
 x-phantom-source: built-in
-description: List the agent's current skills, memory files, and dashboard URLs. The user-facing discovery path for everything the operator can edit.
-when_to_use: Use when the user says "what can you do", "what skills do you have", "show me your skills", "what can I edit", "how do I customize you", "what memory files do you have", "what is in your .claude", "where is the dashboard", or any similar discovery question.
+description: List the agent's current skills, memory files, plugins, and dashboard URLs. The user-facing discovery path for everything the operator can edit.
+when_to_use: Use when the user says "what can you do", "what skills do you have", "show me your skills", "what can I edit", "how do I customize you", "what memory files do you have", "what plugins do you have", "what is in your .claude", "where is the dashboard", or any similar discovery question.
 allowed-tools:
   - Read
   - Glob
@@ -30,7 +30,13 @@ Use Glob to find every `.md` file directly under `/home/phantom/.claude/` (depth
 
 **Success criteria**: you have a list of memory file paths with sizes.
 
-### 3. Render as three sections
+### 2.5 List plugins
+
+Use Read to open `/home/phantom/.claude/settings.json`. Parse it as JSON. If there is no `enabledPlugins` field, skip this section. Otherwise, for each `key: value` in `enabledPlugins` where the value is truthy (true, an object, or a non-empty array), record the `plugin-id@marketplace-id` and a short fallback description.
+
+**Success criteria**: you have a list of currently active plugin keys, or you know the list is empty.
+
+### 3. Render as four sections
 
 Format the response like this:
 
@@ -49,7 +55,14 @@ Format the response like this:
 > - **rules/...** - any rule files you have written
 > - **memory/...** - any free-form notes you have written
 >
-> **Dashboard.** You can see and edit all of the above at `<public_url>/ui/dashboard/`. Skills tab is for creating, editing, and deleting skills. Memory files tab is for everything else under .claude/. The other tabs (sessions, cost, scheduler, evolution, memory explorer, settings) are coming in later releases.
+> **Plugins.** I have K plugins enabled from claude-plugins-official:
+>
+> - **linear** - Linear issue tracking
+> - **notion** - Notion workspace knowledge
+> - **slack** - Slack workspace messages
+> - **claude-md-management** - CLAUDE.md maintenance
+>
+> **Dashboard.** You can see and edit all of the above at `<public_url>/ui/dashboard/`. Skills tab is for creating, editing, and deleting skills. Memory files tab is for everything else under .claude/. Plugins tab is for browsing and installing third-party plugins with a trust modal. The other tabs (sessions, cost, scheduler, evolution, memory explorer, settings) are coming in later releases.
 
 If `public_url` is not available, use `http://localhost:<port>/ui/dashboard/` or whatever matches the operator's known URL.
 

--- a/src/agent/prompt-blocks/dashboard-awareness.ts
+++ b/src/agent/prompt-blocks/dashboard-awareness.ts
@@ -13,6 +13,7 @@ export function buildDashboardAwarenessLines(publicUrl: string | undefined): str
 	const dashboardUrl = base ? `${base}/ui/dashboard/` : "/ui/dashboard/";
 	const skillsUrl = base ? `${base}/ui/dashboard/#/skills` : "/ui/dashboard/#/skills";
 	const memoryUrl = base ? `${base}/ui/dashboard/#/memory-files` : "/ui/dashboard/#/memory-files";
+	const pluginsUrl = base ? `${base}/ui/dashboard/#/plugins` : "/ui/dashboard/#/plugins";
 
 	const lines: string[] = [];
 	lines.push("");
@@ -20,7 +21,7 @@ export function buildDashboardAwarenessLines(publicUrl: string | undefined): str
 	lines.push("");
 	lines.push("Your operator has a dashboard they use to shape how you work. It is a");
 	lines.push("hand-crafted UI, separate from the pages you generate with phantom_create_page.");
-	lines.push("Two tabs are live today:");
+	lines.push("Three tabs are live today:");
 	lines.push("");
 	lines.push(`- Skills:       ${skillsUrl}`);
 	lines.push("    Markdown files under /home/phantom/.claude/skills/<name>/SKILL.md.");
@@ -36,9 +37,23 @@ export function buildDashboardAwarenessLines(publicUrl: string | undefined): str
 	lines.push("    memory/*.md (anything your operator wants you to know permanently).");
 	lines.push("    Edits are picked up on your next session start.");
 	lines.push("");
+	lines.push(`- Plugins:      ${pluginsUrl}`);
+	lines.push("    Third-party extensions from the claude-plugins-official marketplace.");
+	lines.push("    Your operator can browse, install, or uninstall plugins here with a");
+	lines.push("    trust modal on every first install. After install, the plugin's");
+	lines.push("    skills, commands, and MCP servers become part of your toolbelt on the");
+	lines.push("    next message. Four plugins are pre-installed on fresh Phantom VMs:");
+	lines.push("    linear (issue tracking), notion (workspace knowledge), slack (workspace");
+	lines.push("    messages beyond your own threads), and claude-md-management (keeps your");
+	lines.push("    CLAUDE.md memory tight). Every install and uninstall is audited.");
+	lines.push("");
 	lines.push("When your operator asks 'what can I customize', 'how do I edit your skills',");
 	lines.push(`'show me the dashboard', or anything similar, point them at ${dashboardUrl}`);
 	lines.push("and (if they want the current catalog) fire the show-my-tools skill.");
+	lines.push("");
+	lines.push("When your operator asks 'what plugins do you have', 'install a plugin for X',");
+	lines.push("'show me the marketplace', or 'add a capability', point them at the plugins");
+	lines.push("tab and (if they want the active set) fire the list-plugins skill.");
 	lines.push("");
 	lines.push("Other tabs (sessions, cost, scheduler, evolution, memory explorer, settings)");
 	lines.push("are marked Coming Soon in the dashboard today and will light up in later PRs.");

--- a/src/db/__tests__/migrate.test.ts
+++ b/src/db/__tests__/migrate.test.ts
@@ -35,7 +35,7 @@ describe("runMigrations", () => {
 		runMigrations(db);
 
 		const migrationCount = db.query("SELECT COUNT(*) as count FROM _migrations").get() as { count: number };
-		expect(migrationCount.count).toBe(14);
+		expect(migrationCount.count).toBe(16);
 	});
 
 	test("tracks applied migration indices", () => {
@@ -47,6 +47,6 @@ describe("runMigrations", () => {
 			.all()
 			.map((r) => (r as { index_num: number }).index_num);
 
-		expect(indices).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]);
+		expect(indices).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]);
 	});
 });

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -132,4 +132,24 @@ export const MIGRATIONS: string[] = [
 	)`,
 
 	"CREATE INDEX IF NOT EXISTS idx_memory_file_audit_log_path ON memory_file_audit_log(file_path, id DESC)",
+
+	// PR2 dashboard: plugin install audit log. Every install/uninstall from the
+	// UI API writes a row here so the operator can see the history of what was
+	// enabled or disabled, who did it, and what the marketplace source was at
+	// install time. Agent-originated writes to settings.json bypass this path
+	// today; a future PR may add a file watcher to capture those.
+	`CREATE TABLE IF NOT EXISTS plugin_install_audit_log (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		plugin_name TEXT NOT NULL,
+		marketplace TEXT NOT NULL,
+		action TEXT NOT NULL,
+		source_type TEXT,
+		source_url TEXT,
+		previous_value TEXT,
+		new_value TEXT,
+		actor TEXT NOT NULL,
+		created_at TEXT NOT NULL DEFAULT (datetime('now'))
+	)`,
+
+	"CREATE INDEX IF NOT EXISTS idx_plugin_install_audit_log_plugin ON plugin_install_audit_log(plugin_name, marketplace, id DESC)",
 ];

--- a/src/plugins/__tests__/audit.test.ts
+++ b/src/plugins/__tests__/audit.test.ts
@@ -1,0 +1,146 @@
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { MIGRATIONS } from "../../db/schema.ts";
+import { listPluginAudit, recordPluginInstall } from "../audit.ts";
+
+function createTestDb(): Database {
+	const db = new Database(":memory:");
+	for (const stmt of MIGRATIONS) {
+		db.run(stmt);
+	}
+	return db;
+}
+
+let db: Database;
+
+beforeEach(() => {
+	db = createTestDb();
+});
+
+afterEach(() => {
+	db.close();
+});
+
+describe("plugin_install_audit_log", () => {
+	test("records and lists a single install", () => {
+		recordPluginInstall(db, {
+			plugin: "notion",
+			marketplace: "claude-plugins-official",
+			action: "install",
+			sourceType: "url",
+			sourceUrl: "https://github.com/makenotion/claude-code-notion-plugin.git",
+			previousValue: null,
+			newValue: true,
+			actor: "user",
+		});
+		const rows = listPluginAudit(db);
+		expect(rows).toHaveLength(1);
+		expect(rows[0].plugin_name).toBe("notion");
+		expect(rows[0].marketplace).toBe("claude-plugins-official");
+		expect(rows[0].action).toBe("install");
+		expect(rows[0].actor).toBe("user");
+		expect(rows[0].new_value).toBe("true");
+		expect(rows[0].previous_value).toBeNull();
+	});
+
+	test("encodes complex previous/new values as JSON strings", () => {
+		recordPluginInstall(db, {
+			plugin: "notion",
+			marketplace: "claude-plugins-official",
+			action: "reinstall",
+			sourceType: "url",
+			sourceUrl: null,
+			previousValue: false,
+			newValue: { pinned: "1.2.3" },
+			actor: "user",
+		});
+		const rows = listPluginAudit(db);
+		expect(rows[0].previous_value).toBe("false");
+		expect(rows[0].new_value).toBe('{"pinned":"1.2.3"}');
+	});
+
+	test("orders rows by id desc", () => {
+		for (let i = 0; i < 3; i++) {
+			recordPluginInstall(db, {
+				plugin: "notion",
+				marketplace: "claude-plugins-official",
+				action: "install",
+				sourceType: "url",
+				sourceUrl: "https://example.com",
+				previousValue: null,
+				newValue: true,
+				actor: "user",
+			});
+		}
+		const rows = listPluginAudit(db);
+		expect(rows).toHaveLength(3);
+		expect(rows[0].id).toBeGreaterThan(rows[1].id);
+		expect(rows[1].id).toBeGreaterThan(rows[2].id);
+	});
+
+	test("filters by plugin name", () => {
+		recordPluginInstall(db, {
+			plugin: "notion",
+			marketplace: "claude-plugins-official",
+			action: "install",
+			sourceType: "url",
+			sourceUrl: null,
+			previousValue: null,
+			newValue: true,
+			actor: "user",
+		});
+		recordPluginInstall(db, {
+			plugin: "linear",
+			marketplace: "claude-plugins-official",
+			action: "install",
+			sourceType: "local",
+			sourceUrl: null,
+			previousValue: null,
+			newValue: true,
+			actor: "user",
+		});
+		expect(listPluginAudit(db, { plugin: "notion" })).toHaveLength(1);
+		expect(listPluginAudit(db, { plugin: "linear" })).toHaveLength(1);
+		expect(listPluginAudit(db)).toHaveLength(2);
+	});
+
+	test("filters by plugin and marketplace together", () => {
+		recordPluginInstall(db, {
+			plugin: "notion",
+			marketplace: "claude-plugins-official",
+			action: "install",
+			sourceType: "url",
+			sourceUrl: null,
+			previousValue: null,
+			newValue: true,
+			actor: "user",
+		});
+		recordPluginInstall(db, {
+			plugin: "notion",
+			marketplace: "other-marketplace",
+			action: "install",
+			sourceType: "url",
+			sourceUrl: null,
+			previousValue: null,
+			newValue: true,
+			actor: "user",
+		});
+		expect(listPluginAudit(db, { plugin: "notion", marketplace: "claude-plugins-official" })).toHaveLength(1);
+	});
+
+	test("respects limit", () => {
+		for (let i = 0; i < 5; i++) {
+			recordPluginInstall(db, {
+				plugin: "notion",
+				marketplace: "claude-plugins-official",
+				action: "install",
+				sourceType: "url",
+				sourceUrl: null,
+				previousValue: null,
+				newValue: true,
+				actor: "user",
+			});
+		}
+		expect(listPluginAudit(db, { limit: 2 })).toHaveLength(2);
+	});
+});

--- a/src/plugins/__tests__/curated.test.ts
+++ b/src/plugins/__tests__/curated.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { __resetCuratedCacheForTests, loadCuratedOverlay, lookupCuratedEntry } from "../curated.ts";
+
+let tmp: string;
+let path: string;
+
+beforeEach(() => {
+	__resetCuratedCacheForTests();
+	tmp = mkdtempSync(join(tmpdir(), "phantom-curated-"));
+	path = join(tmp, "plugins-curated.json");
+});
+
+afterEach(() => {
+	rmSync(tmp, { recursive: true, force: true });
+});
+
+describe("loadCuratedOverlay", () => {
+	test("returns empty overlay when file is missing", () => {
+		const overlay = loadCuratedOverlay(path);
+		expect(overlay).toEqual({ version: 1, plugins: {} });
+	});
+
+	test("parses an empty-but-valid overlay", () => {
+		writeFileSync(path, '{"version":1,"plugins":{}}');
+		const overlay = loadCuratedOverlay(path);
+		expect(overlay.plugins).toEqual({});
+	});
+
+	test("parses a populated overlay", () => {
+		writeFileSync(
+			path,
+			JSON.stringify({
+				version: 1,
+				plugins: {
+					"notion@claude-plugins-official": {
+						tags: ["phantom-recommended", "production-tested"],
+						audience: ["founder", "pm"],
+						note: "Phantom default.",
+					},
+				},
+			}),
+		);
+		const overlay = loadCuratedOverlay(path);
+		const entry = lookupCuratedEntry(overlay, "notion@claude-plugins-official");
+		expect(entry).not.toBeNull();
+		expect(entry?.tags).toContain("phantom-recommended");
+	});
+
+	test("returns empty on malformed JSON", () => {
+		writeFileSync(path, "{ not json");
+		const overlay = loadCuratedOverlay(path);
+		expect(overlay).toEqual({ version: 1, plugins: {} });
+	});
+
+	test("returns empty on schema violation", () => {
+		writeFileSync(
+			path,
+			JSON.stringify({
+				version: 1,
+				plugins: { "notion@claude-plugins-official": { tags: ["not-a-real-tag"] } },
+			}),
+		);
+		const overlay = loadCuratedOverlay(path);
+		expect(overlay).toEqual({ version: 1, plugins: {} });
+	});
+
+	test("returns empty on wrong version", () => {
+		writeFileSync(path, '{"version":2,"plugins":{}}');
+		const overlay = loadCuratedOverlay(path);
+		expect(overlay).toEqual({ version: 1, plugins: {} });
+	});
+
+	test("caches by mtime", () => {
+		writeFileSync(
+			path,
+			JSON.stringify({
+				version: 1,
+				plugins: { "a@b": { tags: ["phantom-recommended"] } },
+			}),
+		);
+		const first = loadCuratedOverlay(path);
+		const second = loadCuratedOverlay(path);
+		expect(first).toBe(second); // same reference on cache hit
+	});
+});

--- a/src/plugins/__tests__/manifest.test.ts
+++ b/src/plugins/__tests__/manifest.test.ts
@@ -58,6 +58,34 @@ describe("UpstreamPluginSchema", () => {
 		});
 		expect(parsed.name).toBe("notion");
 	});
+
+	test("accepts lspServers as a record keyed by server name (real upstream shape)", () => {
+		const parsed = UpstreamPluginSchema.parse({
+			name: "clangd-lsp",
+			description: "C/C++ language server",
+			lspServers: {
+				clangd: {
+					command: "clangd",
+					args: ["--background-index"],
+					extensionToLanguage: { ".c": "c", ".cpp": "cpp" },
+				},
+			},
+		});
+		expect(parsed.name).toBe("clangd-lsp");
+	});
+
+	test("accepts lspServers as an object with multiple servers", () => {
+		const parsed = UpstreamPluginSchema.parse({
+			name: "polyglot-lsp",
+			description: "many languages",
+			lspServers: {
+				clangd: { command: "clangd" },
+				rust_analyzer: { command: "rust-analyzer" },
+				gopls: { command: "gopls" },
+			},
+		});
+		expect(parsed.name).toBe("polyglot-lsp");
+	});
 });
 
 describe("MarketplaceSchema", () => {

--- a/src/plugins/__tests__/manifest.test.ts
+++ b/src/plugins/__tests__/manifest.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, test } from "bun:test";
+import {
+	CuratedOverlaySchema,
+	EnabledPluginsMapSchema,
+	MarketplaceSchema,
+	NormalizedPluginSchema,
+	UpstreamPluginSchema,
+	isEnabledValueActive,
+	normalizeSource,
+} from "../manifest.ts";
+
+describe("UpstreamPluginSchema", () => {
+	test("parses a minimal entry", () => {
+		const parsed = UpstreamPluginSchema.parse({
+			name: "notion",
+			description: "Notion integration",
+		});
+		expect(parsed.name).toBe("notion");
+	});
+
+	test("parses a url-type source", () => {
+		const parsed = UpstreamPluginSchema.parse({
+			name: "notion",
+			description: "x",
+			source: { source: "url", url: "https://github.com/makenotion/claude-code-notion-plugin.git" },
+			category: "productivity",
+		});
+		expect(parsed.source).toMatchObject({ source: "url" });
+	});
+
+	test("parses a local ./source", () => {
+		const parsed = UpstreamPluginSchema.parse({
+			name: "linear",
+			description: "Linear",
+			source: "./external_plugins/linear",
+		});
+		expect(parsed.source).toBe("./external_plugins/linear");
+	});
+
+	test("parses a git-subdir source", () => {
+		const parsed = UpstreamPluginSchema.parse({
+			name: "expo",
+			description: "Expo skills",
+			source: { source: "git-subdir", url: "expo/skills", path: "." },
+		});
+		expect((parsed.source as { source: string }).source).toBe("git-subdir");
+	});
+
+	test("reject missing name", () => {
+		expect(() => UpstreamPluginSchema.parse({ description: "x" })).toThrow();
+	});
+
+	test("tolerates unknown fields", () => {
+		const parsed = UpstreamPluginSchema.parse({
+			name: "notion",
+			description: "x",
+			randomUpstreamField: 42,
+		});
+		expect(parsed.name).toBe("notion");
+	});
+});
+
+describe("MarketplaceSchema", () => {
+	test("parses a tiny valid marketplace", () => {
+		const parsed = MarketplaceSchema.parse({
+			name: "claude-plugins-official",
+			description: "Test",
+			owner: { name: "Anthropic" },
+			plugins: [
+				{ name: "notion", description: "Notion" },
+				{ name: "linear", description: "Linear", source: "./external_plugins/linear" },
+			],
+		});
+		expect(parsed.plugins).toHaveLength(2);
+	});
+
+	test("requires plugins array", () => {
+		expect(() => MarketplaceSchema.parse({ name: "x" })).toThrow();
+	});
+});
+
+describe("CuratedOverlaySchema", () => {
+	test("parses an empty overlay", () => {
+		const parsed = CuratedOverlaySchema.parse({ version: 1, plugins: {} });
+		expect(parsed.plugins).toEqual({});
+	});
+
+	test("parses a populated entry", () => {
+		const parsed = CuratedOverlaySchema.parse({
+			version: 1,
+			plugins: {
+				"notion@claude-plugins-official": {
+					tags: ["phantom-recommended", "production-tested"],
+					audience: ["founder", "pm"],
+					note: "Phantom's default workspace plugin.",
+					pinned_version: "1.2.3",
+				},
+			},
+		});
+		expect(parsed.plugins["notion@claude-plugins-official"].tags).toContain("phantom-recommended");
+	});
+
+	test("rejects invalid tag", () => {
+		expect(() =>
+			CuratedOverlaySchema.parse({
+				version: 1,
+				plugins: { "notion@claude-plugins-official": { tags: ["not-a-real-tag"] } },
+			}),
+		).toThrow();
+	});
+
+	test("rejects wrong version", () => {
+		expect(() => CuratedOverlaySchema.parse({ version: 2, plugins: {} })).toThrow();
+	});
+});
+
+describe("EnabledPluginsMapSchema", () => {
+	test("accepts boolean, array, object values", () => {
+		const parsed = EnabledPluginsMapSchema.parse({
+			"a@b": true,
+			"c@d": false,
+			"e@f": ["^1.0.0"],
+			"g@h": { pinned: "1.2.3" },
+		});
+		expect(parsed["a@b"]).toBe(true);
+	});
+});
+
+describe("isEnabledValueActive", () => {
+	test("handles all shapes", () => {
+		expect(isEnabledValueActive(undefined)).toBe(false);
+		expect(isEnabledValueActive(false)).toBe(false);
+		expect(isEnabledValueActive(true)).toBe(true);
+		expect(isEnabledValueActive([])).toBe(false);
+		expect(isEnabledValueActive(["^1.0.0"])).toBe(true);
+		expect(isEnabledValueActive({})).toBe(false);
+		expect(isEnabledValueActive({ pinned: "1.2.3" })).toBe(true);
+	});
+});
+
+describe("normalizeSource", () => {
+	test("url object", () => {
+		const n = normalizeSource({ source: "url", url: "https://github.com/x/y.git" });
+		expect(n).toEqual({ source_type: "url", source_url: "https://github.com/x/y.git" });
+	});
+
+	test("string local path", () => {
+		const n = normalizeSource("./plugins/foo");
+		expect(n).toEqual({ source_type: "local", source_url: "./plugins/foo" });
+	});
+
+	test("undefined source falls back to local", () => {
+		const n = normalizeSource(undefined);
+		expect(n).toEqual({ source_type: "local", source_url: null });
+	});
+
+	test("git-subdir source", () => {
+		const n = normalizeSource({ source: "git-subdir", url: "expo/skills", path: "." });
+		expect(n.source_type).toBe("git-subdir");
+	});
+});
+
+describe("NormalizedPluginSchema", () => {
+	test("parses a realistic normalized entry", () => {
+		const parsed = NormalizedPluginSchema.parse({
+			name: "notion",
+			marketplace: "claude-plugins-official",
+			description: "Notion workspace integration.",
+			source_type: "url",
+			source_url: "https://github.com/makenotion/claude-code-notion-plugin.git",
+			category: "productivity",
+			homepage: null,
+			version: null,
+			tags: [],
+			curated_tags: [],
+			curated_note: null,
+			audience: [],
+			pinned_version: null,
+			enabled: true,
+		});
+		expect(parsed.enabled).toBe(true);
+	});
+});

--- a/src/plugins/__tests__/marketplace.test.ts
+++ b/src/plugins/__tests__/marketplace.test.ts
@@ -1,0 +1,230 @@
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { MIGRATIONS } from "../../db/schema.ts";
+import { __resetCuratedCacheForTests } from "../curated.ts";
+import { type FetchMarketplaceFn, getCatalog, resolveMarketplace } from "../marketplace.ts";
+
+function createTestDb(): Database {
+	const db = new Database(":memory:");
+	for (const stmt of MIGRATIONS) {
+		db.run(stmt);
+	}
+	return db;
+}
+
+const FIXTURE_BODY = JSON.stringify({
+	$schema: "https://anthropic.com/claude-code/marketplace.schema.json",
+	name: "claude-plugins-official",
+	description: "Test",
+	owner: { name: "Anthropic" },
+	plugins: [
+		{
+			name: "notion",
+			description: "Notion workspace integration.",
+			category: "productivity",
+			source: { source: "url", url: "https://github.com/makenotion/claude-code-notion-plugin.git" },
+			homepage: "https://github.com/makenotion/claude-code-notion-plugin",
+		},
+		{
+			name: "linear",
+			description: "Linear issue tracking.",
+			category: "productivity",
+			source: "./external_plugins/linear",
+		},
+		{
+			name: "slack",
+			description: "Slack workspace.",
+			category: "productivity",
+			source: { source: "url", url: "https://github.com/slackapi/slack-mcp-plugin.git" },
+		},
+		{
+			name: "claude-md-management",
+			description: "Maintain CLAUDE.md files.",
+			author: { name: "Anthropic" },
+			source: "./plugins/claude-md-management",
+			category: "productivity",
+		},
+		{
+			name: "expo",
+			description: "Expo skills.",
+			source: { source: "git-subdir", url: "expo/skills" },
+			category: "development",
+		},
+		{
+			name: "stagehand",
+			description: "Stagehand browser automation.",
+			source: { source: "github", repo: "example/stagehand" },
+			category: "automation",
+		},
+	],
+});
+
+let db: Database;
+let tmpDir: string;
+let overlayPath: string;
+
+beforeEach(() => {
+	__resetCuratedCacheForTests();
+	db = createTestDb();
+	tmpDir = mkdtempSync(join(tmpdir(), "phantom-marketplace-"));
+	overlayPath = join(tmpDir, "curated.json");
+	writeFileSync(overlayPath, '{"version":1,"plugins":{}}');
+});
+
+afterEach(() => {
+	db.close();
+	rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function makeFetcher(body: string = FIXTURE_BODY): FetchMarketplaceFn {
+	let calls = 0;
+	const fn: FetchMarketplaceFn & { calls: () => number } = Object.assign(
+		async () => {
+			calls += 1;
+			return { ok: true, body, etag: "test-etag" };
+		},
+		{ calls: () => calls },
+	);
+	return fn;
+}
+
+describe("resolveMarketplace", () => {
+	test("fetches and caches on first call", async () => {
+		const fetcher = makeFetcher() as FetchMarketplaceFn & { calls: () => number };
+		const result = await resolveMarketplace({ db, fetcher });
+		expect(result.cacheHit).toBe(false);
+		expect(result.marketplace.plugins).toHaveLength(6);
+		expect(fetcher.calls()).toBe(1);
+	});
+
+	test("serves from cache within TTL", async () => {
+		const fetcher = makeFetcher() as FetchMarketplaceFn & { calls: () => number };
+		await resolveMarketplace({ db, fetcher });
+		const second = await resolveMarketplace({ db, fetcher });
+		expect(second.cacheHit).toBe(true);
+		expect(second.fromStaleCache).toBe(false);
+		expect(fetcher.calls()).toBe(1);
+	});
+
+	test("force refresh bypasses cache", async () => {
+		const fetcher = makeFetcher() as FetchMarketplaceFn & { calls: () => number };
+		await resolveMarketplace({ db, fetcher });
+		await resolveMarketplace({ db, fetcher, forceRefresh: true });
+		expect(fetcher.calls()).toBe(2);
+	});
+
+	test("stale-while-error serves cache when fetch fails", async () => {
+		const good = makeFetcher() as FetchMarketplaceFn & { calls: () => number };
+		await resolveMarketplace({ db, fetcher: good });
+		const bad: FetchMarketplaceFn = async () => ({ ok: false, body: "", etag: null });
+		const result = await resolveMarketplace({ db, fetcher: bad, forceRefresh: true });
+		expect(result.cacheHit).toBe(true);
+		expect(result.fromStaleCache).toBe(true);
+	});
+
+	test("throws when fetch fails and no cache exists", async () => {
+		const bad: FetchMarketplaceFn = async () => ({ ok: false, body: "", etag: null });
+		await expect(resolveMarketplace({ db, fetcher: bad })).rejects.toThrow(/unreachable/);
+	});
+
+	test("rejects an invalid body but keeps previous cache", async () => {
+		const good = makeFetcher();
+		await resolveMarketplace({ db, fetcher: good });
+		const badBody: FetchMarketplaceFn = async () => ({ ok: true, body: "{ not a marketplace }", etag: null });
+		const result = await resolveMarketplace({ db, fetcher: badBody, forceRefresh: true });
+		expect(result.cacheHit).toBe(true);
+		expect(result.fromStaleCache).toBe(true);
+	});
+});
+
+describe("getCatalog", () => {
+	test("filters unsupported transports and counts them", async () => {
+		const fetcher = makeFetcher();
+		const catalog = await getCatalog({ db, fetcher, activeKeys: new Set(), overlayPath });
+		// 6 plugins total, expo(git-subdir) filtered -> 5 rendered, 1 hidden
+		expect(catalog.plugins).toHaveLength(5);
+		expect(catalog.hidden_by_transport).toBe(1);
+		const names = catalog.plugins.map((p) => p.name);
+		expect(names).toContain("notion");
+		expect(names).toContain("linear");
+		expect(names).toContain("slack");
+		expect(names).toContain("claude-md-management");
+		expect(names).toContain("stagehand");
+		expect(names).not.toContain("expo");
+	});
+
+	test("marks active plugins as enabled", async () => {
+		const fetcher = makeFetcher();
+		const active = new Set(["notion@claude-plugins-official", "slack@claude-plugins-official"]);
+		const catalog = await getCatalog({ db, fetcher, activeKeys: active, overlayPath });
+		const notion = catalog.plugins.find((p) => p.name === "notion");
+		expect(notion?.enabled).toBe(true);
+		const linear = catalog.plugins.find((p) => p.name === "linear");
+		expect(linear?.enabled).toBe(false);
+	});
+
+	test("merges curated overlay tags and notes", async () => {
+		writeFileSync(
+			overlayPath,
+			JSON.stringify({
+				version: 1,
+				plugins: {
+					"notion@claude-plugins-official": {
+						tags: ["phantom-recommended"],
+						note: "Default pick.",
+						audience: ["founder", "pm"],
+					},
+				},
+			}),
+		);
+		const fetcher = makeFetcher();
+		const catalog = await getCatalog({ db, fetcher, activeKeys: new Set(), overlayPath });
+		const notion = catalog.plugins.find((p) => p.name === "notion");
+		expect(notion?.curated_tags).toContain("phantom-recommended");
+		expect(notion?.curated_note).toBe("Default pick.");
+		expect(notion?.audience).toContain("founder");
+	});
+
+	test("phantom-recommended sorts to the top", async () => {
+		writeFileSync(
+			overlayPath,
+			JSON.stringify({
+				version: 1,
+				plugins: {
+					"slack@claude-plugins-official": { tags: ["phantom-recommended"] },
+				},
+			}),
+		);
+		const fetcher = makeFetcher();
+		const catalog = await getCatalog({ db, fetcher, activeKeys: new Set(), overlayPath });
+		expect(catalog.plugins[0].name).toBe("slack");
+	});
+
+	test("normalizes local source type to 'local'", async () => {
+		const fetcher = makeFetcher();
+		const catalog = await getCatalog({ db, fetcher, activeKeys: new Set(), overlayPath });
+		const linear = catalog.plugins.find((p) => p.name === "linear");
+		expect(linear?.source_type).toBe("local");
+		expect(linear?.source_url).toBe("./external_plugins/linear");
+	});
+
+	test("normalizes url source type and keeps the URL", async () => {
+		const fetcher = makeFetcher();
+		const catalog = await getCatalog({ db, fetcher, activeKeys: new Set(), overlayPath });
+		const notion = catalog.plugins.find((p) => p.name === "notion");
+		expect(notion?.source_type).toBe("url");
+		expect(notion?.source_url).toContain("makenotion");
+	});
+
+	test("returns fetched_at and cache flags", async () => {
+		const fetcher = makeFetcher();
+		const first = await getCatalog({ db, fetcher, activeKeys: new Set(), overlayPath });
+		const second = await getCatalog({ db, fetcher, activeKeys: new Set(), overlayPath });
+		expect(first.cache_hit).toBe(false);
+		expect(second.cache_hit).toBe(true);
+		expect(first.fetched_at).toBeTruthy();
+	});
+});

--- a/src/plugins/__tests__/paths.test.ts
+++ b/src/plugins/__tests__/paths.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+	OFFICIAL_MARKETPLACE_ID,
+	formatPluginKey,
+	getClaudeRoot,
+	getPluginCacheRoot,
+	getUserSettingsPath,
+	isValidMarketplaceId,
+	isValidPluginId,
+	parsePluginKey,
+} from "../paths.ts";
+
+const priorOverride = process.env.PHANTOM_CLAUDE_ROOT;
+
+afterEach(() => {
+	if (priorOverride !== undefined) {
+		process.env.PHANTOM_CLAUDE_ROOT = priorOverride;
+	} else {
+		Reflect.deleteProperty(process.env, "PHANTOM_CLAUDE_ROOT");
+	}
+});
+
+describe("isValidPluginId", () => {
+	test("accepts standard plugin ids", () => {
+		expect(isValidPluginId("notion")).toBe(true);
+		expect(isValidPluginId("claude-md-management")).toBe(true);
+		expect(isValidPluginId("pr-review-toolkit")).toBe(true);
+		expect(isValidPluginId("a1-b2-c3")).toBe(true);
+	});
+
+	test("rejects empty, uppercase, spaces, slashes, traversal", () => {
+		expect(isValidPluginId("")).toBe(false);
+		expect(isValidPluginId("Notion")).toBe(false);
+		expect(isValidPluginId("my plugin")).toBe(false);
+		expect(isValidPluginId("folder/name")).toBe(false);
+		expect(isValidPluginId("../etc/passwd")).toBe(false);
+	});
+
+	test("rejects null bytes", () => {
+		expect(isValidPluginId("notion\0evil")).toBe(false);
+	});
+
+	test("caps length at 64", () => {
+		expect(isValidPluginId("a".repeat(64))).toBe(true);
+		expect(isValidPluginId("a".repeat(65))).toBe(false);
+	});
+});
+
+describe("isValidMarketplaceId", () => {
+	test("accepts the canonical marketplace id", () => {
+		expect(isValidMarketplaceId(OFFICIAL_MARKETPLACE_ID)).toBe(true);
+		expect(isValidMarketplaceId("claude-plugins-official")).toBe(true);
+	});
+
+	test("rejects empty and invalid", () => {
+		expect(isValidMarketplaceId("")).toBe(false);
+		expect(isValidMarketplaceId("Claude-Plugins")).toBe(false);
+	});
+});
+
+describe("parsePluginKey", () => {
+	test("parses canonical key", () => {
+		const parsed = parsePluginKey("notion@claude-plugins-official");
+		expect(parsed).toEqual({ plugin: "notion", marketplace: "claude-plugins-official" });
+	});
+
+	test("rejects missing parts", () => {
+		expect(parsePluginKey("notion")).toBeNull();
+		expect(parsePluginKey("@claude-plugins-official")).toBeNull();
+		expect(parsePluginKey("notion@")).toBeNull();
+		expect(parsePluginKey("")).toBeNull();
+	});
+
+	test("rejects invalid halves", () => {
+		expect(parsePluginKey("Notion@claude-plugins-official")).toBeNull();
+		expect(parsePluginKey("notion@Claude-Plugins")).toBeNull();
+		expect(parsePluginKey("../x@y")).toBeNull();
+	});
+
+	test("handles plugin ids with dots and underscores", () => {
+		const parsed = parsePluginKey("my_plugin.v2@claude-plugins-official");
+		expect(parsed).toEqual({ plugin: "my_plugin.v2", marketplace: "claude-plugins-official" });
+	});
+});
+
+describe("formatPluginKey", () => {
+	test("builds the canonical string", () => {
+		expect(formatPluginKey("notion", "claude-plugins-official")).toBe("notion@claude-plugins-official");
+	});
+
+	test("throws on invalid id", () => {
+		expect(() => formatPluginKey("", "claude-plugins-official")).toThrow();
+		expect(() => formatPluginKey("Notion", "claude-plugins-official")).toThrow();
+		expect(() => formatPluginKey("notion", "Invalid Marketplace")).toThrow();
+	});
+});
+
+describe("getClaudeRoot + getUserSettingsPath + getPluginCacheRoot", () => {
+	test("honors PHANTOM_CLAUDE_ROOT override", () => {
+		const tmp = mkdtempSync(join(tmpdir(), "phantom-plugins-"));
+		try {
+			process.env.PHANTOM_CLAUDE_ROOT = tmp;
+			expect(getClaudeRoot()).toBe(tmp);
+			expect(getUserSettingsPath()).toBe(join(tmp, "settings.json"));
+			expect(getPluginCacheRoot()).toBe(join(tmp, "plugins"));
+		} finally {
+			rmSync(tmp, { recursive: true, force: true });
+		}
+	});
+});

--- a/src/plugins/__tests__/seed.test.ts
+++ b/src/plugins/__tests__/seed.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { DEFAULT_PLUGIN_PICKS, seedDefaultPlugins } from "../seed.ts";
+
+let tmp: string;
+let settingsPath: string;
+
+beforeEach(() => {
+	tmp = mkdtempSync(join(tmpdir(), "phantom-seed-"));
+	settingsPath = join(tmp, "settings.json");
+});
+
+afterEach(() => {
+	rmSync(tmp, { recursive: true, force: true });
+});
+
+describe("seedDefaultPlugins", () => {
+	test("creates settings.json and adds all four picks on a fresh container", () => {
+		const result = seedDefaultPlugins(DEFAULT_PLUGIN_PICKS, settingsPath);
+		expect(result.created).toBe(true);
+		expect(result.added).toHaveLength(4);
+		expect(result.skipped).toHaveLength(0);
+		const settings = JSON.parse(readFileSync(settingsPath, "utf-8"));
+		expect(settings.enabledPlugins["linear@claude-plugins-official"]).toBe(true);
+		expect(settings.enabledPlugins["notion@claude-plugins-official"]).toBe(true);
+		expect(settings.enabledPlugins["slack@claude-plugins-official"]).toBe(true);
+		expect(settings.enabledPlugins["claude-md-management@claude-plugins-official"]).toBe(true);
+	});
+
+	test("preserves an existing settings.json with unrelated fields", () => {
+		writeFileSync(settingsPath, JSON.stringify({ permissions: { allow: ["Read"] }, model: "claude-opus-4-6" }));
+		seedDefaultPlugins(DEFAULT_PLUGIN_PICKS, settingsPath);
+		const settings = JSON.parse(readFileSync(settingsPath, "utf-8"));
+		expect(settings.permissions).toEqual({ allow: ["Read"] });
+		expect(settings.model).toBe("claude-opus-4-6");
+		expect(Object.keys(settings.enabledPlugins)).toHaveLength(4);
+	});
+
+	test("preserves operator-disabled picks (set to false)", () => {
+		writeFileSync(
+			settingsPath,
+			JSON.stringify({
+				enabledPlugins: {
+					"linear@claude-plugins-official": false,
+				},
+			}),
+		);
+		const result = seedDefaultPlugins(DEFAULT_PLUGIN_PICKS, settingsPath);
+		expect(result.added).not.toContain("linear@claude-plugins-official");
+		expect(result.skipped).toContain("linear@claude-plugins-official");
+		const settings = JSON.parse(readFileSync(settingsPath, "utf-8"));
+		expect(settings.enabledPlugins["linear@claude-plugins-official"]).toBe(false);
+		// Other picks still added
+		expect(settings.enabledPlugins["notion@claude-plugins-official"]).toBe(true);
+	});
+
+	test("preserves operator-installed entries from other marketplaces", () => {
+		writeFileSync(
+			settingsPath,
+			JSON.stringify({
+				enabledPlugins: {
+					"my-custom@my-marketplace": true,
+				},
+			}),
+		);
+		seedDefaultPlugins(DEFAULT_PLUGIN_PICKS, settingsPath);
+		const settings = JSON.parse(readFileSync(settingsPath, "utf-8"));
+		expect(settings.enabledPlugins["my-custom@my-marketplace"]).toBe(true);
+		expect(settings.enabledPlugins["notion@claude-plugins-official"]).toBe(true);
+	});
+
+	test("is idempotent: running twice does not double-add", () => {
+		seedDefaultPlugins(DEFAULT_PLUGIN_PICKS, settingsPath);
+		const second = seedDefaultPlugins(DEFAULT_PLUGIN_PICKS, settingsPath);
+		expect(second.added).toEqual([]);
+		expect(second.skipped).toHaveLength(4);
+		const settings = JSON.parse(readFileSync(settingsPath, "utf-8"));
+		expect(Object.keys(settings.enabledPlugins)).toHaveLength(4);
+	});
+
+	test("DEFAULT_PLUGIN_PICKS is exactly four", () => {
+		expect(DEFAULT_PLUGIN_PICKS).toHaveLength(4);
+		const names = DEFAULT_PLUGIN_PICKS.map((p) => p.plugin);
+		expect(names).toContain("linear");
+		expect(names).toContain("notion");
+		expect(names).toContain("slack");
+		expect(names).toContain("claude-md-management");
+	});
+});

--- a/src/plugins/__tests__/seed.test.ts
+++ b/src/plugins/__tests__/seed.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { DEFAULT_PLUGIN_PICKS, seedDefaultPlugins } from "../seed.ts";
@@ -87,5 +87,30 @@ describe("seedDefaultPlugins", () => {
 		expect(names).toContain("notion");
 		expect(names).toContain("slack");
 		expect(names).toContain("claude-md-management");
+	});
+
+	test("dryRun computes the would-add set without writing settings.json", () => {
+		// File does not exist yet. Dry run should report would-add but never create.
+		expect(existsSync(settingsPath)).toBe(false);
+		const result = seedDefaultPlugins(DEFAULT_PLUGIN_PICKS, settingsPath, { dryRun: true });
+		expect(result.added).toHaveLength(4);
+		expect(result.skipped).toHaveLength(0);
+		expect(existsSync(settingsPath)).toBe(false);
+	});
+
+	test("dryRun on an existing settings.json does not mutate the file", () => {
+		const original = JSON.stringify({
+			enabledPlugins: {
+				"linear@claude-plugins-official": false,
+				"my-custom@my-marketplace": true,
+			},
+			model: "claude-opus-4-6",
+		});
+		writeFileSync(settingsPath, original);
+		const result = seedDefaultPlugins(DEFAULT_PLUGIN_PICKS, settingsPath, { dryRun: true });
+		expect(result.added).toHaveLength(3); // notion, slack, claude-md-management
+		expect(result.skipped).toContain("linear@claude-plugins-official");
+		const onDisk = readFileSync(settingsPath, "utf-8");
+		expect(onDisk).toBe(original); // byte-for-byte identical
 	});
 });

--- a/src/plugins/__tests__/settings-io.test.ts
+++ b/src/plugins/__tests__/settings-io.test.ts
@@ -1,0 +1,203 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { installPlugin, listEnabledPlugins, readSettings, uninstallPlugin, writeSettings } from "../settings-io.ts";
+
+let tmp: string;
+let path: string;
+
+beforeEach(() => {
+	tmp = mkdtempSync(join(tmpdir(), "phantom-settings-"));
+	path = join(tmp, "settings.json");
+});
+
+afterEach(() => {
+	rmSync(tmp, { recursive: true, force: true });
+});
+
+describe("readSettings", () => {
+	test("returns empty object and existed=false when file missing", () => {
+		const result = readSettings(path);
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.settings).toEqual({});
+			expect(result.existed).toBe(false);
+			expect(result.raw).toBeNull();
+		}
+	});
+
+	test("parses a valid file", () => {
+		writeFileSync(path, '{"permissions": {"allow": ["Read"]}}');
+		const result = readSettings(path);
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.existed).toBe(true);
+			expect(result.settings.permissions).toEqual({ allow: ["Read"] });
+		}
+	});
+
+	test("fails on invalid JSON", () => {
+		writeFileSync(path, "{ not json");
+		const result = readSettings(path);
+		expect(result.ok).toBe(false);
+		if (!result.ok) expect(result.error).toMatch(/not valid JSON/);
+	});
+
+	test("fails on non-object", () => {
+		writeFileSync(path, '["an","array"]');
+		const result = readSettings(path);
+		expect(result.ok).toBe(false);
+	});
+});
+
+describe("writeSettings", () => {
+	test("writes pretty-printed JSON", () => {
+		const result = writeSettings({ foo: "bar", enabledPlugins: { "a@b": true } }, path);
+		expect(result.ok).toBe(true);
+		const raw = readFileSync(path, "utf-8");
+		expect(raw).toContain('"foo": "bar"');
+		expect(raw).toContain('"enabledPlugins"');
+		expect(raw.endsWith("\n")).toBe(true);
+	});
+
+	test("round-trips fields untouched", () => {
+		const original = {
+			permissions: { allow: ["Read", "Glob"], deny: ["Bash(rm:*)"] },
+			model: "claude-opus-4-6",
+			enabledPlugins: { "a@b": true, "c@d": false },
+		};
+		writeSettings(original, path);
+		const read = readSettings(path);
+		expect(read.ok).toBe(true);
+		if (read.ok) expect(read.settings).toEqual(original);
+	});
+});
+
+describe("installPlugin", () => {
+	test("creates enabledPlugins if missing", () => {
+		writeFileSync(path, '{"permissions": {"allow": ["Read"]}}');
+		const result = installPlugin("notion@claude-plugins-official", path);
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.already_installed).toBe(false);
+			expect(result.previous_value).toBeNull();
+			expect(result.new_value).toBe(true);
+		}
+		const read = readSettings(path);
+		if (read.ok) {
+			expect(read.settings.enabledPlugins).toEqual({ "notion@claude-plugins-official": true });
+			expect(read.settings.permissions).toEqual({ allow: ["Read"] });
+		}
+	});
+
+	test("preserves other enabledPlugins entries", () => {
+		writeFileSync(path, '{"enabledPlugins": {"linear@claude-plugins-official": true}}');
+		const result = installPlugin("notion@claude-plugins-official", path);
+		expect(result.ok).toBe(true);
+		const read = readSettings(path);
+		if (read.ok) {
+			expect(read.settings.enabledPlugins).toEqual({
+				"linear@claude-plugins-official": true,
+				"notion@claude-plugins-official": true,
+			});
+		}
+	});
+
+	test("is idempotent when key is already true", () => {
+		writeFileSync(path, '{"enabledPlugins": {"notion@claude-plugins-official": true}}');
+		const result = installPlugin("notion@claude-plugins-official", path);
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.already_installed).toBe(true);
+			expect(result.previous_value).toBe(true);
+			expect(result.new_value).toBe(true);
+		}
+	});
+
+	test("re-enables a key that was set to false", () => {
+		writeFileSync(path, '{"enabledPlugins": {"notion@claude-plugins-official": false}}');
+		const result = installPlugin("notion@claude-plugins-official", path);
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.already_installed).toBe(false);
+			expect(result.previous_value).toBe(false);
+			expect(result.new_value).toBe(true);
+		}
+		const read = readSettings(path);
+		if (read.ok) {
+			expect((read.settings.enabledPlugins as Record<string, unknown>)["notion@claude-plugins-official"]).toBe(true);
+		}
+	});
+
+	test("creates settings.json when it does not exist", () => {
+		const result = installPlugin("notion@claude-plugins-official", path);
+		expect(result.ok).toBe(true);
+		const read = readSettings(path);
+		expect(read.ok).toBe(true);
+		if (read.ok) {
+			expect(read.existed).toBe(true);
+			expect(read.settings.enabledPlugins).toEqual({ "notion@claude-plugins-official": true });
+		}
+	});
+});
+
+describe("uninstallPlugin", () => {
+	test("sets an active key to false", () => {
+		writeFileSync(path, '{"enabledPlugins": {"notion@claude-plugins-official": true}}');
+		const result = uninstallPlugin("notion@claude-plugins-official", path);
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.was_active).toBe(true);
+			expect(result.previous_value).toBe(true);
+			expect(result.new_value).toBe(false);
+		}
+	});
+
+	test("is a no-op on a key that is already false", () => {
+		writeFileSync(path, '{"enabledPlugins": {"notion@claude-plugins-official": false}}');
+		const result = uninstallPlugin("notion@claude-plugins-official", path);
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.was_active).toBe(false);
+		}
+	});
+
+	test("adds the key as false if previously absent", () => {
+		writeFileSync(path, "{}");
+		const result = uninstallPlugin("notion@claude-plugins-official", path);
+		expect(result.ok).toBe(true);
+		const read = readSettings(path);
+		if (read.ok) {
+			expect((read.settings.enabledPlugins as Record<string, unknown>)["notion@claude-plugins-official"]).toBe(false);
+		}
+	});
+});
+
+describe("listEnabledPlugins", () => {
+	test("separates active from disabled", () => {
+		writeFileSync(
+			path,
+			JSON.stringify({
+				enabledPlugins: {
+					"linear@claude-plugins-official": true,
+					"notion@claude-plugins-official": true,
+					"slack@claude-plugins-official": false,
+					"context7@claude-plugins-official": [],
+				},
+			}),
+		);
+		const result = listEnabledPlugins(path);
+		expect(Object.keys(result.active).sort()).toEqual([
+			"linear@claude-plugins-official",
+			"notion@claude-plugins-official",
+		]);
+		expect(result.disabled.sort()).toEqual(["context7@claude-plugins-official", "slack@claude-plugins-official"]);
+	});
+
+	test("returns empty when settings.json is missing", () => {
+		const result = listEnabledPlugins(path);
+		expect(result.active).toEqual({});
+		expect(result.disabled).toEqual([]);
+	});
+});

--- a/src/plugins/audit.ts
+++ b/src/plugins/audit.ts
@@ -1,0 +1,90 @@
+// Append-only audit log for plugin installs and uninstalls.
+//
+// Same pattern as src/skills/audit.ts and src/memory-files/audit.ts:
+// every create/update/delete from the dashboard API records a row here. The
+// agent's own settings.json writes bypass this path today; a future PR may
+// add a file watcher to capture those.
+
+import type { Database } from "bun:sqlite";
+
+export type PluginAuditAction = "install" | "uninstall" | "reinstall" | "seed";
+export type PluginAuditActor = "user" | "agent" | "seed";
+
+export type PluginAuditEntry = {
+	id: number;
+	plugin_name: string;
+	marketplace: string;
+	action: PluginAuditAction;
+	source_type: string | null;
+	source_url: string | null;
+	previous_value: string | null;
+	new_value: string | null;
+	actor: PluginAuditActor;
+	created_at: string;
+};
+
+export function recordPluginInstall(
+	db: Database,
+	params: {
+		plugin: string;
+		marketplace: string;
+		action: PluginAuditAction;
+		sourceType: string | null;
+		sourceUrl: string | null;
+		previousValue: unknown;
+		newValue: unknown;
+		actor: PluginAuditActor;
+	},
+): void {
+	db.run(
+		`INSERT INTO plugin_install_audit_log (plugin_name, marketplace, action, source_type, source_url, previous_value, new_value, actor)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		[
+			params.plugin,
+			params.marketplace,
+			params.action,
+			params.sourceType,
+			params.sourceUrl,
+			params.previousValue === undefined || params.previousValue === null ? null : JSON.stringify(params.previousValue),
+			params.newValue === undefined || params.newValue === null ? null : JSON.stringify(params.newValue),
+			params.actor,
+		],
+	);
+}
+
+export function listPluginAudit(
+	db: Database,
+	filter?: { plugin?: string; marketplace?: string; limit?: number },
+): PluginAuditEntry[] {
+	const limit = filter?.limit ?? 100;
+	if (filter?.plugin && filter?.marketplace) {
+		return db
+			.query(
+				`SELECT id, plugin_name, marketplace, action, source_type, source_url, previous_value, new_value, actor, created_at
+				 FROM plugin_install_audit_log
+				 WHERE plugin_name = ? AND marketplace = ?
+				 ORDER BY id DESC
+				 LIMIT ?`,
+			)
+			.all(filter.plugin, filter.marketplace, limit) as PluginAuditEntry[];
+	}
+	if (filter?.plugin) {
+		return db
+			.query(
+				`SELECT id, plugin_name, marketplace, action, source_type, source_url, previous_value, new_value, actor, created_at
+				 FROM plugin_install_audit_log
+				 WHERE plugin_name = ?
+				 ORDER BY id DESC
+				 LIMIT ?`,
+			)
+			.all(filter.plugin, limit) as PluginAuditEntry[];
+	}
+	return db
+		.query(
+			`SELECT id, plugin_name, marketplace, action, source_type, source_url, previous_value, new_value, actor, created_at
+			 FROM plugin_install_audit_log
+			 ORDER BY id DESC
+			 LIMIT ?`,
+		)
+		.all(limit) as PluginAuditEntry[];
+}

--- a/src/plugins/curated.ts
+++ b/src/plugins/curated.ts
@@ -1,0 +1,89 @@
+// Loader for the Phantom-curated plugin metadata overlay.
+//
+// The file lives at config/plugins-curated.json (repo root, beside the other
+// config yaml files). It is a simple JSON document with an optional entry
+// per plugin-id@marketplace-id key. Entries annotate the upstream marketplace
+// entry with Phantom-specific tags, notes, audience, and optional version
+// pinning. See research file 05 for the full design.
+//
+// The loader is defensive: a missing, unreadable, or malformed overlay does
+// NOT break the plugins tab. It returns an empty overlay and logs one warning.
+
+import { existsSync, readFileSync, statSync } from "node:fs";
+import { resolve } from "node:path";
+import { type CuratedOverlay, CuratedOverlaySchema } from "./manifest.ts";
+
+const DEFAULT_OVERLAY: CuratedOverlay = { version: 1, plugins: {} };
+
+export function getCuratedOverlayPath(): string {
+	const override = process.env.PHANTOM_CURATED_OVERLAY_PATH;
+	if (override) {
+		return resolve(override);
+	}
+	return resolve(process.cwd(), "config", "plugins-curated.json");
+}
+
+// In-memory cache keyed by mtime so reloads are cheap.
+type CacheSlot = { mtimeMs: number; overlay: CuratedOverlay };
+let cache: { path: string; slot: CacheSlot } | null = null;
+
+export function loadCuratedOverlay(pathOverride?: string): CuratedOverlay {
+	const path = pathOverride ?? getCuratedOverlayPath();
+
+	if (!existsSync(path)) {
+		return DEFAULT_OVERLAY;
+	}
+
+	let mtimeMs: number;
+	try {
+		mtimeMs = statSync(path).mtimeMs;
+	} catch {
+		return DEFAULT_OVERLAY;
+	}
+
+	if (cache && cache.path === path && cache.slot.mtimeMs === mtimeMs) {
+		return cache.slot.overlay;
+	}
+
+	let raw: string;
+	try {
+		raw = readFileSync(path, "utf-8");
+	} catch (err: unknown) {
+		const msg = err instanceof Error ? err.message : String(err);
+		console.warn(`[plugins] curated overlay read failed (${path}): ${msg}`);
+		return DEFAULT_OVERLAY;
+	}
+
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(raw);
+	} catch (err: unknown) {
+		const msg = err instanceof Error ? err.message : String(err);
+		console.warn(`[plugins] curated overlay is not valid JSON (${path}): ${msg}`);
+		return DEFAULT_OVERLAY;
+	}
+
+	const result = CuratedOverlaySchema.safeParse(parsed);
+	if (!result.success) {
+		const issue = result.error.issues[0];
+		const where = issue.path.length > 0 ? issue.path.join(".") : "root";
+		console.warn(`[plugins] curated overlay schema error (${path}) at ${where}: ${issue.message}`);
+		return DEFAULT_OVERLAY;
+	}
+
+	const overlay: CuratedOverlay = result.data;
+	cache = { path, slot: { mtimeMs, overlay } };
+	return overlay;
+}
+
+// Test-only: force a cache drop. Invoked by the curated.test.ts file.
+export function __resetCuratedCacheForTests(): void {
+	cache = null;
+}
+
+export function lookupCuratedEntry(
+	overlay: CuratedOverlay,
+	pluginKey: string,
+): CuratedOverlay["plugins"][string] | null {
+	return overlay.plugins[pluginKey] ?? null;
+}

--- a/src/plugins/manifest.ts
+++ b/src/plugins/manifest.ts
@@ -84,7 +84,11 @@ export const UpstreamPluginSchema = z
 		tags: z.array(z.string()).optional(),
 		keywords: z.array(z.string()).optional(),
 		skills: z.array(z.string()).optional(),
-		lspServers: z.array(z.unknown()).optional(),
+		// Upstream lspServers is a Record<string, LspServerConfig> keyed by server name
+		// (e.g. {"clangd": {...}}), not an array. We do not render this field anywhere,
+		// so accept any shape and let .passthrough() keep it on the parsed object for
+		// future use. Strict typing here would reject ~12 real plugins from the catalog.
+		lspServers: z.unknown().optional(),
 		strict: z.boolean().optional(),
 	})
 	.passthrough();

--- a/src/plugins/manifest.ts
+++ b/src/plugins/manifest.ts
@@ -1,0 +1,182 @@
+// Zod schemas for the claude-plugins-official marketplace.json, the plugin
+// entry shape Phantom renders in its browser, the curated metadata overlay,
+// and the settings.json `enabledPlugins` shape.
+//
+// Every field Phantom reads is declared here. PR1's Codex P2 lesson: if you
+// have a strict Zod schema and you read an optional marker field, declare it
+// in the schema or the field is unreachable. We apply that discipline: every
+// field the dashboard or audit log ever touches has a slot in the schema.
+//
+// The schemas are intentionally permissive on fields Phantom does not use
+// (authors, tags, lspServers, keywords) via a passthrough tail. The fields
+// Phantom DOES use are strictly validated.
+
+import { z } from "zod";
+
+// Transport types supported by Claude Code's plugin resolver. PR2 v1 only
+// renders url, github, and local sources. git-subdir, npm, pip exist in the
+// schema for forward-compat but the dashboard filters them out with a
+// "coming in a later release" footnote. Declaring them here means we still
+// parse the upstream marketplace cleanly.
+export const PluginSourceTypeSchema = z.enum(["url", "github", "git", "git-subdir", "npm", "pip", "file", "directory"]);
+
+export type PluginSourceType = z.infer<typeof PluginSourceTypeSchema>;
+
+// Upstream source field is either a relative path string ("./plugins/foo")
+// or an object with a source discriminator. We preserve both forms and
+// normalize to a tagged union at the merge step.
+export const PluginSourceObjectSchema = z
+	.object({
+		source: PluginSourceTypeSchema,
+		url: z.string().optional(),
+		repo: z.string().optional(),
+		ref: z.string().optional(),
+		path: z.string().optional(),
+		sha: z.string().optional(),
+		sparsePaths: z.array(z.string()).optional(),
+		package: z.string().optional(),
+		headers: z.record(z.string()).optional(),
+	})
+	.passthrough();
+
+export const PluginSourceSchema = z.union([z.string(), PluginSourceObjectSchema]);
+
+export type PluginSource = z.infer<typeof PluginSourceSchema>;
+
+// Normalized shape the dashboard actually renders per card. Every field is
+// declared; no passthrough. This is the contract between the fetcher and the
+// UI.
+export const NormalizedPluginSchema = z
+	.object({
+		name: z.string().min(1),
+		marketplace: z.string().min(1),
+		description: z.string().default(""),
+		source_type: z.enum(["url", "github", "local", "git", "git-subdir", "npm", "pip", "file", "directory"]),
+		source_url: z.string().nullable(),
+		category: z.string().nullable(),
+		homepage: z.string().nullable(),
+		version: z.string().nullable(),
+		tags: z.array(z.string()).default([]),
+		curated_tags: z.array(z.string()).default([]),
+		curated_note: z.string().nullable(),
+		audience: z.array(z.string()).default([]),
+		pinned_version: z.string().nullable(),
+		enabled: z.boolean().default(false),
+	})
+	.strict();
+
+export type NormalizedPlugin = z.infer<typeof NormalizedPluginSchema>;
+
+// The upstream plugin entry as it appears in marketplace.json. We only
+// strictly validate the fields we read and use passthrough for everything
+// else so upstream schema additions do not break us.
+export const UpstreamPluginSchema = z
+	.object({
+		name: z.string().min(1),
+		description: z.string().optional(),
+		category: z.string().optional(),
+		source: PluginSourceSchema.optional(),
+		homepage: z.string().optional(),
+		version: z.string().optional(),
+		author: z
+			.union([z.string(), z.object({ name: z.string().optional(), email: z.string().optional() }).passthrough()])
+			.optional(),
+		tags: z.array(z.string()).optional(),
+		keywords: z.array(z.string()).optional(),
+		skills: z.array(z.string()).optional(),
+		lspServers: z.array(z.unknown()).optional(),
+		strict: z.boolean().optional(),
+	})
+	.passthrough();
+
+export type UpstreamPlugin = z.infer<typeof UpstreamPluginSchema>;
+
+export const MarketplaceOwnerSchema = z
+	.object({
+		name: z.string().optional(),
+		email: z.string().optional(),
+	})
+	.passthrough();
+
+export const MarketplaceSchema = z
+	.object({
+		$schema: z.string().optional(),
+		name: z.string().min(1),
+		description: z.string().optional(),
+		owner: MarketplaceOwnerSchema.optional(),
+		plugins: z.array(UpstreamPluginSchema),
+	})
+	.passthrough();
+
+export type Marketplace = z.infer<typeof MarketplaceSchema>;
+
+// ----- Curated overlay schema (see research file 05) -----
+
+export const CuratedTagSchema = z.enum(["phantom-recommended", "production-tested", "experimental", "deprecated"]);
+
+export type CuratedTag = z.infer<typeof CuratedTagSchema>;
+
+export const CuratedEntrySchema = z
+	.object({
+		tags: z.array(CuratedTagSchema).optional(),
+		category: z.string().optional(),
+		audience: z.array(z.string()).optional(),
+		note: z.string().max(280).optional(),
+		pinned_version: z.string().nullable().optional(),
+		last_reviewed: z.string().optional(),
+	})
+	.strict();
+
+export type CuratedEntry = z.infer<typeof CuratedEntrySchema>;
+
+export const CuratedOverlaySchema = z
+	.object({
+		$schema: z.string().optional(),
+		version: z.literal(1),
+		plugins: z.record(CuratedEntrySchema).default({}),
+	})
+	.strict();
+
+export type CuratedOverlay = z.infer<typeof CuratedOverlaySchema>;
+
+// ----- enabledPlugins schema -----
+//
+// The value of each enabledPlugins entry can be `true`, `false`, a
+// string[] (version constraints), or an object. We accept all four. We
+// treat `false` and missing entries as uninstalled. Everything else is
+// installed. (The CLI uses `false` instead of deleting keys on uninstall.)
+
+export const EnabledPluginValueSchema = z.union([z.boolean(), z.array(z.string()), z.record(z.unknown())]);
+
+export type EnabledPluginValue = z.infer<typeof EnabledPluginValueSchema>;
+
+export const EnabledPluginsMapSchema = z.record(EnabledPluginValueSchema);
+
+export type EnabledPluginsMap = z.infer<typeof EnabledPluginsMapSchema>;
+
+export function isEnabledValueActive(value: EnabledPluginValue | undefined): boolean {
+	if (value === undefined) return false;
+	if (value === false) return false;
+	if (value === true) return true;
+	if (Array.isArray(value)) return value.length > 0;
+	if (typeof value === "object" && value !== null) return Object.keys(value).length > 0;
+	return false;
+}
+
+// Normalize the upstream source field to the flat `(type, url)` shape the
+// dashboard renders. This is the single place that handles the two upstream
+// representations (string "./..." vs object).
+export function normalizeSource(source: PluginSource | undefined): {
+	source_type: NormalizedPlugin["source_type"];
+	source_url: string | null;
+} {
+	if (source === undefined) {
+		return { source_type: "local", source_url: null };
+	}
+	if (typeof source === "string") {
+		return { source_type: "local", source_url: source };
+	}
+	const type = source.source;
+	const url = source.url ?? source.repo ?? source.package ?? source.path ?? null;
+	return { source_type: type, source_url: url };
+}

--- a/src/plugins/marketplace.ts
+++ b/src/plugins/marketplace.ts
@@ -1,0 +1,262 @@
+// Marketplace fetcher with TTL cache + curated overlay merge.
+//
+// Fetches claude-plugins-official marketplace.json from the raw GitHub CDN,
+// caches the raw document in SQLite so the dashboard renders instantly on
+// subsequent loads, normalizes each upstream entry to the shape the dashboard
+// expects, filters out unsupported transports per the PR2 v1 scope, and
+// merges the Phantom curated overlay on top.
+//
+// The fetch is not on the hot path: the dashboard calls this once per tab
+// open and the TTL is 10 minutes. If the fetch fails, we serve the cached
+// document even if it is past TTL (stale-while-error) so a network blip
+// never breaks the plugins tab.
+
+import type { Database } from "bun:sqlite";
+import { loadCuratedOverlay, lookupCuratedEntry } from "./curated.ts";
+import {
+	type CuratedOverlay,
+	type Marketplace,
+	MarketplaceSchema,
+	type NormalizedPlugin,
+	type UpstreamPlugin,
+	normalizeSource,
+} from "./manifest.ts";
+import { OFFICIAL_MARKETPLACE_ID } from "./paths.ts";
+
+// v1 scope: url, github, local are rendered in the browser. git, git-subdir,
+// npm, pip, file, and directory entries are filtered out with an informational
+// footnote. This is the brief's explicit constraint.
+const SUPPORTED_SOURCE_TYPES: ReadonlySet<NormalizedPlugin["source_type"]> = new Set(["url", "github", "local"]);
+
+const OFFICIAL_MARKETPLACE_URL =
+	"https://raw.githubusercontent.com/anthropics/claude-plugins-official/main/.claude-plugin/marketplace.json";
+
+const DEFAULT_TTL_MS = 10 * 60 * 1000; // 10 minutes
+
+export type MarketplaceCacheRow = {
+	marketplace_id: string;
+	etag: string | null;
+	fetched_at: string;
+	body: string;
+};
+
+export function ensureMarketplaceCacheTable(db: Database): void {
+	db.run(
+		`CREATE TABLE IF NOT EXISTS plugin_marketplace_cache (
+			marketplace_id TEXT PRIMARY KEY,
+			etag TEXT,
+			fetched_at TEXT NOT NULL,
+			body TEXT NOT NULL
+		)`,
+	);
+}
+
+function readCachedRow(db: Database, marketplaceId: string): MarketplaceCacheRow | null {
+	const row = db
+		.query("SELECT marketplace_id, etag, fetched_at, body FROM plugin_marketplace_cache WHERE marketplace_id = ?")
+		.get(marketplaceId) as MarketplaceCacheRow | null;
+	return row;
+}
+
+function writeCachedRow(db: Database, marketplaceId: string, body: string, etag: string | null): void {
+	db.run(
+		`INSERT INTO plugin_marketplace_cache (marketplace_id, etag, fetched_at, body)
+		 VALUES (?, ?, datetime('now'), ?)
+		 ON CONFLICT(marketplace_id) DO UPDATE SET
+		   etag = excluded.etag,
+		   fetched_at = excluded.fetched_at,
+		   body = excluded.body`,
+		[marketplaceId, etag, body],
+	);
+}
+
+function cacheAgeMs(row: MarketplaceCacheRow): number {
+	return Date.now() - Date.parse(`${row.fetched_at}Z`);
+}
+
+// Injectable fetcher so tests never hit the network.
+export type FetchMarketplaceFn = (url: string) => Promise<{ ok: boolean; body: string; etag: string | null }>;
+
+const defaultFetcher: FetchMarketplaceFn = async (url: string) => {
+	const response = await fetch(url, { headers: { Accept: "application/json" } });
+	if (!response.ok) {
+		return { ok: false, body: "", etag: null };
+	}
+	const body = await response.text();
+	const etag = response.headers.get("etag");
+	return { ok: true, body, etag };
+};
+
+export type MarketplaceResolveOptions = {
+	db: Database;
+	fetcher?: FetchMarketplaceFn;
+	ttlMs?: number;
+	marketplaceId?: string;
+	marketplaceUrl?: string;
+	forceRefresh?: boolean;
+};
+
+export type MarketplaceResolveResult = {
+	marketplace: Marketplace;
+	fetchedAt: string;
+	cacheHit: boolean;
+	fromStaleCache: boolean;
+};
+
+export async function resolveMarketplace(options: MarketplaceResolveOptions): Promise<MarketplaceResolveResult> {
+	const {
+		db,
+		fetcher = defaultFetcher,
+		ttlMs = DEFAULT_TTL_MS,
+		marketplaceId = OFFICIAL_MARKETPLACE_ID,
+		marketplaceUrl = OFFICIAL_MARKETPLACE_URL,
+		forceRefresh = false,
+	} = options;
+
+	ensureMarketplaceCacheTable(db);
+
+	const cached = readCachedRow(db, marketplaceId);
+
+	if (!forceRefresh && cached && cacheAgeMs(cached) < ttlMs) {
+		const parsed = MarketplaceSchema.parse(JSON.parse(cached.body));
+		return { marketplace: parsed, fetchedAt: cached.fetched_at, cacheHit: true, fromStaleCache: false };
+	}
+
+	let fetched: Awaited<ReturnType<FetchMarketplaceFn>>;
+	try {
+		fetched = await fetcher(marketplaceUrl);
+	} catch (err: unknown) {
+		if (cached) {
+			const parsed = MarketplaceSchema.parse(JSON.parse(cached.body));
+			return { marketplace: parsed, fetchedAt: cached.fetched_at, cacheHit: true, fromStaleCache: true };
+		}
+		const msg = err instanceof Error ? err.message : String(err);
+		throw new Error(`Failed to fetch marketplace ${marketplaceId}: ${msg}`);
+	}
+
+	if (!fetched.ok) {
+		if (cached) {
+			const parsed = MarketplaceSchema.parse(JSON.parse(cached.body));
+			return { marketplace: parsed, fetchedAt: cached.fetched_at, cacheHit: true, fromStaleCache: true };
+		}
+		throw new Error(`Marketplace ${marketplaceId} unreachable and no cache available`);
+	}
+
+	// Validate before caching so malformed bodies never poison the cache.
+	let parsedDoc: Marketplace;
+	try {
+		parsedDoc = MarketplaceSchema.parse(JSON.parse(fetched.body));
+	} catch (err: unknown) {
+		const msg = err instanceof Error ? err.message : String(err);
+		if (cached) {
+			const prev = MarketplaceSchema.parse(JSON.parse(cached.body));
+			return { marketplace: prev, fetchedAt: cached.fetched_at, cacheHit: true, fromStaleCache: true };
+		}
+		throw new Error(`Marketplace ${marketplaceId} response invalid: ${msg}`);
+	}
+
+	writeCachedRow(db, marketplaceId, fetched.body, fetched.etag);
+	const now = new Date().toISOString().replace("T", " ").replace(/\..*/, "");
+	return { marketplace: parsedDoc, fetchedAt: now, cacheHit: false, fromStaleCache: false };
+}
+
+// ----- Normalization and curated merge -----
+
+export function normalizeUpstream(
+	upstream: UpstreamPlugin,
+	marketplaceId: string,
+	overlay: CuratedOverlay,
+	activeKeys: Set<string>,
+): NormalizedPlugin {
+	const { source_type, source_url } = normalizeSource(upstream.source);
+	const key = `${upstream.name}@${marketplaceId}`;
+	const curated = lookupCuratedEntry(overlay, key);
+	return {
+		name: upstream.name,
+		marketplace: marketplaceId,
+		description: upstream.description ?? "",
+		source_type,
+		source_url,
+		category: curated?.category ?? upstream.category ?? null,
+		homepage: upstream.homepage ?? null,
+		version: upstream.version ?? null,
+		tags: upstream.tags ?? [],
+		curated_tags: curated?.tags ?? [],
+		curated_note: curated?.note ?? null,
+		audience: curated?.audience ?? [],
+		pinned_version: curated?.pinned_version ?? null,
+		enabled: activeKeys.has(key),
+	};
+}
+
+export type CatalogOptions = {
+	db: Database;
+	fetcher?: FetchMarketplaceFn;
+	ttlMs?: number;
+	activeKeys: Set<string>;
+	overlayPath?: string;
+	forceRefresh?: boolean;
+};
+
+export type Catalog = {
+	marketplace: string;
+	plugins: NormalizedPlugin[];
+	hidden_by_transport: number; // count of filtered entries so the UI can show a footnote
+	fetched_at: string;
+	cache_hit: boolean;
+	from_stale_cache: boolean;
+};
+
+export async function getCatalog(options: CatalogOptions): Promise<Catalog> {
+	const overlay = loadCuratedOverlay(options.overlayPath);
+	const resolved = await resolveMarketplace({
+		db: options.db,
+		fetcher: options.fetcher,
+		ttlMs: options.ttlMs,
+		forceRefresh: options.forceRefresh,
+	});
+
+	const normalized: NormalizedPlugin[] = [];
+	let hidden = 0;
+	for (const upstream of resolved.marketplace.plugins) {
+		const flat = normalizeUpstream(upstream, resolved.marketplace.name, overlay, options.activeKeys);
+		if (!SUPPORTED_SOURCE_TYPES.has(flat.source_type)) {
+			hidden += 1;
+			continue;
+		}
+		normalized.push(flat);
+	}
+
+	normalized.sort(sortNormalized);
+
+	return {
+		marketplace: resolved.marketplace.name,
+		plugins: normalized,
+		hidden_by_transport: hidden,
+		fetched_at: resolved.fetchedAt,
+		cache_hit: resolved.cacheHit,
+		from_stale_cache: resolved.fromStaleCache,
+	};
+}
+
+// Phantom-recommended floats to the top, then production-tested, then
+// untagged, then experimental, then deprecated. Within each tier, sort by
+// name ascending. Installed entries stay within their tier (installed state
+// is surfaced by a badge, not by order).
+export function sortNormalized(a: NormalizedPlugin, b: NormalizedPlugin): number {
+	const tierA = curatedTier(a);
+	const tierB = curatedTier(b);
+	if (tierA !== tierB) return tierA - tierB;
+	return a.name.localeCompare(b.name);
+}
+
+function curatedTier(p: NormalizedPlugin): number {
+	if (p.curated_tags.includes("phantom-recommended")) return 0;
+	if (p.curated_tags.includes("production-tested")) return 1;
+	if (p.curated_tags.length === 0) return 2;
+	if (p.curated_tags.includes("experimental")) return 3;
+	if (p.curated_tags.includes("deprecated")) return 4;
+	return 2;
+}
+
+export const SUPPORTED_TRANSPORT_LIST: ReadonlyArray<NormalizedPlugin["source_type"]> = ["url", "github", "local"];

--- a/src/plugins/paths.ts
+++ b/src/plugins/paths.ts
@@ -1,0 +1,82 @@
+// Resolve and validate plugin-related filesystem paths.
+//
+// Plugins in Claude Code live under the user-scope `.claude` directory on
+// disk: settings.json declares which plugins are enabled and the CLI clones
+// each plugin under `~/.claude/plugins/` on next query init. Phantom never
+// writes to the plugin cache itself; it only writes to settings.json and
+// lets the CLI subprocess do the clone + manifest validation + load.
+//
+// Responsibilities here:
+//   - locate the user-scope settings.json (/home/phantom/.claude/settings.json)
+//   - locate the plugin cache root (/home/phantom/.claude/plugins/) for
+//     read-only listing inside the audit tab
+//   - validate plugin keys of the form `plugin-id@marketplace-id`
+
+import { homedir } from "node:os";
+import { resolve } from "node:path";
+
+const CLAUDE_ROOT_OVERRIDE = "PHANTOM_CLAUDE_ROOT";
+
+// Same character set the Claude Code CLI uses for plugin and marketplace ids:
+// lowercase letters, digits, hyphens, underscores. Length bounded so a hostile
+// write cannot try to bloat the audit log or filesystem.
+const PLUGIN_ID_PATTERN = /^[a-z0-9][a-z0-9_.-]{0,63}$/;
+const MARKETPLACE_ID_PATTERN = /^[a-z0-9][a-z0-9_.-]{0,63}$/;
+
+export function getClaudeRoot(): string {
+	const override = process.env[CLAUDE_ROOT_OVERRIDE];
+	if (override) {
+		return resolve(override);
+	}
+	return resolve(homedir(), ".claude");
+}
+
+export function getUserSettingsPath(): string {
+	return resolve(getClaudeRoot(), "settings.json");
+}
+
+export function getPluginCacheRoot(): string {
+	return resolve(getClaudeRoot(), "plugins");
+}
+
+export function isValidPluginId(id: string): boolean {
+	if (typeof id !== "string") return false;
+	if (id.includes("\0")) return false;
+	return PLUGIN_ID_PATTERN.test(id);
+}
+
+export function isValidMarketplaceId(id: string): boolean {
+	if (typeof id !== "string") return false;
+	if (id.includes("\0")) return false;
+	return MARKETPLACE_ID_PATTERN.test(id);
+}
+
+export type PluginKey = {
+	plugin: string;
+	marketplace: string;
+};
+
+// Parse a `plugin-id@marketplace-id` key. Returns null if either half is
+// missing or invalid.
+export function parsePluginKey(key: string): PluginKey | null {
+	if (typeof key !== "string") return null;
+	const at = key.lastIndexOf("@");
+	if (at <= 0 || at === key.length - 1) return null;
+	const plugin = key.slice(0, at);
+	const marketplace = key.slice(at + 1);
+	if (!isValidPluginId(plugin)) return null;
+	if (!isValidMarketplaceId(marketplace)) return null;
+	return { plugin, marketplace };
+}
+
+export function formatPluginKey(plugin: string, marketplace: string): string {
+	if (!isValidPluginId(plugin)) {
+		throw new Error(`Invalid plugin id: ${JSON.stringify(plugin)}`);
+	}
+	if (!isValidMarketplaceId(marketplace)) {
+		throw new Error(`Invalid marketplace id: ${JSON.stringify(marketplace)}`);
+	}
+	return `${plugin}@${marketplace}`;
+}
+
+export const OFFICIAL_MARKETPLACE_ID = "claude-plugins-official";

--- a/src/plugins/seed.ts
+++ b/src/plugins/seed.ts
@@ -51,10 +51,19 @@ export type SeedResult = {
 	created: boolean;
 };
 
+export type SeedOptions = {
+	// When true, compute the would-add and would-skip sets but do NOT write
+	// settings.json. Used by the CLI dry-run path so operators can preview the
+	// effect of `bun run src/plugins/seed.ts` before they pass --apply.
+	dryRun?: boolean;
+};
+
 export function seedDefaultPlugins(
 	picks: ReadonlyArray<PluginPick>,
 	settingsPath: string = getUserSettingsPath(),
+	options: SeedOptions = {},
 ): SeedResult {
+	const dryRun = options.dryRun === true;
 	const created = !existsSync(settingsPath);
 	const read = readSettings(settingsPath);
 	if (!read.ok) {
@@ -80,6 +89,12 @@ export function seedDefaultPlugins(
 		return { added, skipped, created: false };
 	}
 
+	if (dryRun) {
+		// Report what would change, but never touch the file. The "created"
+		// flag still reports the would-have-created state for an honest preview.
+		return { added, skipped, created };
+	}
+
 	settings.enabledPlugins = enabled as typeof settings.enabledPlugins;
 	const write = writeSettings(settings, settingsPath);
 	if (!write.ok) {
@@ -101,17 +116,20 @@ function main(): void {
 		);
 		return;
 	}
-	if (!args.includes("--apply")) {
-		process.stdout.write("[seed] Dry run mode (use --apply to write).\n");
+	const dryRun = !args.includes("--apply");
+	if (dryRun) {
+		process.stdout.write("[seed] Dry run mode (use --apply to write). No changes will be made.\n");
 	}
 	try {
-		const result = seedDefaultPlugins(DEFAULT_PLUGIN_PICKS);
+		const result = seedDefaultPlugins(DEFAULT_PLUGIN_PICKS, getUserSettingsPath(), { dryRun });
+		const verb = dryRun ? "Would add" : "Added";
+		const skipVerb = dryRun ? "Would preserve" : "Preserved";
 		if (result.added.length > 0) {
-			process.stdout.write(`[seed] Added ${result.added.length} default plugin(s): ${result.added.join(", ")}\n`);
+			process.stdout.write(`[seed] ${verb} ${result.added.length} default plugin(s): ${result.added.join(", ")}\n`);
 		}
 		if (result.skipped.length > 0) {
 			process.stdout.write(
-				`[seed] Preserved ${result.skipped.length} existing plugin(s): ${result.skipped.join(", ")}\n`,
+				`[seed] ${skipVerb} ${result.skipped.length} existing plugin(s): ${result.skipped.join(", ")}\n`,
 			);
 		}
 		if (result.added.length === 0 && result.skipped.length === 0) {

--- a/src/plugins/seed.ts
+++ b/src/plugins/seed.ts
@@ -1,0 +1,129 @@
+// First-boot default plugin seeder.
+//
+// Invoked from scripts/docker-entrypoint.sh on container start via
+// `bun run src/plugins/seed.ts --apply`. Reads the user-scope settings.json
+// at /home/phantom/.claude/settings.json (or whatever PHANTOM_CLAUDE_ROOT
+// points at), and merges in Phantom's four default plugins if they are
+// not already mentioned. The rule is "preserve operator choices": if the
+// operator (or the agent) has already added or removed any of the picks
+// since last boot, leave them alone.
+//
+// The picks are documented in research file 03 (default plugin picks) and
+// represent the cross-role catalog Phantom ships with: linear, notion,
+// slack, claude-md-management.
+
+import { existsSync } from "node:fs";
+import { OFFICIAL_MARKETPLACE_ID, formatPluginKey, getUserSettingsPath } from "./paths.ts";
+import { readSettings, writeSettings } from "./settings-io.ts";
+
+export type PluginPick = {
+	plugin: string;
+	marketplace: string;
+	description: string;
+};
+
+export const DEFAULT_PLUGIN_PICKS: ReadonlyArray<PluginPick> = [
+	{
+		plugin: "linear",
+		marketplace: OFFICIAL_MARKETPLACE_ID,
+		description: "Linear issue tracking. Read issues, triage bugs, update statuses.",
+	},
+	{
+		plugin: "notion",
+		marketplace: OFFICIAL_MARKETPLACE_ID,
+		description: "Notion workspace. Search pages, create docs, manage databases.",
+	},
+	{
+		plugin: "slack",
+		marketplace: OFFICIAL_MARKETPLACE_ID,
+		description: "Slack workspace. Search messages across channels beyond Phantom's own threads.",
+	},
+	{
+		plugin: "claude-md-management",
+		marketplace: OFFICIAL_MARKETPLACE_ID,
+		description: "Audits and improves your CLAUDE.md memory file.",
+	},
+];
+
+export type SeedResult = {
+	added: string[];
+	skipped: string[];
+	created: boolean;
+};
+
+export function seedDefaultPlugins(
+	picks: ReadonlyArray<PluginPick>,
+	settingsPath: string = getUserSettingsPath(),
+): SeedResult {
+	const created = !existsSync(settingsPath);
+	const read = readSettings(settingsPath);
+	if (!read.ok) {
+		throw new Error(`seedDefaultPlugins: ${read.error}`);
+	}
+	const settings = read.settings;
+	const enabled = (settings.enabledPlugins ?? {}) as Record<string, unknown>;
+
+	const added: string[] = [];
+	const skipped: string[] = [];
+
+	for (const pick of picks) {
+		const key = formatPluginKey(pick.plugin, pick.marketplace);
+		if (key in enabled) {
+			skipped.push(key);
+			continue;
+		}
+		enabled[key] = true;
+		added.push(key);
+	}
+
+	if (added.length === 0 && created === false) {
+		return { added, skipped, created: false };
+	}
+
+	settings.enabledPlugins = enabled as typeof settings.enabledPlugins;
+	const write = writeSettings(settings, settingsPath);
+	if (!write.ok) {
+		throw new Error(`seedDefaultPlugins: ${write.error}`);
+	}
+
+	return { added, skipped, created };
+}
+
+// CLI entrypoint. Invoked by docker-entrypoint.sh.
+function main(): void {
+	const args = process.argv.slice(2);
+	if (args.includes("--help") || args.includes("-h")) {
+		process.stdout.write(
+			"Usage: bun run src/plugins/seed.ts [--apply]\n\n" +
+				"  --apply   merge the four default Phantom plugins into the\n" +
+				"            user-scope settings.json if they are not already\n" +
+				"            present. Operator-edited entries are preserved.\n",
+		);
+		return;
+	}
+	if (!args.includes("--apply")) {
+		process.stdout.write("[seed] Dry run mode (use --apply to write).\n");
+	}
+	try {
+		const result = seedDefaultPlugins(DEFAULT_PLUGIN_PICKS);
+		if (result.added.length > 0) {
+			process.stdout.write(`[seed] Added ${result.added.length} default plugin(s): ${result.added.join(", ")}\n`);
+		}
+		if (result.skipped.length > 0) {
+			process.stdout.write(
+				`[seed] Preserved ${result.skipped.length} existing plugin(s): ${result.skipped.join(", ")}\n`,
+			);
+		}
+		if (result.added.length === 0 && result.skipped.length === 0) {
+			process.stdout.write("[seed] No defaults configured.\n");
+		}
+	} catch (err: unknown) {
+		const msg = err instanceof Error ? err.message : String(err);
+		process.stderr.write(`[seed] Failed: ${msg}\n`);
+		process.exit(1);
+	}
+}
+
+if (import.meta.main) {
+	main();
+}

--- a/src/plugins/settings-io.ts
+++ b/src/plugins/settings-io.ts
@@ -1,0 +1,170 @@
+// Atomic read / modify / write of /home/phantom/.claude/settings.json.
+//
+// PR2 only touches the `enabledPlugins` field. Every other field is
+// preserved byte-for-byte on a round trip (minus key reordering via JSON
+// serialization). Writes go through tmp-then-rename so a crash never leaves
+// a torn file. No file locking; last-write-wins per the Cardinal Rule.
+//
+// Why we do NOT use YAML or a TOML intermediate: settings.json is JSON by
+// spec and the CLI parses it as JSON. Anything else is a compatibility hazard.
+//
+// Why we do NOT guard against `enabledPlugins` being set to unexpected shapes:
+// the CLI is permissive here (it accepts booleans, string arrays, and
+// objects). We preserve whatever is there and only mutate the single key we
+// are touching.
+
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { type EnabledPluginValue, type EnabledPluginsMap, isEnabledValueActive } from "./manifest.ts";
+import { getUserSettingsPath } from "./paths.ts";
+
+export type SettingsJson = Record<string, unknown> & {
+	enabledPlugins?: EnabledPluginsMap;
+};
+
+export type ReadSettingsResult =
+	| { ok: true; settings: SettingsJson; existed: boolean; raw: string | null }
+	| { ok: false; error: string };
+
+export function readSettings(path: string = getUserSettingsPath()): ReadSettingsResult {
+	if (!existsSync(path)) {
+		return { ok: true, settings: {}, existed: false, raw: null };
+	}
+	let raw: string;
+	try {
+		raw = readFileSync(path, "utf-8");
+	} catch (err: unknown) {
+		const msg = err instanceof Error ? err.message : String(err);
+		return { ok: false, error: `Failed to read settings: ${msg}` };
+	}
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(raw);
+	} catch (err: unknown) {
+		const msg = err instanceof Error ? err.message : String(err);
+		return { ok: false, error: `Settings is not valid JSON: ${msg}` };
+	}
+	if (parsed == null || typeof parsed !== "object" || Array.isArray(parsed)) {
+		return { ok: false, error: "Settings must be a JSON object" };
+	}
+	return { ok: true, settings: parsed as SettingsJson, existed: true, raw };
+}
+
+function ensureDir(dir: string): void {
+	if (!existsSync(dir)) {
+		mkdirSync(dir, { recursive: true });
+	}
+}
+
+function writeAtomic(path: string, content: string): void {
+	const dir = dirname(path);
+	ensureDir(dir);
+	const tmp = join(dir, `.settings.json.tmp-${process.pid}-${Date.now()}`);
+	writeFileSync(tmp, content, { encoding: "utf-8", mode: 0o644 });
+	renameSync(tmp, path);
+}
+
+export type WriteSettingsResult = { ok: true; settings: SettingsJson } | { ok: false; error: string };
+
+export function writeSettings(settings: SettingsJson, path: string = getUserSettingsPath()): WriteSettingsResult {
+	// Two-space indent matches the Claude Code CLI's own formatter so diffs
+	// on disk are minimal when the agent and the dashboard write the same file.
+	const serialized = `${JSON.stringify(settings, null, 2)}\n`;
+	try {
+		writeAtomic(path, serialized);
+	} catch (err: unknown) {
+		const msg = err instanceof Error ? err.message : String(err);
+		return { ok: false, error: `Failed to write settings: ${msg}` };
+	}
+	return { ok: true, settings };
+}
+
+export type InstallPluginResult =
+	| {
+			ok: true;
+			key: string;
+			previous_value: EnabledPluginValue | null;
+			new_value: EnabledPluginValue;
+			already_installed: boolean;
+	  }
+	| { ok: false; status: 400 | 500; error: string };
+
+// Merge an `enabledPlugins` entry into settings.json. If the key is already
+// present AND active, returns `already_installed: true` without rewriting.
+// Otherwise, sets the key to `true` and writes back atomically.
+export function installPlugin(key: string, path?: string): InstallPluginResult {
+	const read = readSettings(path);
+	if (!read.ok) {
+		return { ok: false, status: 500, error: read.error };
+	}
+	const settings = read.settings;
+	const existing = (settings.enabledPlugins ?? {}) as EnabledPluginsMap;
+	const previous: EnabledPluginValue | null = existing[key] ?? null;
+	if (previous !== null && isEnabledValueActive(previous)) {
+		return { ok: true, key, previous_value: previous, new_value: previous, already_installed: true };
+	}
+	const next: EnabledPluginsMap = { ...existing, [key]: true };
+	const merged: SettingsJson = { ...settings, enabledPlugins: next };
+	const write = writeSettings(merged, path);
+	if (!write.ok) {
+		return { ok: false, status: 500, error: write.error };
+	}
+	return { ok: true, key, previous_value: previous, new_value: true, already_installed: false };
+}
+
+export type UninstallPluginResult =
+	| {
+			ok: true;
+			key: string;
+			previous_value: EnabledPluginValue | null;
+			new_value: EnabledPluginValue;
+			was_active: boolean;
+	  }
+	| { ok: false; status: 400 | 500; error: string };
+
+// Soft-uninstall: sets the enabledPlugins entry to `false`. Matches the CLI's
+// own uninstall behavior (cli.js:5641 region where TL6() sets false instead
+// of deleting). Preserves the key so re-enable is a one-click flip.
+export function uninstallPlugin(key: string, path?: string): UninstallPluginResult {
+	const read = readSettings(path);
+	if (!read.ok) {
+		return { ok: false, status: 500, error: read.error };
+	}
+	const settings = read.settings;
+	const existing = (settings.enabledPlugins ?? {}) as EnabledPluginsMap;
+	const previous: EnabledPluginValue | null = existing[key] ?? null;
+	const wasActive = isEnabledValueActive(previous ?? undefined);
+	if (previous === false) {
+		return { ok: true, key, previous_value: false, new_value: false, was_active: false };
+	}
+	const next: EnabledPluginsMap = { ...existing, [key]: false };
+	const merged: SettingsJson = { ...settings, enabledPlugins: next };
+	const write = writeSettings(merged, path);
+	if (!write.ok) {
+		return { ok: false, status: 500, error: write.error };
+	}
+	return { ok: true, key, previous_value: previous, new_value: false, was_active: wasActive };
+}
+
+// Read-only snapshot: returns the currently-active enabledPlugins keys, with
+// their stored value. Used by the dashboard `GET /ui/api/plugins` handler.
+export function listEnabledPlugins(path?: string): {
+	active: Record<string, EnabledPluginValue>;
+	disabled: string[];
+} {
+	const read = readSettings(path);
+	if (!read.ok) {
+		return { active: {}, disabled: [] };
+	}
+	const enabled = (read.settings.enabledPlugins ?? {}) as EnabledPluginsMap;
+	const active: Record<string, EnabledPluginValue> = {};
+	const disabled: string[] = [];
+	for (const [key, value] of Object.entries(enabled)) {
+		if (isEnabledValueActive(value)) {
+			active[key] = value;
+		} else {
+			disabled.push(key);
+		}
+	}
+	return { active, disabled };
+}

--- a/src/ui/api/__tests__/plugins.test.ts
+++ b/src/ui/api/__tests__/plugins.test.ts
@@ -1,0 +1,281 @@
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { MIGRATIONS } from "../../../db/schema.ts";
+import { __resetCuratedCacheForTests } from "../../../plugins/curated.ts";
+import type { FetchMarketplaceFn } from "../../../plugins/marketplace.ts";
+import {
+	clearPluginsApiOverridesForTests,
+	handleUiRequest,
+	setDashboardDb,
+	setPluginsApiOverridesForTests,
+	setPublicDir,
+} from "../../serve.ts";
+import { createSession, revokeAllSessions } from "../../session.ts";
+
+setPublicDir(resolve(import.meta.dir, "../../../../public"));
+
+const FIXTURE_BODY = JSON.stringify({
+	$schema: "https://anthropic.com/claude-code/marketplace.schema.json",
+	name: "claude-plugins-official",
+	owner: { name: "Anthropic" },
+	plugins: [
+		{
+			name: "notion",
+			description: "Notion workspace integration.",
+			category: "productivity",
+			source: { source: "url", url: "https://github.com/makenotion/claude-code-notion-plugin.git" },
+		},
+		{
+			name: "linear",
+			description: "Linear issue tracking.",
+			category: "productivity",
+			source: "./external_plugins/linear",
+		},
+		{
+			name: "expo",
+			description: "Expo skills.",
+			source: { source: "git-subdir", url: "expo/skills" },
+		},
+	],
+});
+
+const fixtureFetcher: FetchMarketplaceFn = async () => ({ ok: true, body: FIXTURE_BODY, etag: "x" });
+
+let tmp: string;
+let settingsPath: string;
+let overlayPath: string;
+let db: Database;
+let sessionToken: string;
+
+beforeEach(() => {
+	__resetCuratedCacheForTests();
+	tmp = mkdtempSync(join(tmpdir(), "phantom-plugins-api-"));
+	settingsPath = join(tmp, "settings.json");
+	overlayPath = join(tmp, "curated.json");
+	writeFileSync(overlayPath, '{"version":1,"plugins":{}}');
+	db = new Database(":memory:");
+	for (const migration of MIGRATIONS) {
+		try {
+			db.run(migration);
+		} catch {
+			// ignore
+		}
+	}
+	setDashboardDb(db);
+	setPluginsApiOverridesForTests({ fetcher: fixtureFetcher, settingsPath, overlayPath });
+	sessionToken = createSession().sessionToken;
+});
+
+afterEach(() => {
+	rmSync(tmp, { recursive: true, force: true });
+	clearPluginsApiOverridesForTests();
+	db.close();
+	revokeAllSessions();
+});
+
+function req(path: string, init?: RequestInit): Request {
+	return new Request(`http://localhost${path}`, {
+		...init,
+		headers: {
+			Cookie: `phantom_session=${encodeURIComponent(sessionToken)}`,
+			Accept: "application/json",
+			...((init?.headers as Record<string, string>) ?? {}),
+		},
+	});
+}
+
+describe("plugins API", () => {
+	test("401 without session cookie", async () => {
+		const res = await handleUiRequest(
+			new Request("http://localhost/ui/api/plugins/marketplace", { headers: { Accept: "application/json" } }),
+		);
+		expect(res.status).toBe(401);
+	});
+
+	test("GET marketplace returns normalized catalog", async () => {
+		const res = await handleUiRequest(req("/ui/api/plugins/marketplace"));
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as {
+			marketplace: string;
+			plugins: Array<{ name: string; enabled: boolean; source_type: string }>;
+			hidden_by_transport: number;
+		};
+		expect(body.marketplace).toBe("claude-plugins-official");
+		// 3 fixtures, expo filtered -> 2 visible
+		expect(body.plugins).toHaveLength(2);
+		expect(body.hidden_by_transport).toBe(1);
+		const names = body.plugins.map((p) => p.name).sort();
+		expect(names).toEqual(["linear", "notion"]);
+	});
+
+	test("GET /ui/api/plugins returns empty active list initially", async () => {
+		const res = await handleUiRequest(req("/ui/api/plugins"));
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as { active: string[]; disabled: string[] };
+		expect(body.active).toEqual([]);
+		expect(body.disabled).toEqual([]);
+	});
+
+	test("POST install writes settings.json and audit", async () => {
+		const res = await handleUiRequest(
+			req("/ui/api/plugins/install", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ plugin: "notion" }),
+			}),
+		);
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as { ok: boolean; key: string; already_installed: boolean };
+		expect(body.ok).toBe(true);
+		expect(body.key).toBe("notion@claude-plugins-official");
+		expect(body.already_installed).toBe(false);
+		const written = JSON.parse(readFileSync(settingsPath, "utf-8"));
+		expect(written.enabledPlugins["notion@claude-plugins-official"]).toBe(true);
+	});
+
+	test("POST install is idempotent on second call", async () => {
+		await handleUiRequest(
+			req("/ui/api/plugins/install", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ plugin: "notion" }),
+			}),
+		);
+		const res = await handleUiRequest(
+			req("/ui/api/plugins/install", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ plugin: "notion" }),
+			}),
+		);
+		const body = (await res.json()) as { already_installed: boolean };
+		expect(body.already_installed).toBe(true);
+	});
+
+	test("POST install 404 when plugin not in marketplace", async () => {
+		const res = await handleUiRequest(
+			req("/ui/api/plugins/install", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ plugin: "ghost" }),
+			}),
+		);
+		expect(res.status).toBe(404);
+	});
+
+	test("POST install 422 with missing plugin field", async () => {
+		const res = await handleUiRequest(
+			req("/ui/api/plugins/install", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ marketplace: "claude-plugins-official" }),
+			}),
+		);
+		expect(res.status).toBe(422);
+	});
+
+	test("DELETE soft-uninstalls", async () => {
+		await handleUiRequest(
+			req("/ui/api/plugins/install", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ plugin: "notion" }),
+			}),
+		);
+		const res = await handleUiRequest(
+			req(`/ui/api/plugins/${encodeURIComponent("notion@claude-plugins-official")}`, { method: "DELETE" }),
+		);
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as { ok: boolean; was_active: boolean; new_value: unknown };
+		expect(body.ok).toBe(true);
+		expect(body.was_active).toBe(true);
+		expect(body.new_value).toBe(false);
+		const written = JSON.parse(readFileSync(settingsPath, "utf-8"));
+		expect(written.enabledPlugins["notion@claude-plugins-official"]).toBe(false);
+	});
+
+	test("DELETE rejects malformed key", async () => {
+		const res = await handleUiRequest(req("/ui/api/plugins/notion-without-marketplace", { method: "DELETE" }));
+		expect(res.status).toBe(422);
+	});
+
+	test("GET audit returns full timeline for a plugin", async () => {
+		await handleUiRequest(
+			req("/ui/api/plugins/install", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ plugin: "notion" }),
+			}),
+		);
+		await handleUiRequest(
+			req(`/ui/api/plugins/${encodeURIComponent("notion@claude-plugins-official")}`, { method: "DELETE" }),
+		);
+		const res = await handleUiRequest(
+			req(`/ui/api/plugins/${encodeURIComponent("notion@claude-plugins-official")}/audit`),
+		);
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as { audit: Array<{ action: string }> };
+		expect(body.audit).toHaveLength(2);
+		expect(body.audit[0].action).toBe("uninstall");
+		expect(body.audit[1].action).toBe("install");
+	});
+
+	test("POST find returns ranked matches", async () => {
+		const res = await handleUiRequest(
+			req("/ui/api/plugins/find", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ query: "linear" }),
+			}),
+		);
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as { results: Array<{ name: string; score: number }> };
+		expect(body.results.length).toBeGreaterThan(0);
+		expect(body.results[0].name).toBe("linear");
+	});
+
+	test("POST find 422 on empty query", async () => {
+		const res = await handleUiRequest(
+			req("/ui/api/plugins/find", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ query: "" }),
+			}),
+		);
+		expect(res.status).toBe(422);
+	});
+
+	test("install records source URL in audit log", async () => {
+		await handleUiRequest(
+			req("/ui/api/plugins/install", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ plugin: "notion" }),
+			}),
+		);
+		const res = await handleUiRequest(
+			req(`/ui/api/plugins/${encodeURIComponent("notion@claude-plugins-official")}/audit`),
+		);
+		const body = (await res.json()) as { audit: Array<{ source_type: string; source_url: string }> };
+		expect(body.audit[0].source_type).toBe("url");
+		expect(body.audit[0].source_url).toContain("makenotion");
+	});
+
+	test("install preserves unrelated settings.json fields", async () => {
+		writeFileSync(settingsPath, JSON.stringify({ permissions: { allow: ["Read"] }, model: "claude-opus-4-6" }));
+		await handleUiRequest(
+			req("/ui/api/plugins/install", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ plugin: "notion" }),
+			}),
+		);
+		const written = JSON.parse(readFileSync(settingsPath, "utf-8"));
+		expect(written.permissions).toEqual({ allow: ["Read"] });
+		expect(written.model).toBe("claude-opus-4-6");
+		expect(written.enabledPlugins["notion@claude-plugins-official"]).toBe(true);
+	});
+});

--- a/src/ui/api/plugins.ts
+++ b/src/ui/api/plugins.ts
@@ -1,0 +1,302 @@
+// UI API routes for the plugins tab.
+//
+// All routes live under /ui/api/plugins and are cookie-auth gated by the
+// dispatcher in src/ui/serve.ts.
+//
+//   GET    /ui/api/plugins/marketplace          -> normalized catalog (cached)
+//   GET    /ui/api/plugins                       -> currently active enabledPlugins
+//   POST   /ui/api/plugins/install               -> body { plugin, marketplace }
+//   DELETE /ui/api/plugins/:plugin@:marketplace -> soft uninstall
+//   GET    /ui/api/plugins/:plugin@:marketplace/audit -> audit timeline
+//   POST   /ui/api/plugins/find                  -> body { query }, top-5 matches
+//
+// JSON in, JSON out. All errors are { error: string } with the appropriate
+// HTTP status. The plugins-curated.json overlay is loaded transparently by the
+// catalog fetcher; this layer does not handle merging.
+
+import type { Database } from "bun:sqlite";
+import { listPluginAudit, recordPluginInstall } from "../../plugins/audit.ts";
+import { type FetchMarketplaceFn, getCatalog } from "../../plugins/marketplace.ts";
+import { OFFICIAL_MARKETPLACE_ID, formatPluginKey, parsePluginKey } from "../../plugins/paths.ts";
+import { installPlugin, listEnabledPlugins, uninstallPlugin } from "../../plugins/settings-io.ts";
+
+export type PluginsApiDeps = {
+	db: Database;
+	// Test seam so __tests__/plugins.test.ts can pass a fake fetcher.
+	fetcher?: FetchMarketplaceFn;
+	settingsPath?: string;
+	overlayPath?: string;
+};
+
+function json(body: unknown, init?: ResponseInit): Response {
+	return new Response(JSON.stringify(body), {
+		...init,
+		headers: {
+			"Content-Type": "application/json",
+			"Cache-Control": "no-store",
+			...((init?.headers as Record<string, string>) ?? {}),
+		},
+	});
+}
+
+async function readJson(req: Request): Promise<unknown | { __error: string }> {
+	try {
+		return await req.json();
+	} catch (err: unknown) {
+		const msg = err instanceof Error ? err.message : String(err);
+		return { __error: `Invalid JSON body: ${msg}` };
+	}
+}
+
+type InstallBody = { plugin: string; marketplace?: string };
+
+function parseInstallBody(raw: unknown): { ok: true; body: InstallBody } | { ok: false; error: string } {
+	if (!raw || typeof raw !== "object") {
+		return { ok: false, error: "Request body must be a JSON object" };
+	}
+	const shape = raw as { plugin?: unknown; marketplace?: unknown };
+	if (typeof shape.plugin !== "string" || shape.plugin.length === 0) {
+		return { ok: false, error: "plugin field is required and must be a non-empty string" };
+	}
+	if (shape.marketplace !== undefined && typeof shape.marketplace !== "string") {
+		return { ok: false, error: "marketplace field, when present, must be a string" };
+	}
+	return { ok: true, body: { plugin: shape.plugin, marketplace: shape.marketplace ?? OFFICIAL_MARKETPLACE_ID } };
+}
+
+type FindBody = { query: string; limit?: number };
+
+function parseFindBody(raw: unknown): { ok: true; body: FindBody } | { ok: false; error: string } {
+	if (!raw || typeof raw !== "object") {
+		return { ok: false, error: "Request body must be a JSON object" };
+	}
+	const shape = raw as { query?: unknown; limit?: unknown };
+	if (typeof shape.query !== "string" || shape.query.trim().length === 0) {
+		return { ok: false, error: "query field is required and must be a non-empty string" };
+	}
+	const limit =
+		typeof shape.limit === "number" && Number.isFinite(shape.limit) && shape.limit > 0
+			? Math.min(20, Math.floor(shape.limit))
+			: 5;
+	return { ok: true, body: { query: shape.query.trim(), limit } };
+}
+
+function activeKeys(deps: PluginsApiDeps): Set<string> {
+	const list = listEnabledPlugins(deps.settingsPath);
+	return new Set(Object.keys(list.active));
+}
+
+function fuzzyScore(query: string, plugin: { name: string; description: string; category: string | null }): number {
+	const q = query.toLowerCase();
+	const tokens = q.split(/\s+/).filter(Boolean);
+	let score = 0;
+	const haystack = `${plugin.name} ${plugin.description} ${plugin.category ?? ""}`.toLowerCase();
+	for (const token of tokens) {
+		if (plugin.name.toLowerCase().includes(token)) score += 5;
+		if ((plugin.category ?? "").toLowerCase().includes(token)) score += 3;
+		if (haystack.includes(token)) score += 1;
+	}
+	return score;
+}
+
+export async function handlePluginsApi(req: Request, url: URL, deps: PluginsApiDeps): Promise<Response | null> {
+	const pathname = url.pathname;
+
+	// GET /ui/api/plugins/marketplace
+	if (pathname === "/ui/api/plugins/marketplace" && req.method === "GET") {
+		try {
+			const catalog = await getCatalog({
+				db: deps.db,
+				fetcher: deps.fetcher,
+				activeKeys: activeKeys(deps),
+				overlayPath: deps.overlayPath,
+				forceRefresh: url.searchParams.get("refresh") === "1",
+			});
+			return json({
+				marketplace: catalog.marketplace,
+				plugins: catalog.plugins,
+				hidden_by_transport: catalog.hidden_by_transport,
+				fetched_at: catalog.fetched_at,
+				cache_hit: catalog.cache_hit,
+				from_stale_cache: catalog.from_stale_cache,
+			});
+		} catch (err: unknown) {
+			const msg = err instanceof Error ? err.message : String(err);
+			return json({ error: msg }, { status: 502 });
+		}
+	}
+
+	// GET /ui/api/plugins
+	if (pathname === "/ui/api/plugins" && req.method === "GET") {
+		const list = listEnabledPlugins(deps.settingsPath);
+		return json({
+			active: Object.keys(list.active).sort(),
+			disabled: list.disabled.sort(),
+		});
+	}
+
+	// POST /ui/api/plugins/install
+	if (pathname === "/ui/api/plugins/install" && req.method === "POST") {
+		const raw = await readJson(req);
+		if (raw && typeof raw === "object" && "__error" in raw) {
+			return json({ error: (raw as { __error: string }).__error }, { status: 400 });
+		}
+		const parsed = parseInstallBody(raw);
+		if (!parsed.ok) {
+			return json({ error: parsed.error }, { status: 422 });
+		}
+		const { plugin, marketplace } = parsed.body;
+		let key: string;
+		try {
+			key = formatPluginKey(plugin, marketplace ?? OFFICIAL_MARKETPLACE_ID);
+		} catch (err: unknown) {
+			const msg = err instanceof Error ? err.message : String(err);
+			return json({ error: msg }, { status: 422 });
+		}
+
+		// Look up the upstream entry so we can record the source URL in the audit.
+		let sourceType: string | null = null;
+		let sourceUrl: string | null = null;
+		try {
+			const catalog = await getCatalog({
+				db: deps.db,
+				fetcher: deps.fetcher,
+				activeKeys: activeKeys(deps),
+				overlayPath: deps.overlayPath,
+			});
+			const entry = catalog.plugins.find(
+				(p) => p.name === plugin && p.marketplace === (marketplace ?? OFFICIAL_MARKETPLACE_ID),
+			);
+			if (!entry) {
+				return json(
+					{ error: `Plugin ${plugin} not found in marketplace ${marketplace ?? OFFICIAL_MARKETPLACE_ID}` },
+					{ status: 404 },
+				);
+			}
+			sourceType = entry.source_type;
+			sourceUrl = entry.source_url;
+		} catch (err: unknown) {
+			const msg = err instanceof Error ? err.message : String(err);
+			return json({ error: `Marketplace unreachable: ${msg}` }, { status: 502 });
+		}
+
+		const result = installPlugin(key, deps.settingsPath);
+		if (!result.ok) {
+			return json({ error: result.error }, { status: result.status });
+		}
+
+		recordPluginInstall(deps.db, {
+			plugin,
+			marketplace: marketplace ?? OFFICIAL_MARKETPLACE_ID,
+			action: result.already_installed ? "reinstall" : "install",
+			sourceType,
+			sourceUrl,
+			previousValue: result.previous_value,
+			newValue: result.new_value,
+			actor: "user",
+		});
+
+		return json({
+			ok: true,
+			key,
+			already_installed: result.already_installed,
+			previous_value: result.previous_value,
+			new_value: result.new_value,
+			source_type: sourceType,
+			source_url: sourceUrl,
+		});
+	}
+
+	// POST /ui/api/plugins/find
+	if (pathname === "/ui/api/plugins/find" && req.method === "POST") {
+		const raw = await readJson(req);
+		if (raw && typeof raw === "object" && "__error" in raw) {
+			return json({ error: (raw as { __error: string }).__error }, { status: 400 });
+		}
+		const parsed = parseFindBody(raw);
+		if (!parsed.ok) {
+			return json({ error: parsed.error }, { status: 422 });
+		}
+		try {
+			const catalog = await getCatalog({
+				db: deps.db,
+				fetcher: deps.fetcher,
+				activeKeys: activeKeys(deps),
+				overlayPath: deps.overlayPath,
+			});
+			const scored = catalog.plugins
+				.map((p) => ({ plugin: p, score: fuzzyScore(parsed.body.query, p) }))
+				.filter((s) => s.score > 0)
+				.sort((a, b) => b.score - a.score)
+				.slice(0, parsed.body.limit ?? 5);
+			return json({
+				query: parsed.body.query,
+				results: scored.map((s) => ({
+					name: s.plugin.name,
+					marketplace: s.plugin.marketplace,
+					description: s.plugin.description,
+					source_type: s.plugin.source_type,
+					source_url: s.plugin.source_url,
+					category: s.plugin.category,
+					curated_tags: s.plugin.curated_tags,
+					enabled: s.plugin.enabled,
+					score: s.score,
+				})),
+			});
+		} catch (err: unknown) {
+			const msg = err instanceof Error ? err.message : String(err);
+			return json({ error: `Marketplace unreachable: ${msg}` }, { status: 502 });
+		}
+	}
+
+	// /ui/api/plugins/<plugin@marketplace>/audit
+	const auditMatch = pathname.match(/^\/ui\/api\/plugins\/([^/]+)\/audit$/);
+	if (auditMatch) {
+		const decoded = decodeURIComponent(auditMatch[1]);
+		const parsed = parsePluginKey(decoded);
+		if (!parsed) {
+			return json({ error: `Invalid plugin key: ${decoded}` }, { status: 422 });
+		}
+		if (req.method === "GET") {
+			const rows = listPluginAudit(deps.db, { plugin: parsed.plugin, marketplace: parsed.marketplace });
+			return json({ key: decoded, audit: rows });
+		}
+		return json({ error: "Method not allowed" }, { status: 405 });
+	}
+
+	// /ui/api/plugins/<plugin@marketplace>
+	const itemMatch = pathname.match(/^\/ui\/api\/plugins\/([^/]+)$/);
+	if (itemMatch) {
+		const decoded = decodeURIComponent(itemMatch[1]);
+		const parsed = parsePluginKey(decoded);
+		if (!parsed) {
+			return json({ error: `Invalid plugin key: ${decoded}` }, { status: 422 });
+		}
+		if (req.method === "DELETE") {
+			const result = uninstallPlugin(decoded, deps.settingsPath);
+			if (!result.ok) {
+				return json({ error: result.error }, { status: result.status });
+			}
+			recordPluginInstall(deps.db, {
+				plugin: parsed.plugin,
+				marketplace: parsed.marketplace,
+				action: "uninstall",
+				sourceType: null,
+				sourceUrl: null,
+				previousValue: result.previous_value,
+				newValue: result.new_value,
+				actor: "user",
+			});
+			return json({
+				ok: true,
+				key: decoded,
+				was_active: result.was_active,
+				previous_value: result.previous_value,
+				new_value: result.new_value,
+			});
+		}
+		return json({ error: "Method not allowed" }, { status: 405 });
+	}
+
+	return null;
+}

--- a/src/ui/serve.ts
+++ b/src/ui/serve.ts
@@ -7,6 +7,7 @@ import { consumeMagicLink, createSession, isValidSession } from "./session.ts";
 import { secretsExpiredHtml, secretsFormHtml } from "../secrets/form-page.ts";
 import { getSecretRequest, saveSecrets, validateMagicToken } from "../secrets/store.ts";
 import { handleMemoryFilesApi } from "./api/memory-files.ts";
+import { type PluginsApiDeps, handlePluginsApi } from "./api/plugins.ts";
 import { handleSkillsApi } from "./api/skills.ts";
 
 const COOKIE_NAME = "phantom_session";
@@ -15,6 +16,7 @@ const COOKIE_MAX_AGE = 7 * 24 * 60 * 60; // 7 days in seconds
 let publicDir = resolve(process.cwd(), "public");
 let secretsDb: Database | null = null;
 let dashboardDb: Database | null = null;
+let pluginsApiOverrides: Pick<PluginsApiDeps, "fetcher" | "settingsPath" | "overlayPath"> = {};
 
 type SecretSavedCallback = (requestId: string, secretNames: string[]) => Promise<void>;
 let onSecretSaved: SecretSavedCallback | null = null;
@@ -25,6 +27,19 @@ export function setSecretsDb(db: Database): void {
 
 export function setDashboardDb(db: Database): void {
 	dashboardDb = db;
+}
+
+// Test-only seam. Production wiring leaves these undefined and the plugins
+// API uses the default GitHub fetcher and the canonical settings.json /
+// curated overlay paths.
+export function setPluginsApiOverridesForTests(
+	overrides: Pick<PluginsApiDeps, "fetcher" | "settingsPath" | "overlayPath">,
+): void {
+	pluginsApiOverrides = overrides;
+}
+
+export function clearPluginsApiOverridesForTests(): void {
+	pluginsApiOverrides = {};
 }
 
 export function setSecretSavedCallback(fn: SecretSavedCallback): void {
@@ -146,6 +161,13 @@ export async function handleUiRequest(req: Request): Promise<Response> {
 			return Response.json({ error: "Dashboard API not initialized" }, { status: 503 });
 		}
 		const apiResponse = await handleMemoryFilesApi(req, url, { db: dashboardDb });
+		if (apiResponse) return apiResponse;
+	}
+	if (url.pathname.startsWith("/ui/api/plugins")) {
+		if (!dashboardDb) {
+			return Response.json({ error: "Dashboard API not initialized" }, { status: 503 });
+		}
+		const apiResponse = await handlePluginsApi(req, url, { db: dashboardDb, ...pluginsApiOverrides });
 		if (apiResponse) return apiResponse;
 	}
 


### PR DESCRIPTION
## Summary

Adds the plugins surface to the dashboard. Operators can now browse the claude-plugins-official marketplace, install plugins through a trust-modal-gated flow, and see a per-plugin audit timeline. The agent inherits installed plugins on its next message.

Four default plugins are pre-installed on fresh installs: linear, notion, slack, claude-md-management. Picks are cross-role (operators, founders, PMs, GTM, ops, account managers) and avoid plugin-developer or coding-specific surfaces.

The Phantom-curated metadata overlay ships as an empty mechanism (config/plugins-curated.json with version 1 and zero entries). Curators can populate it later without touching code to add tags like phantom-recommended, audience labels, notes, and version pins. The dashboard merges overlay annotations on top of upstream marketplace metadata; upstream description and source are never replaced.

## Architecture

- `src/plugins/paths.ts` resolves the user-scope settings.json path and validates plugin-id@marketplace-id keys
- `src/plugins/manifest.ts` declares Zod schemas for the upstream marketplace, the normalized dashboard shape, the curated overlay, and the enabledPlugins map
- `src/plugins/settings-io.ts` does atomic read-modify-write of settings.json with installPlugin and uninstallPlugin helpers that preserve unrelated fields
- `src/plugins/marketplace.ts` fetches the canonical marketplace from the raw GitHub CDN, caches in SQLite with a 10 minute TTL, falls back to stale cache on fetch error, filters out unsupported transports (git-subdir, npm, pip), and merges the curated overlay
- `src/plugins/curated.ts` loads config/plugins-curated.json with mtime caching and degrades safely on missing or malformed input
- `src/plugins/audit.ts` writes an append-only plugin_install_audit_log table with full provenance
- `src/plugins/seed.ts` is a Bun-callable seeder invoked from the docker entrypoint to merge the four default picks into settings.json on first boot, preserving operator choices
- `src/ui/api/plugins.ts` exposes six routes behind the existing cookie-auth gate: marketplace, list, install, uninstall, audit, find
- `public/dashboard/plugins.js` plus matching CSS implements the marketplace browser, install trust modal, soft uninstall, audit timeline, and find-a-plugin search
- The dashboard-awareness prompt block now describes the plugins tab and lists the four defaults
- show-my-tools and a new list-plugins built-in skill enumerate the active plugin set from settings.json

## Test plan

- [ ] `bun test` passes (1138 pass, 0 fail, +94 over main)
- [ ] `bun run lint` clean
- [ ] `bun run typecheck` clean
- [ ] Open the dashboard, click the plugins tab, confirm the catalog renders within a second from cold cache
- [ ] Filter by Recommended (empty in v1), Installed (the four defaults after seeding), All (every supported plugin)
- [ ] Click install on a plugin not in the defaults, confirm the trust modal blocks the install button until the checkbox is checked
- [ ] Confirm the install writes settings.json correctly and the audit row carries the source URL
- [ ] Click uninstall on an installed plugin, confirm soft-disable (key set to false, not removed)
- [ ] Click history on a card, confirm the audit timeline modal renders all rows in reverse chronological order
- [ ] Use the find-a-plugin CTA, confirm fuzzy ranking returns sensible matches
- [ ] On a fresh container, confirm the seeder adds all four defaults and preserves an operator-edited disable

## Rollback

Revert the merge commit. Plugin install state is in settings.json and the audit table; both survive a code rollback. Disabling all four defaults in settings.json takes the operator back to the pre-PR2 baseline at runtime.