### PR TITLE
feat: evolution conditional firing gate and cadence batching

### DIFF
--- a/src/db/__tests__/migrate.test.ts
+++ b/src/db/__tests__/migrate.test.ts
@@ -41,8 +41,10 @@ describe("runMigrations", () => {
 		// the total from the PR2 baseline of 16 up to 22. The PR3 fix pass
 		// appends two ALTER TABLE statements on subagent_audit_log to add
 		// previous_frontmatter_json and new_frontmatter_json columns,
-		// bringing the total to 24.
-		expect(migrationCount.count).toBe(24);
+		// bringing the total to 24. Phase 2 evolution cadence adds the
+		// evolution_queue table and its enqueued_at index, bringing the
+		// total to 26.
+		expect(migrationCount.count).toBe(26);
 	});
 
 	test("tracks applied migration indices", () => {
@@ -54,7 +56,9 @@ describe("runMigrations", () => {
 			.all()
 			.map((r) => (r as { index_num: number }).index_num);
 
-		expect(indices).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23]);
+		expect(indices).toEqual([
+			0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25,
+		]);
 	});
 
 	test("subagent_audit_log has frontmatter JSON columns after migration", () => {
@@ -66,5 +70,15 @@ describe("runMigrations", () => {
 			.map((r) => (r as { name: string }).name);
 		expect(cols).toContain("previous_frontmatter_json");
 		expect(cols).toContain("new_frontmatter_json");
+	});
+
+	test("evolution_queue table exists after migration", () => {
+		const db = freshDb();
+		runMigrations(db);
+		const row = db.query("SELECT name FROM sqlite_master WHERE type='table' AND name='evolution_queue'").get() as {
+			name: string;
+		} | null;
+		expect(row).not.toBeNull();
+		expect(row?.name).toBe("evolution_queue");
 	});
 });

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -210,4 +210,19 @@ export const MIGRATIONS: string[] = [
 	// _migrations gate.
 	"ALTER TABLE subagent_audit_log ADD COLUMN previous_frontmatter_json TEXT",
 	"ALTER TABLE subagent_audit_log ADD COLUMN new_frontmatter_json TEXT",
+
+	// Phase 2 evolution cadence: sessions that passed the conditional firing
+	// gate wait here until the cadence cron or the demand trigger drains the
+	// queue into the batch processor. Rows are removed on successful drain;
+	// a crashed drain leaves them in place so the next tick can retry them.
+	`CREATE TABLE IF NOT EXISTS evolution_queue (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		session_id TEXT NOT NULL,
+		session_key TEXT NOT NULL,
+		gate_decision_json TEXT NOT NULL,
+		session_summary_json TEXT NOT NULL,
+		enqueued_at TEXT NOT NULL DEFAULT (datetime('now'))
+	)`,
+
+	"CREATE INDEX IF NOT EXISTS idx_evolution_queue_enqueued_at ON evolution_queue(enqueued_at)",
 ];

--- a/src/evolution/__tests__/cadence.test.ts
+++ b/src/evolution/__tests__/cadence.test.ts
@@ -1,0 +1,337 @@
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { MIGRATIONS } from "../../db/schema.ts";
+import { processBatch } from "../batch-processor.ts";
+import { DEFAULT_CADENCE_CONFIG, EvolutionCadence, loadCadenceConfig } from "../cadence.ts";
+import type { EvolutionConfig } from "../config.ts";
+import type { EvolutionEngine } from "../engine.ts";
+import type { GateDecision } from "../gate-types.ts";
+import { EvolutionQueue } from "../queue.ts";
+import type { EvolutionResult, SessionSummary } from "../types.ts";
+
+// Phase 2 cadence + batch processor tests.
+
+const TEST_DIR = "/tmp/phantom-test-cadence";
+
+function setupEnv(): EvolutionConfig {
+	mkdirSync(`${TEST_DIR}/phantom-config/meta`, { recursive: true });
+	writeFileSync(`${TEST_DIR}/phantom-config/meta/metrics.json`, "{}", "utf-8");
+	return {
+		cadence: { reflection_interval: 1, consolidation_interval: 10, full_review_interval: 50, drift_check_interval: 20 },
+		gates: { drift_threshold: 0.7, max_file_lines: 200, auto_rollback_threshold: 0.1, auto_rollback_window: 5 },
+		reflection: { model: "claude-sonnet-4-20250514", effort: "high", max_budget_usd: 0.5 },
+		judges: { enabled: "always", cost_cap_usd_per_day: 50.0, max_golden_suite_size: 50 },
+		paths: {
+			config_dir: `${TEST_DIR}/phantom-config`,
+			constitution: `${TEST_DIR}/phantom-config/constitution.md`,
+			version_file: `${TEST_DIR}/phantom-config/meta/version.json`,
+			metrics_file: `${TEST_DIR}/phantom-config/meta/metrics.json`,
+			evolution_log: `${TEST_DIR}/phantom-config/meta/evolution-log.jsonl`,
+			golden_suite: `${TEST_DIR}/phantom-config/meta/golden-suite.jsonl`,
+			session_log: `${TEST_DIR}/phantom-config/memory/session-log.jsonl`,
+		},
+	};
+}
+
+function newDb(): Database {
+	const db = new Database(":memory:");
+	db.run("PRAGMA journal_mode = WAL");
+	for (const stmt of MIGRATIONS) db.run(stmt);
+	return db;
+}
+
+function makeSummary(overrides: Partial<SessionSummary> = {}): SessionSummary {
+	return {
+		session_id: "s1",
+		session_key: "slack:C1:T1",
+		user_id: "u1",
+		user_messages: ["help"],
+		assistant_messages: ["ok"],
+		tools_used: ["Read"],
+		files_tracked: [],
+		outcome: "success",
+		cost_usd: 0.04,
+		started_at: "2026-04-14T10:00:00Z",
+		ended_at: "2026-04-14T10:01:00Z",
+		...overrides,
+	};
+}
+
+const DECISION: GateDecision = {
+	fire: true,
+	source: "haiku",
+	reason: "haiku said evolve",
+	haiku_cost_usd: 0.0006,
+};
+
+function fakeEngine(options: {
+	onRun?: (session: SessionSummary) => Promise<EvolutionResult>;
+}): EvolutionEngine {
+	const calls: SessionSummary[] = [];
+	const run =
+		options.onRun ??
+		(async (): Promise<EvolutionResult> => ({ version: 0, changes_applied: [], changes_rejected: [] }));
+	const shape = {
+		runSingleSessionPipeline: async (session: SessionSummary) => {
+			calls.push(session);
+			return run(session);
+		},
+		calls,
+	};
+	return shape as unknown as EvolutionEngine;
+}
+
+describe("loadCadenceConfig", () => {
+	beforeEach(() => setupEnv());
+	afterEach(() => rmSync(TEST_DIR, { recursive: true, force: true }));
+
+	test("returns defaults when evolution.json is absent", () => {
+		const config = setupEnv();
+		const cadence = loadCadenceConfig(config);
+		expect(cadence).toEqual(DEFAULT_CADENCE_CONFIG);
+	});
+
+	test("reads cadence_minutes and demand_trigger_depth overrides", () => {
+		const config = setupEnv();
+		writeFileSync(
+			`${TEST_DIR}/phantom-config/meta/evolution.json`,
+			JSON.stringify({ cadence_minutes: 240, demand_trigger_depth: 10 }),
+			"utf-8",
+		);
+		const cadence = loadCadenceConfig(config);
+		expect(cadence.cadenceMinutes).toBe(240);
+		expect(cadence.demandTriggerDepth).toBe(10);
+	});
+
+	test("falls back to defaults on malformed evolution.json", () => {
+		const config = setupEnv();
+		writeFileSync(`${TEST_DIR}/phantom-config/meta/evolution.json`, "{not json", "utf-8");
+		const cadence = loadCadenceConfig(config);
+		expect(cadence).toEqual(DEFAULT_CADENCE_CONFIG);
+	});
+});
+
+describe("processBatch", () => {
+	beforeEach(() => setupEnv());
+	afterEach(() => rmSync(TEST_DIR, { recursive: true, force: true }));
+
+	test("runs the pipeline per queued session and returns per-row results", async () => {
+		const db = newDb();
+		const queue = new EvolutionQueue(db);
+		queue.enqueue(makeSummary({ session_id: "a" }), DECISION);
+		queue.enqueue(makeSummary({ session_id: "b" }), DECISION);
+		const drained = queue.drainAll();
+
+		const sessionsSeen: string[] = [];
+		const engine = fakeEngine({
+			onRun: async (session) => {
+				sessionsSeen.push(session.session_id);
+				return { version: 1, changes_applied: [], changes_rejected: [] };
+			},
+		});
+
+		const result = await processBatch(drained, engine);
+		expect(result.processed).toBe(2);
+		expect(result.successCount).toBe(2);
+		expect(result.failureCount).toBe(0);
+		expect(sessionsSeen).toEqual(["a", "b"]);
+	});
+
+	test("records a failure entry for a throwing session and continues", async () => {
+		const db = newDb();
+		const queue = new EvolutionQueue(db);
+		queue.enqueue(makeSummary({ session_id: "a" }), DECISION);
+		queue.enqueue(makeSummary({ session_id: "b" }), DECISION);
+		const drained = queue.drainAll();
+
+		let calls = 0;
+		const engine = fakeEngine({
+			onRun: async () => {
+				calls += 1;
+				if (calls === 1) throw new Error("boom");
+				return { version: 1, changes_applied: [], changes_rejected: [] };
+			},
+		});
+
+		const result = await processBatch(drained, engine);
+		expect(result.processed).toBe(2);
+		expect(result.successCount).toBe(1);
+		expect(result.failureCount).toBe(1);
+		const failure = result.results.find((r) => !r.ok);
+		expect(failure).toBeDefined();
+		if (failure && !failure.ok) {
+			expect(failure.error).toContain("boom");
+		}
+	});
+});
+
+describe("EvolutionCadence", () => {
+	beforeEach(() => setupEnv());
+	afterEach(() => rmSync(TEST_DIR, { recursive: true, force: true }));
+
+	test("demand trigger fires drainAndProcess when queue depth hits threshold", async () => {
+		const config = setupEnv();
+		const db = newDb();
+		const queue = new EvolutionQueue(db);
+		const engine = fakeEngine({});
+		const cadence = new EvolutionCadence(engine, queue, config, { cadenceMinutes: 1_000_000, demandTriggerDepth: 3 });
+		cadence.start();
+		try {
+			for (let i = 0; i < 3; i++) {
+				queue.enqueue(makeSummary({ session_id: `s${i}` }), DECISION);
+				cadence.onEnqueue();
+			}
+			// Allow any in-flight drain promise to settle before asserting.
+			await new Promise((r) => setTimeout(r, 50));
+			expect(queue.depth()).toBe(0);
+		} finally {
+			cadence.stop();
+		}
+	});
+
+	test("demand trigger does not fire below the threshold", async () => {
+		const config = setupEnv();
+		const db = newDb();
+		const queue = new EvolutionQueue(db);
+		const engine = fakeEngine({});
+		const cadence = new EvolutionCadence(engine, queue, config, { cadenceMinutes: 1_000_000, demandTriggerDepth: 5 });
+		cadence.start();
+		try {
+			queue.enqueue(makeSummary({ session_id: "s1" }), DECISION);
+			cadence.onEnqueue();
+			await new Promise((r) => setTimeout(r, 20));
+			expect(queue.depth()).toBe(1);
+		} finally {
+			cadence.stop();
+		}
+	});
+
+	test("triggerNow drains the queue and marks rows processed", async () => {
+		const config = setupEnv();
+		const db = newDb();
+		const queue = new EvolutionQueue(db);
+		const engine = fakeEngine({});
+		const cadence = new EvolutionCadence(engine, queue, config, { cadenceMinutes: 1_000_000, demandTriggerDepth: 999 });
+		cadence.start();
+		try {
+			queue.enqueue(makeSummary({ session_id: "s1" }), DECISION);
+			queue.enqueue(makeSummary({ session_id: "s2" }), DECISION);
+			const result = await cadence.triggerNow();
+			expect(result).not.toBeNull();
+			expect(result?.processed).toBe(2);
+			expect(queue.depth()).toBe(0);
+		} finally {
+			cadence.stop();
+		}
+	});
+
+	test("skip on mutex contention: second concurrent trigger returns null without re-running", async () => {
+		const config = setupEnv();
+		const db = newDb();
+		const queue = new EvolutionQueue(db);
+		let runs = 0;
+		const engine = fakeEngine({
+			onRun: async () => {
+				runs += 1;
+				await new Promise((r) => setTimeout(r, 30));
+				return { version: 0, changes_applied: [], changes_rejected: [] };
+			},
+		});
+		const cadence = new EvolutionCadence(engine, queue, config, { cadenceMinutes: 1_000_000, demandTriggerDepth: 999 });
+		cadence.start();
+		try {
+			queue.enqueue(makeSummary({ session_id: "slow-1" }), DECISION);
+			queue.enqueue(makeSummary({ session_id: "slow-2" }), DECISION);
+			const first = cadence.triggerNow();
+			// Second call arrives while the first is still in flight. The
+			// skip-on-contention rule says this one must return null and must
+			// NOT spawn a parallel batch.
+			const second = await cadence.triggerNow();
+			expect(second).toBeNull();
+			const firstResult = await first;
+			expect(firstResult?.processed).toBe(2);
+			// Each queued row is processed exactly once. The skipped second
+			// trigger did not re-drain the queue.
+			expect(runs).toBe(2);
+		} finally {
+			cadence.stop();
+		}
+	});
+
+	test("triggerNow returns null on an empty queue", async () => {
+		const config = setupEnv();
+		const db = newDb();
+		const queue = new EvolutionQueue(db);
+		const engine = fakeEngine({});
+		const cadence = new EvolutionCadence(engine, queue, config, DEFAULT_CADENCE_CONFIG);
+		cadence.start();
+		try {
+			const result = await cadence.triggerNow();
+			expect(result).toBeNull();
+		} finally {
+			cadence.stop();
+		}
+	});
+
+	test("cron tick fires drainAndProcess after the timer elapses", async () => {
+		const config = setupEnv();
+		const db = newDb();
+		const queue = new EvolutionQueue(db);
+		const engine = fakeEngine({});
+		// cadenceMinutes is stored as minutes but the scheduler multiplies by
+		// 60_000; passing 1/60000 gives a 1 ms tick which is enough to run in
+		// a test without leaking real wall-clock time.
+		const cadence = new EvolutionCadence(engine, queue, config, {
+			cadenceMinutes: 1 / 60_000,
+			demandTriggerDepth: 999,
+		});
+		cadence.start();
+		try {
+			queue.enqueue(makeSummary({ session_id: "cron-1" }), DECISION);
+			// Wait long enough for the cron timer to fire.
+			await new Promise((r) => setTimeout(r, 40));
+			expect(queue.depth()).toBe(0);
+		} finally {
+			cadence.stop();
+		}
+	});
+
+	test("queue_stats counters increment after each drain", async () => {
+		const config = setupEnv();
+		const db = newDb();
+		const queue = new EvolutionQueue(db);
+		const engine = fakeEngine({});
+		const cadence = new EvolutionCadence(engine, queue, config, { cadenceMinutes: 1_000_000, demandTriggerDepth: 999 });
+		cadence.start();
+		try {
+			queue.enqueue(makeSummary({ session_id: "m1" }), DECISION);
+			queue.enqueue(makeSummary({ session_id: "m2" }), DECISION);
+			await cadence.triggerNow();
+			const metrics = JSON.parse(readFileSync(config.paths.metrics_file, "utf-8"));
+			expect(metrics.queue_stats).toBeDefined();
+			expect(metrics.queue_stats.manual_fires_total).toBe(1);
+			expect(metrics.queue_stats.batch_size_total).toBe(2);
+			expect(metrics.queue_stats.avg_depth_at_drain).toBeCloseTo(2, 5);
+		} finally {
+			cadence.stop();
+		}
+	});
+
+	test("stop clears the cron timer so no further ticks fire", async () => {
+		const config = setupEnv();
+		const db = newDb();
+		const queue = new EvolutionQueue(db);
+		const engine = fakeEngine({});
+		const cadence = new EvolutionCadence(engine, queue, config, {
+			cadenceMinutes: 1 / 60_000,
+			demandTriggerDepth: 999,
+		});
+		cadence.start();
+		cadence.stop();
+		queue.enqueue(makeSummary({ session_id: "post-stop" }), DECISION);
+		await new Promise((r) => setTimeout(r, 40));
+		// The timer was cleared so the cron cannot drain the queue after stop.
+		expect(queue.depth()).toBe(1);
+	});
+});

--- a/src/evolution/__tests__/gate.test.ts
+++ b/src/evolution/__tests__/gate.test.ts
@@ -1,0 +1,363 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { JudgeSubprocessError } from "../../agent/judge-query.ts";
+import type { AgentRuntime } from "../../agent/runtime.ts";
+import type { EvolutionConfig } from "../config.ts";
+import type { GateDecision } from "../gate-types.ts";
+import { appendGateLog, decideGate, emptyGateStats, recordGateDecision } from "../gate.ts";
+import type { SessionSummary } from "../types.ts";
+
+// Phase 1 gate tests. The gate is a single Haiku call plus a failsafe, so the
+// test surface is small and targeted. We cover:
+//  - Haiku happy path returning evolve=true
+//  - Haiku happy path returning evolve=false
+//  - Haiku parse failure triggers failsafe fire
+//  - Haiku subprocess error triggers failsafe fire with partial cost captured
+//  - The gate log jsonl append shape
+//  - The metrics.json gate_stats counter shape
+//  - Null runtime path hits failsafe (no runtime = no Haiku = default open)
+//  - Zero-runtime observability: gate_stats counters increment correctly on
+//    mixed decisions
+
+const TEST_DIR = "/tmp/phantom-test-gate";
+
+function setupEnv(): EvolutionConfig {
+	mkdirSync(`${TEST_DIR}/phantom-config/meta`, { recursive: true });
+	writeFileSync(`${TEST_DIR}/phantom-config/meta/metrics.json`, "{}", "utf-8");
+	return {
+		cadence: { reflection_interval: 1, consolidation_interval: 10, full_review_interval: 50, drift_check_interval: 20 },
+		gates: { drift_threshold: 0.7, max_file_lines: 200, auto_rollback_threshold: 0.1, auto_rollback_window: 5 },
+		reflection: { model: "claude-sonnet-4-20250514", effort: "high", max_budget_usd: 0.5 },
+		judges: { enabled: "always", cost_cap_usd_per_day: 50.0, max_golden_suite_size: 50 },
+		paths: {
+			config_dir: `${TEST_DIR}/phantom-config`,
+			constitution: `${TEST_DIR}/phantom-config/constitution.md`,
+			version_file: `${TEST_DIR}/phantom-config/meta/version.json`,
+			metrics_file: `${TEST_DIR}/phantom-config/meta/metrics.json`,
+			evolution_log: `${TEST_DIR}/phantom-config/meta/evolution-log.jsonl`,
+			golden_suite: `${TEST_DIR}/phantom-config/meta/golden-suite.jsonl`,
+			session_log: `${TEST_DIR}/phantom-config/memory/session-log.jsonl`,
+		},
+	};
+}
+
+function makeSession(overrides: Partial<SessionSummary> = {}): SessionSummary {
+	return {
+		session_id: "sess-1",
+		session_key: "slack:C123:T456",
+		user_id: "U1",
+		user_messages: ["help me debug this thing"],
+		assistant_messages: ["done"],
+		tools_used: ["Read", "Edit"],
+		files_tracked: [],
+		outcome: "success",
+		cost_usd: 0.15,
+		started_at: "2026-04-14T10:00:00Z",
+		ended_at: "2026-04-14T10:02:00Z",
+		...overrides,
+	};
+}
+
+type FakeRuntime = {
+	judgeQuery: (options: {
+		systemPrompt: string;
+		userMessage: string;
+		schema: unknown;
+		model?: string;
+		maxTokens?: number;
+	}) => Promise<unknown>;
+};
+
+describe("decideGate Haiku happy path", () => {
+	beforeEach(() => setupEnv());
+	afterEach(() => rmSync(TEST_DIR, { recursive: true, force: true }));
+
+	test("evolve=true returns fire source=haiku with cost", async () => {
+		const runtime: FakeRuntime = {
+			judgeQuery: async () => ({
+				verdict: "pass" as const,
+				confidence: 0.9,
+				reasoning: "",
+				data: { evolve: true, reason: "user taught a naming convention" },
+				model: "claude-haiku-4-5",
+				inputTokens: 420,
+				outputTokens: 48,
+				costUsd: 0.0006,
+				durationMs: 1200,
+			}),
+		};
+		const decision = await decideGate(makeSession(), runtime as unknown as AgentRuntime);
+		expect(decision.fire).toBe(true);
+		expect(decision.source).toBe("haiku");
+		expect(decision.haiku_cost_usd).toBeCloseTo(0.0006, 6);
+		expect(decision.reason).toContain("naming");
+	});
+
+	test("evolve=false returns skip source=haiku", async () => {
+		const runtime: FakeRuntime = {
+			judgeQuery: async () => ({
+				verdict: "pass" as const,
+				confidence: 0.9,
+				reasoning: "",
+				data: { evolve: false, reason: "routine task with no new information" },
+				model: "claude-haiku-4-5",
+				inputTokens: 420,
+				outputTokens: 28,
+				costUsd: 0.0005,
+				durationMs: 900,
+			}),
+		};
+		const decision = await decideGate(makeSession(), runtime as unknown as AgentRuntime);
+		expect(decision.fire).toBe(false);
+		expect(decision.source).toBe("haiku");
+		expect(decision.reason).toContain("routine");
+	});
+});
+
+describe("decideGate failsafe path", () => {
+	beforeEach(() => setupEnv());
+	afterEach(() => rmSync(TEST_DIR, { recursive: true, force: true }));
+
+	test("parse failure triggers failsafe fire", async () => {
+		const runtime: FakeRuntime = {
+			judgeQuery: async () => {
+				throw new Error("Judge output failed schema validation");
+			},
+		};
+		const decision = await decideGate(makeSession(), runtime as unknown as AgentRuntime);
+		expect(decision.fire).toBe(true);
+		expect(decision.source).toBe("failsafe");
+		expect(decision.reason).toContain("gate error");
+	});
+
+	test("subprocess error (JudgeSubprocessError) triggers failsafe with partial cost", async () => {
+		const runtime: FakeRuntime = {
+			judgeQuery: async () => {
+				throw new JudgeSubprocessError("simulated SIGKILL", {
+					inputTokens: 380,
+					outputTokens: 0,
+					costUsd: 0.0003,
+					model: "claude-haiku-4-5",
+					durationMs: 800,
+				});
+			},
+		};
+		const decision = await decideGate(makeSession(), runtime as unknown as AgentRuntime);
+		expect(decision.fire).toBe(true);
+		expect(decision.source).toBe("failsafe");
+		expect(decision.haiku_cost_usd).toBeCloseTo(0.0003, 6);
+	});
+
+	test("null runtime triggers failsafe fire with zero cost", async () => {
+		const decision = await decideGate(makeSession(), null);
+		expect(decision.fire).toBe(true);
+		expect(decision.source).toBe("failsafe");
+		expect(decision.haiku_cost_usd).toBe(0);
+	});
+});
+
+describe("gate observability", () => {
+	beforeEach(() => setupEnv());
+	afterEach(() => rmSync(TEST_DIR, { recursive: true, force: true }));
+
+	test("appendGateLog writes one json line per call with the full decision shape", () => {
+		const config = setupEnv();
+		const session = makeSession();
+		const decision: GateDecision = {
+			fire: true,
+			source: "haiku",
+			reason: "test reason",
+			haiku_cost_usd: 0.0006,
+		};
+		appendGateLog(config, session, decision);
+		appendGateLog(config, session, { ...decision, fire: false, reason: "other reason" });
+		const logPath = `${TEST_DIR}/phantom-config/meta/evolution-gate-log.jsonl`;
+		expect(existsSync(logPath)).toBe(true);
+		const contents = readFileSync(logPath, "utf-8");
+		const lines = contents.trim().split("\n");
+		expect(lines.length).toBe(2);
+		const parsed = JSON.parse(lines[0]);
+		expect(parsed.session_id).toBe("sess-1");
+		expect(parsed.fire).toBe(true);
+		expect(parsed.source).toBe("haiku");
+		expect(parsed.haiku_cost_usd).toBeCloseTo(0.0006, 6);
+		expect(typeof parsed.ts).toBe("string");
+		// The minimal gate shape no longer carries rule_index: make sure it
+		// is absent from the persisted log line so downstream consumers do
+		// not accidentally key on a field that never exists in production.
+		expect(parsed.rule_index).toBeUndefined();
+	});
+
+	test("recordGateDecision increments gate_stats counters correctly across mixed decisions", () => {
+		const config = setupEnv();
+		recordGateDecision(config, { fire: true, source: "haiku", reason: "r1", haiku_cost_usd: 0.0006 });
+		recordGateDecision(config, { fire: false, source: "haiku", reason: "r2", haiku_cost_usd: 0.0005 });
+		recordGateDecision(config, { fire: true, source: "failsafe", reason: "r3", haiku_cost_usd: 0 });
+
+		const metrics = JSON.parse(readFileSync(config.paths.metrics_file, "utf-8"));
+		const stats = metrics.gate_stats;
+		expect(stats.total_decisions).toBe(3);
+		expect(stats.fired_by_haiku).toBe(1);
+		expect(stats.skipped_by_haiku).toBe(1);
+		expect(stats.fired_by_failsafe).toBe(1);
+		expect(stats.haiku_cost_usd_total).toBeCloseTo(0.0011, 6);
+	});
+
+	test("emptyGateStats returns all-zero counters", () => {
+		const stats = emptyGateStats();
+		expect(stats.total_decisions).toBe(0);
+		expect(stats.fired_by_haiku).toBe(0);
+		expect(stats.skipped_by_haiku).toBe(0);
+		expect(stats.fired_by_failsafe).toBe(0);
+		expect(stats.haiku_cost_usd_total).toBe(0);
+	});
+});
+
+describe("engine.enqueueIfWorthy routing", () => {
+	beforeEach(() => setupEnv());
+	afterEach(() => rmSync(TEST_DIR, { recursive: true, force: true }));
+
+	test("fire=true routes session into the queue when wired", async () => {
+		const config = setupEnv();
+		const configPath = `${TEST_DIR}/evolution.yaml`;
+		writeFileSync(
+			configPath,
+			[
+				"cadence:",
+				"  reflection_interval: 1",
+				"  consolidation_interval: 10",
+				"gates:",
+				"  drift_threshold: 0.7",
+				"  max_file_lines: 200",
+				"  auto_rollback_threshold: 0.1",
+				"  auto_rollback_window: 5",
+				"reflection:",
+				'  model: "claude-sonnet-4-20250514"',
+				"judges:",
+				'  enabled: "never"',
+				"paths:",
+				`  config_dir: "${config.paths.config_dir}"`,
+				`  constitution: "${config.paths.constitution}"`,
+				`  version_file: "${config.paths.version_file}"`,
+				`  metrics_file: "${config.paths.metrics_file}"`,
+				`  evolution_log: "${config.paths.evolution_log}"`,
+				`  golden_suite: "${config.paths.golden_suite}"`,
+				`  session_log: "${config.paths.session_log}"`,
+			].join("\n"),
+			"utf-8",
+		);
+		writeFileSync(`${config.paths.config_dir}/constitution.md`, "1. Honesty\n", "utf-8");
+		writeFileSync(
+			config.paths.version_file,
+			JSON.stringify({
+				version: 0,
+				parent: null,
+				timestamp: "2026-03-25T00:00:00Z",
+				changes: [],
+				metrics_at_change: { session_count: 0, success_rate_7d: 0, correction_rate_7d: 0 },
+			}),
+			"utf-8",
+		);
+
+		const { Database } = await import("bun:sqlite");
+		const { MIGRATIONS } = await import("../../db/schema.ts");
+		const { EvolutionEngine } = await import("../engine.ts");
+		const { EvolutionQueue } = await import("../queue.ts");
+
+		const db = new Database(":memory:");
+		for (const stmt of MIGRATIONS) db.run(stmt);
+
+		const runtime: FakeRuntime = {
+			judgeQuery: async () => ({
+				verdict: "pass" as const,
+				confidence: 0.9,
+				reasoning: "",
+				data: { evolve: true, reason: "user taught a workflow pattern" },
+				model: "claude-haiku-4-5",
+				inputTokens: 420,
+				outputTokens: 48,
+				costUsd: 0.0006,
+				durationMs: 1200,
+			}),
+		};
+
+		const engine = new EvolutionEngine(configPath, runtime as unknown as AgentRuntime);
+		(engine as unknown as { llmJudgesEnabled: boolean }).llmJudgesEnabled = true;
+		const queue = new EvolutionQueue(db);
+		engine.setQueueWiring(queue, () => undefined);
+
+		const result = await engine.enqueueIfWorthy(makeSession());
+		expect(result.enqueued).toBe(true);
+		expect(result.decision.fire).toBe(true);
+		expect(queue.depth()).toBe(1);
+	});
+
+	test("fire=false does not enqueue and returns enqueued=false", async () => {
+		const config = setupEnv();
+		const configPath = `${TEST_DIR}/evolution.yaml`;
+		writeFileSync(
+			configPath,
+			[
+				"cadence:",
+				"  reflection_interval: 1",
+				"gates:",
+				"  max_file_lines: 200",
+				"judges:",
+				'  enabled: "never"',
+				"paths:",
+				`  config_dir: "${config.paths.config_dir}"`,
+				`  constitution: "${config.paths.constitution}"`,
+				`  version_file: "${config.paths.version_file}"`,
+				`  metrics_file: "${config.paths.metrics_file}"`,
+				`  evolution_log: "${config.paths.evolution_log}"`,
+				`  golden_suite: "${config.paths.golden_suite}"`,
+				`  session_log: "${config.paths.session_log}"`,
+			].join("\n"),
+			"utf-8",
+		);
+		writeFileSync(`${config.paths.config_dir}/constitution.md`, "1. Honesty\n", "utf-8");
+		writeFileSync(
+			config.paths.version_file,
+			JSON.stringify({
+				version: 0,
+				parent: null,
+				timestamp: "2026-03-25T00:00:00Z",
+				changes: [],
+				metrics_at_change: { session_count: 0, success_rate_7d: 0, correction_rate_7d: 0 },
+			}),
+			"utf-8",
+		);
+
+		const { Database } = await import("bun:sqlite");
+		const { MIGRATIONS } = await import("../../db/schema.ts");
+		const { EvolutionEngine } = await import("../engine.ts");
+		const { EvolutionQueue } = await import("../queue.ts");
+
+		const db = new Database(":memory:");
+		for (const stmt of MIGRATIONS) db.run(stmt);
+
+		const runtime: FakeRuntime = {
+			judgeQuery: async () => ({
+				verdict: "pass" as const,
+				confidence: 0.9,
+				reasoning: "",
+				data: { evolve: false, reason: "routine completion" },
+				model: "claude-haiku-4-5",
+				inputTokens: 420,
+				outputTokens: 28,
+				costUsd: 0.0005,
+				durationMs: 900,
+			}),
+		};
+
+		const engine = new EvolutionEngine(configPath, runtime as unknown as AgentRuntime);
+		(engine as unknown as { llmJudgesEnabled: boolean }).llmJudgesEnabled = true;
+		const queue = new EvolutionQueue(db);
+		engine.setQueueWiring(queue, () => undefined);
+
+		const result = await engine.enqueueIfWorthy(makeSession());
+		expect(result.enqueued).toBe(false);
+		expect(result.decision.fire).toBe(false);
+		expect(queue.depth()).toBe(0);
+	});
+});

--- a/src/evolution/__tests__/queue.test.ts
+++ b/src/evolution/__tests__/queue.test.ts
@@ -1,0 +1,140 @@
+import { Database } from "bun:sqlite";
+import { beforeEach, describe, expect, test } from "bun:test";
+import { MIGRATIONS } from "../../db/schema.ts";
+import type { GateDecision } from "../gate-types.ts";
+import { EvolutionQueue } from "../queue.ts";
+import type { SessionSummary } from "../types.ts";
+
+// Phase 2 queue tests. Cover SQLite migration, enqueue persistence, drain
+// ordering, markProcessed, Zod schema validation on read, and the
+// process-restart survival case that justifies the SQLite backing in the
+// first place.
+
+function newDb(): Database {
+	const db = new Database(":memory:");
+	db.run("PRAGMA journal_mode = WAL");
+	for (const stmt of MIGRATIONS) {
+		db.run(stmt);
+	}
+	return db;
+}
+
+function makeSummary(overrides: Partial<SessionSummary> = {}): SessionSummary {
+	return {
+		session_id: "s1",
+		session_key: "slack:C1:T1",
+		user_id: "u1",
+		user_messages: ["help me"],
+		assistant_messages: ["sure"],
+		tools_used: ["Read"],
+		files_tracked: [],
+		outcome: "success",
+		cost_usd: 0.05,
+		started_at: "2026-04-14T10:00:00Z",
+		ended_at: "2026-04-14T10:03:00Z",
+		...overrides,
+	};
+}
+
+const DECISION: GateDecision = {
+	fire: true,
+	source: "haiku",
+	reason: "user taught a workflow pattern",
+	haiku_cost_usd: 0.0006,
+};
+
+describe("EvolutionQueue", () => {
+	let db: Database;
+
+	beforeEach(() => {
+		db = newDb();
+	});
+
+	test("migration created the evolution_queue table", () => {
+		const row = db.query("SELECT name FROM sqlite_master WHERE type='table' AND name='evolution_queue'").get() as {
+			name: string;
+		} | null;
+		expect(row).not.toBeNull();
+		expect(row?.name).toBe("evolution_queue");
+	});
+
+	test("enqueue inserts a row and depth reflects the insert", () => {
+		const queue = new EvolutionQueue(db);
+		expect(queue.depth()).toBe(0);
+		queue.enqueue(makeSummary(), DECISION);
+		expect(queue.depth()).toBe(1);
+	});
+
+	test("drainAll returns rows oldest-first", () => {
+		const queue = new EvolutionQueue(db);
+		queue.enqueue(makeSummary({ session_id: "a" }), DECISION);
+		queue.enqueue(makeSummary({ session_id: "b" }), DECISION);
+		queue.enqueue(makeSummary({ session_id: "c" }), DECISION);
+		const drained = queue.drainAll();
+		expect(drained).toHaveLength(3);
+		expect(drained[0].session_id).toBe("a");
+		expect(drained[1].session_id).toBe("b");
+		expect(drained[2].session_id).toBe("c");
+	});
+
+	test("drainAll returns empty array on empty queue", () => {
+		const queue = new EvolutionQueue(db);
+		expect(queue.drainAll()).toHaveLength(0);
+	});
+
+	test("markProcessed deletes only the specified ids", () => {
+		const queue = new EvolutionQueue(db);
+		queue.enqueue(makeSummary({ session_id: "a" }), DECISION);
+		queue.enqueue(makeSummary({ session_id: "b" }), DECISION);
+		queue.enqueue(makeSummary({ session_id: "c" }), DECISION);
+		const drained = queue.drainAll();
+		queue.markProcessed([drained[0].id, drained[2].id]);
+		const remaining = queue.drainAll();
+		expect(remaining).toHaveLength(1);
+		expect(remaining[0].session_id).toBe("b");
+	});
+
+	test("Zod validates the decoded gate decision and session summary", () => {
+		const queue = new EvolutionQueue(db);
+		queue.enqueue(makeSummary(), DECISION);
+		const drained = queue.drainAll();
+		expect(drained[0].gate_decision.fire).toBe(true);
+		expect(drained[0].gate_decision.source).toBe("haiku");
+		expect(drained[0].session_summary.user_messages).toEqual(["help me"]);
+	});
+
+	test("row survives a reopened database connection", () => {
+		// SQLite in-memory databases do not persist across connections, so we
+		// use a shared `:memory:?cache=shared` style via an explicit file path
+		// that lives for the duration of the test.
+		const path = `/tmp/phantom-test-queue-${process.pid}-${Date.now()}.sqlite`;
+		try {
+			const db1 = new Database(path, { create: true });
+			for (const stmt of MIGRATIONS) db1.run(stmt);
+			const q1 = new EvolutionQueue(db1);
+			q1.enqueue(makeSummary({ session_id: "survivor" }), DECISION);
+			db1.close();
+
+			const db2 = new Database(path);
+			const q2 = new EvolutionQueue(db2);
+			const rows = q2.drainAll();
+			expect(rows).toHaveLength(1);
+			expect(rows[0].session_id).toBe("survivor");
+			db2.close();
+		} finally {
+			try {
+				require("node:fs").rmSync(path, { force: true });
+			} catch {
+				// best-effort cleanup
+			}
+		}
+	});
+
+	test("clear truncates the queue", () => {
+		const queue = new EvolutionQueue(db);
+		queue.enqueue(makeSummary(), DECISION);
+		queue.enqueue(makeSummary(), DECISION);
+		queue.clear();
+		expect(queue.depth()).toBe(0);
+	});
+});

--- a/src/evolution/batch-processor.ts
+++ b/src/evolution/batch-processor.ts
@@ -1,0 +1,66 @@
+import type { EvolutionEngine } from "./engine.ts";
+import type { QueuedSession } from "./queue.ts";
+import type { EvolutionResult } from "./types.ts";
+
+// Phase 2 batch processor. This is a DELIBERATE TEMPORARY SEAM between the
+// cadence drain path and the existing 6-judge pipeline. Phase 3 will replace
+// the body of `processBatch` with a single reflection subprocess that reads
+// the whole batch and writes memory files directly. The Phase 2 body is
+// intentionally minimal so that replacement is as clean as possible:
+//
+// - No strategy pattern.
+// - No configuration knobs.
+// - No abstractions that assume the Phase 3 shape.
+// - A thin wrapper that iterates the batch and calls the existing pipeline.
+//
+// If you find yourself adding indirection here, stop. The next builder agent
+// will delete the body of this function entirely.
+
+export type SessionBatchEntry =
+	| { id: number; ok: true; result: EvolutionResult }
+	| { id: number; ok: false; error: string };
+
+export type BatchResult = {
+	processed: number;
+	successCount: number;
+	failureCount: number;
+	results: SessionBatchEntry[];
+	durationMs: number;
+};
+
+/**
+ * Drain the queue rows and run the existing evolution pipeline per session.
+ * Phase 0's mutex guards the engine so the cadence caller is responsible for
+ * serialising batches; `processBatch` itself does not acquire the mutex.
+ *
+ * Partial failures continue through the batch: if the pipeline throws on one
+ * session, we record the error and move to the next row. Phase 0's
+ * `CycleAborted` catch inside `engine.afterSession` means each session's
+ * failure mode is already bounded.
+ */
+export async function processBatch(queuedSessions: QueuedSession[], engine: EvolutionEngine): Promise<BatchResult> {
+	const startedAt = Date.now();
+	const results: SessionBatchEntry[] = [];
+	let successCount = 0;
+	let failureCount = 0;
+
+	for (const queued of queuedSessions) {
+		try {
+			const result = await engine.runSingleSessionPipeline(queued.session_summary);
+			results.push({ id: queued.id, ok: true, result });
+			successCount += 1;
+		} catch (err: unknown) {
+			const msg = err instanceof Error ? err.message : String(err);
+			results.push({ id: queued.id, ok: false, error: msg });
+			failureCount += 1;
+		}
+	}
+
+	return {
+		processed: results.length,
+		successCount,
+		failureCount,
+		results,
+		durationMs: Date.now() - startedAt,
+	};
+}

--- a/src/evolution/cadence.ts
+++ b/src/evolution/cadence.ts
@@ -1,0 +1,195 @@
+import { existsSync, readFileSync } from "node:fs";
+import { type BatchResult, processBatch } from "./batch-processor.ts";
+import type { EvolutionConfig } from "./config.ts";
+import type { EvolutionEngine } from "./engine.ts";
+import { type QueueTrigger, recordMutexSkip, recordQueueStats } from "./queue-stats.ts";
+import type { EvolutionQueue } from "./queue.ts";
+
+// Phase 2 cadence scheduler.
+//
+// Two trigger paths converge on the same `drainAndProcess`:
+//  1. A cron self-scheduling `setTimeout` that fires every `cadenceMinutes`.
+//  2. A demand watcher that fires immediately when queue depth crosses
+//     `demandTriggerDepth` so bursty sessions get processed without waiting
+//     the full cadence window.
+//
+// The cadence must skip (not wait) on mutex contention. If Phase 0's
+// `EvolutionEngine.afterSession` mutex is held when the cadence fires, the
+// cadence logs a skip and the dropped rows stay in the queue for the next
+// tick. Queuing dropped ticks behind a slow batch would defeat the safety
+// floor that Phase 0 just added, so we bias the other way.
+
+export type CadenceConfig = {
+	cadenceMinutes: number;
+	demandTriggerDepth: number;
+};
+
+export const DEFAULT_CADENCE_CONFIG: CadenceConfig = {
+	cadenceMinutes: 180,
+	demandTriggerDepth: 5,
+};
+
+/**
+ * Runtime config override for the cadence. Operators can tune both knobs
+ * without touching the YAML by dropping `phantom-config/meta/evolution.json`.
+ * The file is optional; defaults apply when absent.
+ */
+export function loadCadenceConfig(config: EvolutionConfig): CadenceConfig {
+	const path = `${configMetaDir(config)}/evolution.json`;
+	if (!existsSync(path)) return DEFAULT_CADENCE_CONFIG;
+	try {
+		const raw: unknown = JSON.parse(readFileSync(path, "utf-8"));
+		if (!raw || typeof raw !== "object") return DEFAULT_CADENCE_CONFIG;
+		const obj = raw as Record<string, unknown>;
+		const cadence =
+			typeof obj.cadence_minutes === "number" ? obj.cadence_minutes : DEFAULT_CADENCE_CONFIG.cadenceMinutes;
+		const depth =
+			typeof obj.demand_trigger_depth === "number"
+				? obj.demand_trigger_depth
+				: DEFAULT_CADENCE_CONFIG.demandTriggerDepth;
+		return { cadenceMinutes: cadence, demandTriggerDepth: depth };
+	} catch {
+		return DEFAULT_CADENCE_CONFIG;
+	}
+}
+
+export class EvolutionCadence {
+	private timer: ReturnType<typeof setTimeout> | null = null;
+	private running = false;
+	private stopped = false;
+	private inFlight: Promise<BatchResult | null> | null = null;
+
+	constructor(
+		private readonly engine: EvolutionEngine,
+		private readonly queue: EvolutionQueue,
+		private readonly evolutionConfig: EvolutionConfig,
+		private readonly cadenceConfig: CadenceConfig,
+	) {}
+
+	start(): void {
+		if (this.running) return;
+		this.running = true;
+		this.stopped = false;
+		this.scheduleNextTick();
+	}
+
+	stop(): void {
+		this.stopped = true;
+		this.running = false;
+		if (this.timer) {
+			clearTimeout(this.timer);
+			this.timer = null;
+		}
+	}
+
+	getCadenceConfig(): CadenceConfig {
+		return this.cadenceConfig;
+	}
+
+	/**
+	 * Notify the cadence that a new row was just enqueued. If the queue depth
+	 * has reached the demand trigger, fire a drain immediately. Otherwise
+	 * do nothing: the cron will pick it up at the next tick.
+	 */
+	onEnqueue(): void {
+		if (!this.running) return;
+		const depth = this.queue.depth();
+		if (depth >= this.cadenceConfig.demandTriggerDepth) {
+			void this.drainAndProcess("demand");
+		}
+	}
+
+	/**
+	 * Manual/test entry point. Always attempts a drain regardless of depth.
+	 * Returns the batch result or null if the drain was skipped due to
+	 * mutex contention.
+	 */
+	async triggerNow(): Promise<BatchResult | null> {
+		return this.drainAndProcess("manual");
+	}
+
+	private scheduleNextTick(): void {
+		if (this.stopped) return;
+		// setTimeout stores its delay in a 32-bit signed integer, so values
+		// above ~24.8 days wrap and fire immediately (not once per month).
+		// Cap the interval at a safe maximum and keep the minimum at 1 ms so
+		// zero-length test cadences still tick once.
+		const MAX_SAFE_TIMEOUT_MS = 2_147_483_000;
+		const rawDelay = this.cadenceConfig.cadenceMinutes * 60_000;
+		const delayMs = Math.max(1, Math.min(MAX_SAFE_TIMEOUT_MS, rawDelay));
+		this.timer = setTimeout(() => {
+			void this.onCronTick();
+		}, delayMs);
+		// Bun's setTimeout returns a Timer object; unref() is safe to call on
+		// either bun or node so the cron does not keep the process alive on
+		// clean shutdown paths.
+		const timer = this.timer as unknown as { unref?: () => void };
+		timer.unref?.();
+	}
+
+	private async onCronTick(): Promise<void> {
+		try {
+			await this.drainAndProcess("cron");
+		} finally {
+			this.scheduleNextTick();
+		}
+	}
+
+	// Skip on mutex contention (never wait). If a previous batch is still
+	// running when a cron or demand tick arrives, we log and return. The
+	// rows stay in the queue and get picked up on the next tick. Waiting
+	// would stack ticks and re-introduce the fork-bomb shape Phase 0 just
+	// closed.
+	private async drainAndProcess(trigger: QueueTrigger): Promise<BatchResult | null> {
+		if (this.inFlight) {
+			console.log(`[evolution] previous batch still in flight, skipping this tick (trigger=${trigger})`);
+			recordMutexSkip(this.evolutionConfig);
+			return null;
+		}
+
+		const work = this.runDrain(trigger);
+		this.inFlight = work;
+		try {
+			return await work;
+		} finally {
+			this.inFlight = null;
+		}
+	}
+
+	private async runDrain(trigger: QueueTrigger): Promise<BatchResult | null> {
+		const queued = this.queue.drainAll();
+		if (queued.length === 0) {
+			return null;
+		}
+		console.log(
+			`[evolution] draining batch of ${queued.length} sessions (trigger=${trigger}, cadence=${this.cadenceConfig.cadenceMinutes}min)`,
+		);
+		const result = await processBatch(queued, this.engine);
+		this.queue.markProcessed(queued.map((q) => q.id));
+
+		const appliedCount = result.results.reduce((sum, r) => {
+			if (r.ok) return sum + r.result.changes_applied.length;
+			return sum;
+		}, 0);
+		console.log(
+			`[evolution] batch complete: ${result.processed} processed, ${appliedCount} applied changes, duration=${result.durationMs}ms`,
+		);
+
+		recordQueueStats(this.evolutionConfig, {
+			trigger,
+			drainedDepth: queued.length,
+			durationMs: result.durationMs,
+		});
+
+		return result;
+	}
+}
+
+function configMetaDir(config: EvolutionConfig): string {
+	// metrics_file lives at `<config_dir>/meta/metrics.json` by default, so
+	// the meta directory is its parent. Pulling it from the path avoids a
+	// second string in the EvolutionConfig schema for the same thing.
+	const metricsPath = config.paths.metrics_file;
+	const idx = metricsPath.lastIndexOf("/");
+	return idx === -1 ? "." : metricsPath.slice(0, idx);
+}

--- a/src/evolution/engine.ts
+++ b/src/evolution/engine.ts
@@ -6,6 +6,8 @@ import { applyApproved } from "./application.ts";
 import { type EvolutionConfig, loadEvolutionConfig } from "./config.ts";
 import { recordObservations, runConsolidation } from "./consolidation.ts";
 import { ConstitutionChecker } from "./constitution.ts";
+import type { GateDecision } from "./gate-types.ts";
+import { appendGateLog, decideGate, recordGateDecision } from "./gate.ts";
 import { addCase, loadSuite, pruneSuite } from "./golden-suite.ts";
 import { runQualityJudge } from "./judges/quality-judge.ts";
 import { type JudgeCosts, emptyJudgeCosts } from "./judges/types.ts";
@@ -18,6 +20,7 @@ import {
 	updateAfterRollback,
 	updateAfterSession,
 } from "./metrics.ts";
+import type { EvolutionQueue } from "./queue.ts";
 import {
 	buildCritiqueFromObservations,
 	extractObservations,
@@ -27,6 +30,12 @@ import {
 import type { EvolutionResult, EvolutionVersion, EvolvedConfig, GoldenCase, SessionSummary } from "./types.ts";
 import { CycleAborted, validateAll, validateAllWithJudges } from "./validation.ts";
 import { getHistory, readVersion, rollback as versionRollback } from "./versioning.ts";
+
+export type EnqueueResult = {
+	enqueued: boolean;
+	decision: GateDecision;
+	inlineResult?: EvolutionResult;
+};
 
 export class EvolutionEngine {
 	private config: EvolutionConfig;
@@ -53,6 +62,11 @@ export class EvolutionEngine {
 	private activeCycleSessionId: string | null = null;
 	private activeCycleSkipCount = 0;
 
+	// Phase 1 + 2 wiring. The queue is optional so engine unit tests that do
+	// not care about batching can still construct a bare engine.
+	private queue: EvolutionQueue | null = null;
+	private onEnqueue: (() => void) | null = null;
+
 	// `runtime` is optional so existing tests and heuristic-only deployments can
 	// construct an engine without wiring a full AgentRuntime. When the engine
 	// is asked to use LLM judges but has no runtime, it falls back to heuristics.
@@ -70,6 +84,17 @@ export class EvolutionEngine {
 
 	setRuntime(runtime: AgentRuntime): void {
 		this.runtime = runtime;
+	}
+
+	/**
+	 * Wire the queue plumbing for Phase 2. Called from `src/index.ts` after
+	 * the evolution queue and cadence have been constructed. Keeping these
+	 * as setters rather than constructor args preserves the existing test
+	 * shape (most engine tests do not care about the queue).
+	 */
+	setQueueWiring(queue: EvolutionQueue, onEnqueue: () => void): void {
+		this.queue = queue;
+		this.onEnqueue = onEnqueue;
 	}
 
 	private resolveJudgeMode(): boolean {
@@ -132,6 +157,46 @@ export class EvolutionEngine {
 	}
 
 	/**
+	 * Phase 1 + 2 entry point. Runs the conditional firing gate on the
+	 * session summary, logs the decision, records gate stats, and either
+	 * drops the session (fire=false) or enqueues it for cadence processing
+	 * (fire=true). Runs OUTSIDE the evolution mutex: the gate is cheap and
+	 * serializing gate calls through the mutex would defeat the purpose.
+	 */
+	async enqueueIfWorthy(session: SessionSummary): Promise<EnqueueResult> {
+		updateAfterSession(this.config, session.outcome, false);
+		const decision = await decideGate(session, this.runtime);
+		appendGateLog(this.config, session, decision);
+		recordGateDecision(this.config, decision);
+
+		if (!decision.fire) {
+			return { enqueued: false, decision };
+		}
+
+		if (this.queue) {
+			this.queue.enqueue(session, decision);
+			this.onEnqueue?.();
+			return { enqueued: true, decision };
+		}
+
+		// Fallback path: no queue wired. This is the shape unit tests exercise
+		// when they construct a bare EvolutionEngine. We keep behaviour close
+		// to the legacy afterSession call so existing assertions still pass.
+		const result = await this.afterSessionInternal(session);
+		return { enqueued: false, decision, inlineResult: result };
+	}
+
+	/**
+	 * Phase 2 batch processor entry point. Called once per queued session by
+	 * `batch-processor.ts` inside the Phase 0 mutex. Publicly exposed so the
+	 * batch processor does not need to reach into private state; Phase 3 will
+	 * replace the batch processor body entirely and this method becomes dead.
+	 */
+	async runSingleSessionPipeline(session: SessionSummary): Promise<EvolutionResult> {
+		return this.afterSessionInternal(session);
+	}
+
+	/**
 	 * Main entry point: run the full 6-step evolution pipeline after a session.
 	 * When useLLMJudges is true, uses Sonnet-powered judges for observation
 	 * extraction, safety gate, constitution gate, regression gate, and quality
@@ -139,10 +204,15 @@ export class EvolutionEngine {
 	 *
 	 * Phase 0 safety floor: calls that arrive while another cycle is in
 	 * flight return immediately with a skipped result and no judge
-	 * subprocesses spawned. Phase 2 will replace this drop-on-floor behavior
-	 * with a real cadence queue.
+	 * subprocesses spawned. Phase 2 replaced `afterSession` as the primary
+	 * entry point with `enqueueIfWorthy`; direct callers still work and the
+	 * mutex guard remains the same.
 	 */
 	async afterSession(session: SessionSummary): Promise<EvolutionResult> {
+		return this.afterSessionInternal(session);
+	}
+
+	private async afterSessionInternal(session: SessionSummary): Promise<EvolutionResult> {
 		// Always bump the session counter so the dashboard's `session_count`
 		// reflects every turn that arrived, including skipped ones. On the skip
 		// path we pass `hadCorrections=false` because no observation extraction

--- a/src/evolution/gate-types.ts
+++ b/src/evolution/gate-types.ts
@@ -1,0 +1,18 @@
+// Phase 1 gate types. Kept in a separate module so the pure types can be
+// imported by queue.ts, cadence.ts, and the test suite without pulling in
+// the prompt strings, the Zod schema, or the runtime dependency.
+
+export type GateSource = "haiku" | "failsafe";
+
+/**
+ * Decision returned by `decideGate`. `source` is either `haiku` (the gate
+ * subprocess returned a valid JSON decision) or `failsafe` (the gate errored
+ * and TypeScript defaulted fire=true to bias toward not losing learning
+ * signal on transient failures).
+ */
+export type GateDecision = {
+	fire: boolean;
+	source: GateSource;
+	reason: string;
+	haiku_cost_usd: number;
+};

--- a/src/evolution/gate.ts
+++ b/src/evolution/gate.ts
@@ -1,0 +1,195 @@
+import { appendFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { JudgeSubprocessError } from "../agent/judge-query.ts";
+import type { AgentRuntime } from "../agent/runtime.ts";
+import type { EvolutionConfig } from "./config.ts";
+import type { GateDecision } from "./gate-types.ts";
+import { gateJudgePrompt } from "./judges/prompts.ts";
+import { GateJudgeResult, type GateJudgeResultType } from "./judges/schemas.ts";
+import { JUDGE_MODEL_HAIKU } from "./judges/types.ts";
+import type { SessionSummary } from "./types.ts";
+
+// Phase 1 conditional firing gate.
+//
+// Cardinal Rule compliance: TypeScript serialises session metadata into a
+// compact summary and asks Haiku. Haiku decides whether the session shows
+// durable learning signal. No regex pre-filter, no hardcoded skip conditions,
+// no `classifyUserIntent` spelled in rules. The agent understands context;
+// TypeScript does not.
+//
+// Failsafe: any error from the Haiku subprocess (timeout, parse failure,
+// subprocess SIGKILL, unparseable JSON) returns `fire: true` so transient
+// failures never silently drop learning signal. Over-firing is bounded by the
+// Phase 0 daily cost cap and by the Phase 2 cadence batching.
+
+const GATE_LOG_FILENAME = "evolution-gate-log.jsonl";
+
+export type GateStats = {
+	total_decisions: number;
+	fired_by_haiku: number;
+	skipped_by_haiku: number;
+	fired_by_failsafe: number;
+	haiku_cost_usd_total: number;
+};
+
+export function emptyGateStats(): GateStats {
+	return {
+		total_decisions: 0,
+		fired_by_haiku: 0,
+		skipped_by_haiku: 0,
+		fired_by_failsafe: 0,
+		haiku_cost_usd_total: 0,
+	};
+}
+
+/**
+ * Main entry point for Phase 1. Builds a compact session summary, sends it
+ * to Haiku via `runJudgeQuery`, and returns the decision. On any error, the
+ * failsafe defaults to `fire: true`.
+ *
+ * The runtime argument is optional so heuristic-only deployments that have
+ * no Agent SDK credentials still get a meaningful decision (they hit the
+ * failsafe path unconditionally, which is the correct bias).
+ */
+export async function decideGate(session: SessionSummary, runtime: AgentRuntime | null): Promise<GateDecision> {
+	if (!runtime) {
+		return {
+			fire: true,
+			source: "failsafe",
+			reason: "no runtime available for Haiku gate, defaulting to fire",
+			haiku_cost_usd: 0,
+		};
+	}
+
+	const firstUser = truncate(session.user_messages[0] ?? "", 240);
+	const lastUser = truncate(session.user_messages[session.user_messages.length - 1] ?? "", 240);
+	const lastAgent = truncate(session.assistant_messages[session.assistant_messages.length - 1] ?? "", 400);
+	const durationSeconds = Math.max(
+		0,
+		Math.round((Date.parse(session.ended_at) - Date.parse(session.started_at)) / 1000),
+	);
+
+	const prompt = gateJudgePrompt({
+		channelType: inferChannelType(session.session_key),
+		turnCount: session.user_messages.length,
+		durationSeconds,
+		totalCostUsd: session.cost_usd ?? 0,
+		toolsUsed: (session.tools_used ?? []).join(",") || "(none)",
+		outcome: session.outcome,
+		firstUserMessage: firstUser || "(none)",
+		lastUserMessage: lastUser || "(none)",
+		lastAgentMessage: lastAgent || "(none)",
+		// The SessionSummary shape does not yet carry reactions or hook block
+		// counts, so these are always zero until Phase 3 extends it. Haiku
+		// still gets a consistent schema shape which we can enrich later
+		// without changing the prompt contract.
+		userReactions: "(none)",
+		hookBlockCount: 0,
+		toolErrorCount: countToolErrors(session),
+	});
+
+	try {
+		const result = await runtime.judgeQuery<GateJudgeResultType>({
+			systemPrompt: prompt.system,
+			userMessage: prompt.user,
+			schema: GateJudgeResult,
+			model: JUDGE_MODEL_HAIKU,
+			maxTokens: 200,
+		});
+		const evolve = result.data.evolve === true;
+		return {
+			fire: evolve,
+			source: "haiku",
+			reason: result.data.reason || (evolve ? "haiku voted to evolve" : "haiku voted to skip"),
+			haiku_cost_usd: result.costUsd,
+		};
+	} catch (err: unknown) {
+		const msg = err instanceof Error ? err.message : String(err);
+		// Phase 0 partial cost capture applies here: a SIGKILLed Haiku
+		// subprocess still burned tokens we want to see in the gate stats.
+		const haikuCost = err instanceof JudgeSubprocessError ? err.partialCost.costUsd : 0;
+		console.warn(
+			`[evolution] gate error for session ${session.session_id}: ${msg} (defaulting to fire=true as failsafe)`,
+		);
+		return {
+			fire: true,
+			source: "failsafe",
+			reason: `gate error: ${msg}`,
+			haiku_cost_usd: haikuCost,
+		};
+	}
+}
+
+/**
+ * Append one line per decision to `evolution-gate-log.jsonl`. Matches the
+ * append pattern used by `application.ts` for `evolution-log.jsonl`.
+ */
+export function appendGateLog(config: EvolutionConfig, session: SessionSummary, decision: GateDecision): void {
+	const logPath = join(dirname(config.paths.metrics_file), GATE_LOG_FILENAME);
+	try {
+		const dir = dirname(logPath);
+		if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+		const line = {
+			ts: new Date().toISOString(),
+			session_id: session.session_id,
+			session_key: session.session_key,
+			fire: decision.fire,
+			source: decision.source,
+			reason: decision.reason,
+			haiku_cost_usd: decision.haiku_cost_usd,
+		};
+		appendFileSync(logPath, `${JSON.stringify(line)}\n`, "utf-8");
+	} catch (err: unknown) {
+		const msg = err instanceof Error ? err.message : String(err);
+		console.warn(`[evolution] Failed to write gate log: ${msg}`);
+	}
+}
+
+/**
+ * Increment the `gate_stats` object on `metrics.json`. Matches the style of
+ * `recordJudgeCosts` in `engine.ts`: read, merge, write.
+ */
+export function recordGateDecision(config: EvolutionConfig, decision: GateDecision): void {
+	const metricsPath = config.paths.metrics_file;
+	try {
+		let metrics: Record<string, unknown> = {};
+		if (existsSync(metricsPath)) {
+			metrics = JSON.parse(readFileSync(metricsPath, "utf-8"));
+		}
+		const stats: GateStats = {
+			...emptyGateStats(),
+			...((metrics.gate_stats as GateStats | undefined) ?? {}),
+		};
+		stats.total_decisions += 1;
+		if (decision.fire) {
+			if (decision.source === "haiku") stats.fired_by_haiku += 1;
+			else stats.fired_by_failsafe += 1;
+		} else {
+			stats.skipped_by_haiku += 1;
+		}
+		stats.haiku_cost_usd_total += decision.haiku_cost_usd;
+		metrics.gate_stats = stats;
+		writeFileSync(metricsPath, `${JSON.stringify(metrics, null, 2)}\n`, "utf-8");
+	} catch (err: unknown) {
+		const msg = err instanceof Error ? err.message : String(err);
+		console.warn(`[evolution] Failed to record gate stats: ${msg}`);
+	}
+}
+
+function truncate(text: string, max: number): string {
+	if (text.length <= max) return text;
+	return `${text.slice(0, max)}...`;
+}
+
+function inferChannelType(sessionKey: string): string {
+	const prefix = sessionKey.split(":")[0];
+	return prefix || "cli";
+}
+
+function countToolErrors(session: SessionSummary): number {
+	let count = 0;
+	for (const msg of session.assistant_messages) {
+		if (msg.includes("Error:")) count += 1;
+	}
+	return count;
+}

--- a/src/evolution/judges/prompts.ts
+++ b/src/evolution/judges/prompts.ts
@@ -238,6 +238,86 @@ SESSION METADATA:
 	};
 }
 
+/**
+ * Phase 1 conditional-firing gate prompt. Haiku 4.5 inspects a compact
+ * session summary and decides whether the session is worth running through
+ * the downstream evolution pipeline. This is the Cardinal Rule compliance
+ * boundary for Phase 1: TypeScript serialises the metadata, Haiku decides
+ * whether there is learning signal. No pre-filter in TypeScript.
+ */
+export function gateJudgePrompt(input: {
+	channelType: string;
+	turnCount: number;
+	durationSeconds: number;
+	totalCostUsd: number;
+	toolsUsed: string;
+	outcome: string;
+	firstUserMessage: string;
+	lastUserMessage: string;
+	lastAgentMessage: string;
+	userReactions: string;
+	hookBlockCount: number;
+	toolErrorCount: number;
+}): { system: string; user: string } {
+	return {
+		system: `You decide whether an autonomous agent should learn from a conversation session. Phantom runs a full reflection pipeline after sessions marked worth learning from; that pipeline writes small notes to the agent's own memory files (user profile, domain knowledge, workflow patterns). Each note costs real money to produce and lives in the agent's prompt for every future session, so write-worthiness matters.
+
+Fire the pipeline (evolve=true) when the session shows at least one of these durable signals:
+- A specific user preference the agent should carry forward (tool choice, code style, communication tone, file layout, naming convention, review cadence).
+- A factual correction where the user told the agent it had something wrong (a fact, a name, a command, a procedure, a piece of infrastructure).
+- A novel user fact the agent did not previously know: their name, role, team, project, accounts, repositories, domain, or any personal identifier worth remembering.
+- Infrastructure or tooling knowledge the agent just learned: URLs, ports, auth layers, deploy commands, environment names, hostnames, service dependencies.
+- A workflow rule the user taught the agent: "always do X before Y", "never touch Z without asking", "use the staging channel for previews", "check-in with me before pushing".
+- A hidden constraint the agent hit the hard way: rate limits, permission boundaries, blocked commands, expired credentials, environment assumptions that were wrong.
+- A genuine error the agent made that is worth recording so future sessions do not repeat it.
+- A recurring task pattern the user demonstrated that could become a reusable procedure.
+- A user reaction that indicates dissatisfaction even without an explicit correction (short reply, tone shift, repeated request, visible frustration).
+
+Do NOT fire (evolve=false) when the session is one of these:
+- A routine task the agent completed cleanly with no new information gained.
+- A one-off question about public facts (weather, news, general programming trivia) where no durable preference is attached.
+- A clarification turn where the user just repeated or rephrased an already-stated request.
+- A "status" / "hi" / "ping" style heartbeat interaction, including onboarding intros.
+- A scheduler or cron-triggered session that ran its job and did not surface new user input.
+- A system-originated message (secret save notification, button click forwarder) without meaningful user content.
+- Polite thanks, acknowledgements, or closing statements ("ok", "thanks", "perfect") with no new instruction.
+
+Edge rules:
+- If the session outcome is failure, fire. Failure sessions are the single highest-signal event shape and should always be reflected on.
+- If the user reaction array contains a negative reaction (thumbs down, angry, confused), fire.
+- If a hook blocker fired during the session, fire: the agent just learned a boundary it previously did not respect.
+- If the agent emitted a tool_use error, fire: the agent learned a usage pattern it should not repeat.
+- If in doubt, fire. Over-firing is bounded by the downstream daily cost cap; under-firing loses real learning signal and is strictly worse.
+
+Respond with ONLY a JSON object matching this schema:
+{
+  "evolve": boolean,
+  "reason": string (under 40 words, cite the specific signal)
+}`,
+		user: `Session metadata:
+channel: ${input.channelType}
+turns: ${input.turnCount}
+duration: ${input.durationSeconds}s
+cost: $${input.totalCostUsd.toFixed(4)}
+tools_used: ${input.toolsUsed}
+outcome: ${input.outcome}
+user_reactions: ${input.userReactions}
+hook_blocks: ${input.hookBlockCount}
+tool_errors: ${input.toolErrorCount}
+
+First user message:
+${input.firstUserMessage}
+
+Last user message:
+${input.lastUserMessage}
+
+Last agent reply:
+${input.lastAgentMessage}
+
+Decide: evolve or skip.`,
+	};
+}
+
 export function qualityAssessmentPrompt(
 	currentConfig: string,
 	sessionTranscript: string,

--- a/src/evolution/judges/schemas.ts
+++ b/src/evolution/judges/schemas.ts
@@ -226,3 +226,17 @@ export const QualityAssessmentResult = z.object({
 });
 
 export type QualityAssessmentResultType = z.infer<typeof QualityAssessmentResult>;
+
+// -- Conditional Firing Gate (Phase 1) --
+//
+// Haiku inspects a compact session summary and decides whether the evolution
+// pipeline should fire. Pure binary output plus a short reason. Keeping the
+// schema intentionally tiny minimises Haiku's output token spend and keeps the
+// parse failure surface as small as possible.
+
+export const GateJudgeResult = z.object({
+	evolve: z.boolean().describe("True if the session is worth learning from, false otherwise."),
+	reason: z.string().max(400).describe("Short natural-language justification, under 40 words."),
+});
+
+export type GateJudgeResultType = z.infer<typeof GateJudgeResult>;

--- a/src/evolution/queue-stats.ts
+++ b/src/evolution/queue-stats.ts
@@ -1,0 +1,103 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import type { EvolutionConfig } from "./config.ts";
+
+// Queue stats bookkeeping for the Phase 2 cadence. Lives in its own module so
+// `cadence.ts` stays focused on the trigger control flow (cron, demand,
+// contention skip) rather than the metrics shape.
+
+export type QueueTrigger = "cron" | "demand" | "manual";
+
+export type QueueStatsEvent = {
+	trigger: QueueTrigger;
+	drainedDepth: number;
+	durationMs: number;
+};
+
+export type QueueStats = {
+	cron_fires_total: number;
+	demand_fires_total: number;
+	manual_fires_total: number;
+	mutex_skips_total: number;
+	batch_size_total: number;
+	avg_depth_at_drain: number;
+	batch_duration_ms_p50: number;
+	batch_duration_ms_p95: number;
+	last_durations: number[];
+};
+
+export function emptyQueueStats(): QueueStats {
+	return {
+		cron_fires_total: 0,
+		demand_fires_total: 0,
+		manual_fires_total: 0,
+		mutex_skips_total: 0,
+		batch_size_total: 0,
+		avg_depth_at_drain: 0,
+		batch_duration_ms_p50: 0,
+		batch_duration_ms_p95: 0,
+		last_durations: [],
+	};
+}
+
+/**
+ * Extend `metrics.json` with a `queue_stats` object so operators can see
+ * cadence behaviour in the same dashboard as the existing evolution counters.
+ * Keeps a sliding window of the last 100 durations so p50/p95 are bounded
+ * memory and do not require a separate time-series store.
+ */
+export function recordQueueStats(config: EvolutionConfig, event: QueueStatsEvent): void {
+	const metricsPath = config.paths.metrics_file;
+	try {
+		let metrics: Record<string, unknown> = {};
+		if (existsSync(metricsPath)) {
+			metrics = JSON.parse(readFileSync(metricsPath, "utf-8"));
+		}
+		const stats: QueueStats = { ...emptyQueueStats(), ...((metrics.queue_stats as QueueStats | undefined) ?? {}) };
+		if (event.trigger === "cron") stats.cron_fires_total += 1;
+		else if (event.trigger === "demand") stats.demand_fires_total += 1;
+		else stats.manual_fires_total += 1;
+
+		stats.batch_size_total += event.drainedDepth;
+		const nextDurations = [...stats.last_durations, event.durationMs].slice(-100);
+		stats.last_durations = nextDurations;
+		stats.batch_duration_ms_p50 = percentile(nextDurations, 0.5);
+		stats.batch_duration_ms_p95 = percentile(nextDurations, 0.95);
+
+		const totalFires = stats.cron_fires_total + stats.demand_fires_total + stats.manual_fires_total;
+		stats.avg_depth_at_drain = totalFires > 0 ? round2(stats.batch_size_total / totalFires) : 0;
+
+		metrics.queue_stats = stats;
+		writeFileSync(metricsPath, `${JSON.stringify(metrics, null, 2)}\n`, "utf-8");
+	} catch (err: unknown) {
+		const msg = err instanceof Error ? err.message : String(err);
+		console.warn(`[evolution] Failed to record queue stats: ${msg}`);
+	}
+}
+
+export function recordMutexSkip(config: EvolutionConfig): void {
+	const metricsPath = config.paths.metrics_file;
+	try {
+		let metrics: Record<string, unknown> = {};
+		if (existsSync(metricsPath)) {
+			metrics = JSON.parse(readFileSync(metricsPath, "utf-8"));
+		}
+		const stats: QueueStats = { ...emptyQueueStats(), ...((metrics.queue_stats as QueueStats | undefined) ?? {}) };
+		stats.mutex_skips_total += 1;
+		metrics.queue_stats = stats;
+		writeFileSync(metricsPath, `${JSON.stringify(metrics, null, 2)}\n`, "utf-8");
+	} catch (err: unknown) {
+		const msg = err instanceof Error ? err.message : String(err);
+		console.warn(`[evolution] Failed to record mutex skip: ${msg}`);
+	}
+}
+
+function percentile(values: number[], p: number): number {
+	if (values.length === 0) return 0;
+	const sorted = [...values].sort((a, b) => a - b);
+	const idx = Math.min(sorted.length - 1, Math.floor(p * sorted.length));
+	return sorted[idx];
+}
+
+function round2(n: number): number {
+	return Math.round(n * 100) / 100;
+}

--- a/src/evolution/queue.ts
+++ b/src/evolution/queue.ts
@@ -1,0 +1,126 @@
+import type { Database } from "bun:sqlite";
+import { z } from "zod";
+import type { GateDecision } from "./gate-types.ts";
+import type { SessionSummary } from "./types.ts";
+
+// Phase 2 persistent queue. Sessions that passed `decideGate` live here until
+// the cadence cron or the demand trigger drains them into `batch-processor.ts`.
+//
+// The rationale for SQLite over an in-memory queue: Phantom restarts often
+// during deploys, and losing the queue on restart would throw away real
+// learning signal. SQLite is the same store already used for sessions and
+// scheduler jobs, so we are not adding a new persistence primitive.
+//
+// Zod validates the JSON columns on read. We never want `JSON.parse` to
+// silently hand off an unexpected shape to the batch processor: the gate
+// decision shape is load-bearing and a drift here would cause downstream
+// crashes that look unrelated to the queue.
+
+const GateSourceSchema = z.enum(["haiku", "failsafe"]);
+
+const GateDecisionSchema: z.ZodType<GateDecision> = z.object({
+	fire: z.boolean(),
+	source: GateSourceSchema,
+	reason: z.string(),
+	haiku_cost_usd: z.number(),
+});
+
+const SessionSummarySchema: z.ZodType<SessionSummary> = z.object({
+	session_id: z.string(),
+	session_key: z.string(),
+	user_id: z.string(),
+	user_messages: z.array(z.string()),
+	assistant_messages: z.array(z.string()),
+	tools_used: z.array(z.string()),
+	files_tracked: z.array(z.string()),
+	outcome: z.enum(["success", "failure", "partial", "abandoned"]),
+	cost_usd: z.number(),
+	started_at: z.string(),
+	ended_at: z.string(),
+});
+
+export type QueuedSession = {
+	id: number;
+	session_id: string;
+	session_key: string;
+	gate_decision: GateDecision;
+	session_summary: SessionSummary;
+	enqueued_at: string;
+};
+
+type QueueRow = {
+	id: number;
+	session_id: string;
+	session_key: string;
+	gate_decision_json: string;
+	session_summary_json: string;
+	enqueued_at: string;
+};
+
+export class EvolutionQueue {
+	constructor(private db: Database) {}
+
+	/**
+	 * Insert one row per gate-approved session. Called from
+	 * `engine.enqueueIfWorthy` after `decideGate` returns `fire=true`.
+	 * Silent on duplicates: a busy multi-turn session can fire multiple
+	 * times and each turn legitimately wants its own row because the
+	 * batch processor ingests the latest summary when the row is drained.
+	 */
+	enqueue(summary: SessionSummary, decision: GateDecision): void {
+		const stmt = this.db.query(
+			`INSERT INTO evolution_queue (session_id, session_key, gate_decision_json, session_summary_json)
+			VALUES (?, ?, ?, ?)`,
+		);
+		stmt.run(summary.session_id, summary.session_key, JSON.stringify(decision), JSON.stringify(summary));
+	}
+
+	depth(): number {
+		const row = this.db.query("SELECT COUNT(*) AS c FROM evolution_queue").get() as { c: number } | null;
+		return row?.c ?? 0;
+	}
+
+	/**
+	 * Read every queued row ordered oldest-first. The cadence drains the
+	 * entire queue in one batch rather than slicing: batch cost economics
+	 * favour bundling, and the 180-minute cadence keeps the worst-case
+	 * batch size bounded by the demand trigger.
+	 */
+	drainAll(): QueuedSession[] {
+		const rows = this.db
+			.query(
+				"SELECT id, session_id, session_key, gate_decision_json, session_summary_json, enqueued_at FROM evolution_queue ORDER BY enqueued_at ASC, id ASC",
+			)
+			.all() as QueueRow[];
+		return rows.map((row) => parseRow(row));
+	}
+
+	markProcessed(ids: number[]): void {
+		if (ids.length === 0) return;
+		// bun:sqlite parameter binding cannot expand arrays directly, so we
+		// build a placeholder list once and pass the ids via spread. Deletion
+		// is a single statement so we do not need a transaction.
+		const placeholders = ids.map(() => "?").join(",");
+		this.db.run(`DELETE FROM evolution_queue WHERE id IN (${placeholders})`, ids);
+	}
+
+	/** Test-only: truncate the queue between assertions. Not exposed to production callers. */
+	clear(): void {
+		this.db.run("DELETE FROM evolution_queue");
+	}
+}
+
+function parseRow(row: QueueRow): QueuedSession {
+	const decisionRaw: unknown = JSON.parse(row.gate_decision_json);
+	const summaryRaw: unknown = JSON.parse(row.session_summary_json);
+	const decision = GateDecisionSchema.parse(decisionRaw);
+	const summary = SessionSummarySchema.parse(summaryRaw);
+	return {
+		id: row.id,
+		session_id: row.session_id,
+		session_key: row.session_key,
+		gate_decision: decision,
+		session_summary: summary,
+		enqueued_at: row.enqueued_at,
+	};
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,7 +33,9 @@ import {
 import { closeDatabase, getDatabase } from "./db/connection.ts";
 import { runMigrations } from "./db/migrate.ts";
 import { createEmailToolServer } from "./email/tool.ts";
+import { EvolutionCadence, loadCadenceConfig } from "./evolution/cadence.ts";
 import { EvolutionEngine } from "./evolution/engine.ts";
+import { EvolutionQueue } from "./evolution/queue.ts";
 import type { SessionSummary } from "./evolution/types.ts";
 import { PeerHealthMonitor } from "./mcp/peer-health.ts";
 import { PeerManager } from "./mcp/peers.ts";
@@ -108,12 +110,26 @@ async function main(): Promise<void> {
 	const runtime = new AgentRuntime(config, db);
 
 	let evolution: EvolutionEngine | null = null;
+	let evolutionCadence: EvolutionCadence | null = null;
 	try {
 		evolution = new EvolutionEngine(undefined, runtime);
 		const currentVersion = evolution.getCurrentVersion();
 		const judgeMode = evolution.usesLLMJudges() ? "LLM judges" : "heuristic";
 		console.log(`[evolution] Engine initialized (v${currentVersion}, ${judgeMode})`);
 		setEvolutionVersionProvider(() => evolution?.getCurrentVersion() ?? 0);
+
+		// Phase 2: persistent queue + cadence scheduler. The cadence starts
+		// here so cron ticks begin immediately after boot. Demand triggers
+		// route through `onEnqueue` which fires a drain whenever the queue
+		// depth crosses `demandTriggerDepth`.
+		const queue = new EvolutionQueue(db);
+		const cadenceConfig = loadCadenceConfig(evolution.getEvolutionConfig());
+		evolutionCadence = new EvolutionCadence(evolution, queue, evolution.getEvolutionConfig(), cadenceConfig);
+		evolution.setQueueWiring(queue, () => evolutionCadence?.onEnqueue());
+		evolutionCadence.start();
+		console.log(
+			`[evolution] Cadence started (cadence=${cadenceConfig.cadenceMinutes}min, demand_trigger=${cadenceConfig.demandTriggerDepth})`,
+		);
 	} catch (err: unknown) {
 		const msg = err instanceof Error ? err.message : String(err);
 		console.warn(`[evolution] Failed to initialize: ${msg}. Running without self-evolution.`);
@@ -151,9 +167,15 @@ async function main(): Promise<void> {
 				ended_at: new Date(signal.timestamp).toISOString(),
 			};
 			evolution
-				.afterSession(sessionSummary)
-				.then((result) => {
-					if (result.changes_applied.length > 0) {
+				.enqueueIfWorthy(sessionSummary)
+				.then((enqResult) => {
+					// Phase 1 fallback path: when no queue is wired, enqueueIfWorthy
+					// runs the pipeline inline and exposes the result so the
+					// evolved config can be re-loaded. In production the cadence
+					// drains the queue out-of-band and the config reload happens
+					// after processBatch completes, not here.
+					const applied = enqResult.inlineResult?.changes_applied.length ?? 0;
+					if (applied > 0) {
 						const updatedConfig = evolution?.getConfig();
 						if (updatedConfig) runtime.setEvolvedConfig(updatedConfig);
 					}
@@ -558,9 +580,10 @@ async function main(): Promise<void> {
 			};
 
 			evolution
-				.afterSession(sessionSummary)
-				.then((result) => {
-					if (result.changes_applied.length > 0) {
+				.enqueueIfWorthy(sessionSummary)
+				.then((enqResult) => {
+					const applied = enqResult.inlineResult?.changes_applied.length ?? 0;
+					if (applied > 0) {
 						const updatedConfig = evolution?.getConfig();
 						if (updatedConfig) {
 							runtime.setEvolvedConfig(updatedConfig);
@@ -588,6 +611,9 @@ async function main(): Promise<void> {
 	});
 	onShutdown("Scheduler", async () => {
 		if (scheduler) scheduler.stop();
+	});
+	onShutdown("Evolution cadence", async () => {
+		evolutionCadence?.stop();
 	});
 	onShutdown("Preview browser", async () => {
 		await closePreviewResources();


### PR DESCRIPTION
## Summary

Phase 1 and Phase 2 of the evolution rethink. Ships the Haiku conditional-firing gate and the SQLite-backed cadence batcher in one commit because they are the natural "when to fire" pair and touching the afterSession call sites in src/index.ts only once is the clean shape.

### Phase 1: conditional firing gate

A new `decideGate` routes every session through a single Haiku 4.5 call that decides whether the session shows durable learning signal. The Haiku prompt enumerates nine fire signals (user preferences, factual corrections, novel facts, infrastructure knowledge, workflow rules, hidden constraints, agent errors, task patterns, dissatisfaction reactions) and seven skip categories (routine completions, public-fact questions, clarifications, heartbeats, scheduler-originated sessions, system-originated messages, polite closers) plus five edge rules that bias toward firing on failure, negative reactions, hook blocks, tool errors, and genuine doubt.

The gate is a pure pass-through. TypeScript serialises the session metadata into a compact summary (first user message 240 chars, last user message 240 chars, last agent reply 400 chars, plus turn count, cost, tool list, channel, outcome, reactions, hook blocks, tool errors) and sends it to Haiku. Haiku decides. No pattern matching in TypeScript. On any error out of the Haiku subprocess path (timeout, parse failure, SIGKILL, unparseable JSON), the failsafe defaults to fire=true so transient failures never silently drop learning signal.

The Haiku gate call routes through `runtime.judgeQuery` which wraps the existing Phase 0 `runJudgeQuery`, inheriting the `JudgeSubprocessError` hardening and partial-cost capture without a parallel subprocess path.

Gate decisions are logged to `evolution-gate-log.jsonl` one line per decision and rolled into a `gate_stats` object on `metrics.json` so operators can measure the fire rate, the Haiku spend, and the failsafe rate over time.

### Phase 2: SQLite cadence batching

A new `evolution_queue` SQLite table persists every session that passed the gate until a cadence tick drains it. Two trigger paths converge on a single drain routine: a self-scheduling `setTimeout` cron at 180 minutes and a demand watcher that fires immediately when the queue depth crosses 5. Both paths are serialised through an in-flight guard that skips on mutex contention rather than waiting, so cron ticks never pile up behind a slow batch. Both knobs (`cadence_minutes`, `demand_trigger_depth`) are overridable via a new optional `phantom-config/meta/evolution.json` file.

A new `batch-processor.ts` is the temporary seam between the cadence and the existing per-session evolution pipeline. It iterates the drained sessions and calls `engine.runSingleSessionPipeline` per row. The seam is intentionally minimal: no strategy pattern, no configuration knobs, no abstractions that assume the Phase 3 shape. Phase 3 will replace the body of `processBatch` with a single reflection subprocess that reads the whole batch at once.

`src/index.ts` swaps its two `afterSession` call sites (the feedback path and the session-end path) to call `enqueueIfWorthy` instead. The cadence is started at boot and stopped in the existing shutdown hook list so SIGTERM properly clears the cron timer.

`metrics.json` gains a `queue_stats` object with cron / demand / manual fire counters, a mutex skip counter, a running batch size total, an average depth at drain, and p50/p95 batch duration windows over the last 100 drains.

## What this does not ship

Phase 3 (reduction from 6 judges to a single reflection subprocess, rewrite of `buildCritiqueFromObservations`, deletion of minority veto, auto-rollback, golden suite, quality judge) is explicitly deferred and lands as its own PR. Phase 4 (cleanup of dead config flags, daily cost cap, golden suite cap, auto-rollback metrics fields) is also deferred.

## Test plan

- [x] `bun test`: 1374 pass / 10 skip / 0 fail (+32 tests over main)
- [x] `bun run lint`: clean
- [x] `bun run typecheck`: clean
- [ ] Soak on a single instance for 24 hours, confirm the gate fire rate sits in a reasonable band (30 to 70 percent) under real traffic
- [ ] Confirm `queue_stats.avg_depth_at_drain` shows the demand trigger is not firing prematurely on a typical day