### PR TITLE
v0.20 PR 2: Sessions dashboard tab

### DIFF
--- a/public/dashboard/dashboard.css
+++ b/public/dashboard/dashboard.css
@@ -1735,15 +1735,15 @@ body {
 	font-size: 11px;
 	color: color-mix(in oklab, var(--color-base-content) 55%, transparent);
 }
-/* 8-color palette for segments, swatches share by index. */
-.dash-channel-bar-segment[data-channel-idx="0"], .dash-channel-bar-swatch[data-channel-idx="0"] { background: var(--color-primary); }
-.dash-channel-bar-segment[data-channel-idx="1"], .dash-channel-bar-swatch[data-channel-idx="1"] { background: var(--color-info); }
-.dash-channel-bar-segment[data-channel-idx="2"], .dash-channel-bar-swatch[data-channel-idx="2"] { background: var(--color-success); }
-.dash-channel-bar-segment[data-channel-idx="3"], .dash-channel-bar-swatch[data-channel-idx="3"] { background: var(--color-warning); }
-.dash-channel-bar-segment[data-channel-idx="4"], .dash-channel-bar-swatch[data-channel-idx="4"] { background: #a855f7; }
-.dash-channel-bar-segment[data-channel-idx="5"], .dash-channel-bar-swatch[data-channel-idx="5"] { background: #ec4899; }
-.dash-channel-bar-segment[data-channel-idx="6"], .dash-channel-bar-swatch[data-channel-idx="6"] { background: #0891b2; }
-.dash-channel-bar-segment[data-channel-idx="7"], .dash-channel-bar-swatch[data-channel-idx="7"] { background: #d97706; }
+/* 8-color palette for segments, swatches, and glyph dots share by index. */
+[data-channel-idx="0"].dash-channel-bar-segment, [data-channel-idx="0"].dash-channel-bar-swatch, [data-channel-idx="0"].dash-channel-glyph-dot { background: var(--color-primary); }
+[data-channel-idx="1"].dash-channel-bar-segment, [data-channel-idx="1"].dash-channel-bar-swatch, [data-channel-idx="1"].dash-channel-glyph-dot { background: var(--color-info); }
+[data-channel-idx="2"].dash-channel-bar-segment, [data-channel-idx="2"].dash-channel-bar-swatch, [data-channel-idx="2"].dash-channel-glyph-dot { background: var(--color-success); }
+[data-channel-idx="3"].dash-channel-bar-segment, [data-channel-idx="3"].dash-channel-bar-swatch, [data-channel-idx="3"].dash-channel-glyph-dot { background: var(--color-warning); }
+[data-channel-idx="4"].dash-channel-bar-segment, [data-channel-idx="4"].dash-channel-bar-swatch, [data-channel-idx="4"].dash-channel-glyph-dot { background: #a855f7; }
+[data-channel-idx="5"].dash-channel-bar-segment, [data-channel-idx="5"].dash-channel-bar-swatch, [data-channel-idx="5"].dash-channel-glyph-dot { background: #ec4899; }
+[data-channel-idx="6"].dash-channel-bar-segment, [data-channel-idx="6"].dash-channel-bar-swatch, [data-channel-idx="6"].dash-channel-glyph-dot { background: #0891b2; }
+[data-channel-idx="7"].dash-channel-bar-segment, [data-channel-idx="7"].dash-channel-bar-swatch, [data-channel-idx="7"].dash-channel-glyph-dot { background: #d97706; }
 
 /* ---- .dash-status-chip: generic status pill. ----------------- */
 .dash-status-chip {

--- a/public/dashboard/dashboard.css
+++ b/public/dashboard/dashboard.css
@@ -1524,3 +1524,582 @@ body {
 	color: color-mix(in oklab, var(--color-base-content) 65%, transparent);
 }
 .dash-save-bar-actions { display: flex; gap: var(--space-2); }
+
+/* ==============================================================
+   Shared dashboard primitives (v0.20 Wave 2)
+   Reused by Sessions, Cost, Scheduler, Memory, Evolution.
+   Keep generic. Tab-specific variants live at the consumer site.
+   ============================================================== */
+
+/* ---- .dash-filter-bar: horizontal filter + search row. ------- */
+.dash-filter-bar {
+	display: flex;
+	align-items: center;
+	gap: var(--space-3);
+	flex-wrap: wrap;
+	padding: var(--space-3) var(--space-4);
+	border: 1px solid var(--color-base-300);
+	border-radius: var(--radius-md);
+	background: var(--color-base-200);
+	margin-bottom: var(--space-4);
+}
+.dash-filter-group {
+	display: inline-flex;
+	align-items: center;
+	gap: var(--space-2);
+}
+.dash-filter-label {
+	font-size: 11px;
+	font-weight: 600;
+	letter-spacing: 0.04em;
+	text-transform: uppercase;
+	color: color-mix(in oklab, var(--color-base-content) 55%, transparent);
+}
+.dash-filter-select {
+	font-family: Inter, system-ui, sans-serif;
+	font-size: 13px;
+	background: var(--color-base-100);
+	color: var(--color-base-content);
+	border: 1px solid var(--color-base-300);
+	border-radius: var(--radius-sm);
+	padding: 6px 10px;
+	cursor: pointer;
+	transition: border-color var(--motion-fast) var(--ease-out), box-shadow var(--motion-base) var(--ease-out);
+}
+.dash-filter-select:hover {
+	border-color: color-mix(in oklab, var(--color-primary) 30%, var(--color-base-300));
+}
+.dash-filter-select:focus-visible {
+	outline: none;
+	border-color: var(--color-primary);
+	box-shadow: 0 0 0 3px color-mix(in oklab, var(--color-primary) 18%, transparent);
+}
+.dash-filter-search {
+	position: relative;
+	flex: 1;
+	min-width: 180px;
+	max-width: 320px;
+	margin-left: auto;
+}
+.dash-filter-search input {
+	width: 100%;
+	box-sizing: border-box;
+	font-family: Inter, sans-serif;
+	font-size: 13px;
+	background: var(--color-base-100);
+	color: var(--color-base-content);
+	border: 1px solid var(--color-base-300);
+	border-radius: var(--radius-sm);
+	padding: 7px 12px 7px 32px;
+	transition: border-color var(--motion-base) var(--ease-out), box-shadow var(--motion-base) var(--ease-out);
+}
+.dash-filter-search input:focus {
+	outline: none;
+	border-color: var(--color-primary);
+	box-shadow: 0 0 0 3px color-mix(in oklab, var(--color-primary) 18%, transparent);
+}
+.dash-filter-search svg {
+	position: absolute;
+	left: 10px;
+	top: 50%;
+	transform: translateY(-50%);
+	width: 13px;
+	height: 13px;
+	color: color-mix(in oklab, var(--color-base-content) 50%, transparent);
+	pointer-events: none;
+}
+
+/* ---- .dash-metric-strip: horizontal row of metric cards. ----- */
+.dash-metric-strip {
+	display: grid;
+	grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+	gap: var(--space-3);
+	margin-bottom: var(--space-4);
+}
+.dash-metric-card {
+	display: flex;
+	flex-direction: column;
+	gap: 6px;
+	padding: var(--space-4);
+	border: 1px solid var(--color-base-300);
+	border-radius: var(--radius-md);
+	background: var(--color-base-200);
+	min-width: 0;
+}
+.dash-metric-label {
+	font-size: 10px;
+	font-weight: 600;
+	letter-spacing: 0.09em;
+	text-transform: uppercase;
+	color: color-mix(in oklab, var(--color-base-content) 50%, transparent);
+	margin: 0;
+}
+.dash-metric-value {
+	font-family: 'Instrument Serif', Georgia, serif;
+	font-size: 28px;
+	font-weight: 500;
+	line-height: 1.05;
+	color: var(--color-base-content);
+	font-variant-numeric: tabular-nums;
+	margin: 0;
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+.dash-metric-delta {
+	font-family: 'JetBrains Mono', monospace;
+	font-size: 11px;
+	color: color-mix(in oklab, var(--color-base-content) 55%, transparent);
+	margin: 0;
+}
+.dash-metric-delta-up { color: var(--color-success); }
+.dash-metric-delta-down { color: var(--color-error); }
+
+/* Skeleton variant - inherits .dash-metric-card frame, shimmer fills. */
+.dash-metric-card.dash-metric-skeleton .dash-metric-label,
+.dash-metric-card.dash-metric-skeleton .dash-metric-value {
+	color: transparent;
+	background: linear-gradient(90deg,
+		var(--color-base-300) 25%,
+		color-mix(in oklab, var(--color-base-300) 50%, transparent) 50%,
+		var(--color-base-300) 75%);
+	background-size: 200% 100%;
+	animation: dash-shimmer 1.5s infinite;
+	border-radius: 4px;
+}
+.dash-metric-card.dash-metric-skeleton .dash-metric-label {
+	width: 48%;
+	height: 10px;
+}
+.dash-metric-card.dash-metric-skeleton .dash-metric-value {
+	width: 70%;
+	height: 24px;
+}
+
+/* ---- .dash-channel-bar: stacked horizontal segment bar. ------ */
+.dash-channel-bar {
+	display: flex;
+	flex-direction: column;
+	gap: var(--space-2);
+	padding: var(--space-3) var(--space-4);
+	border: 1px solid var(--color-base-300);
+	border-radius: var(--radius-md);
+	background: var(--color-base-200);
+	margin-bottom: var(--space-5);
+}
+.dash-channel-bar-track {
+	display: flex;
+	width: 100%;
+	height: 10px;
+	border-radius: var(--radius-pill);
+	background: color-mix(in oklab, var(--color-base-300) 60%, transparent);
+	overflow: hidden;
+}
+.dash-channel-bar-segment {
+	height: 100%;
+	min-width: 2px;
+	transition: filter var(--motion-fast) var(--ease-out);
+}
+.dash-channel-bar-segment:hover {
+	filter: brightness(1.1);
+}
+.dash-channel-bar-segment + .dash-channel-bar-segment {
+	border-left: 1px solid color-mix(in oklab, var(--color-base-100) 40%, transparent);
+}
+.dash-channel-bar-legend {
+	display: flex;
+	flex-wrap: wrap;
+	gap: var(--space-3) var(--space-4);
+}
+.dash-channel-bar-label {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	font-size: 11.5px;
+	color: color-mix(in oklab, var(--color-base-content) 70%, transparent);
+	font-variant-numeric: tabular-nums;
+}
+.dash-channel-bar-swatch {
+	width: 8px;
+	height: 8px;
+	border-radius: 2px;
+	flex-shrink: 0;
+}
+.dash-channel-bar-label-name {
+	font-weight: 500;
+	color: var(--color-base-content);
+}
+.dash-channel-bar-label-count {
+	font-family: 'JetBrains Mono', monospace;
+	font-size: 11px;
+	color: color-mix(in oklab, var(--color-base-content) 55%, transparent);
+}
+/* 8-color palette for segments, swatches share by index. */
+.dash-channel-bar-segment[data-channel-idx="0"], .dash-channel-bar-swatch[data-channel-idx="0"] { background: var(--color-primary); }
+.dash-channel-bar-segment[data-channel-idx="1"], .dash-channel-bar-swatch[data-channel-idx="1"] { background: var(--color-info); }
+.dash-channel-bar-segment[data-channel-idx="2"], .dash-channel-bar-swatch[data-channel-idx="2"] { background: var(--color-success); }
+.dash-channel-bar-segment[data-channel-idx="3"], .dash-channel-bar-swatch[data-channel-idx="3"] { background: var(--color-warning); }
+.dash-channel-bar-segment[data-channel-idx="4"], .dash-channel-bar-swatch[data-channel-idx="4"] { background: #a855f7; }
+.dash-channel-bar-segment[data-channel-idx="5"], .dash-channel-bar-swatch[data-channel-idx="5"] { background: #ec4899; }
+.dash-channel-bar-segment[data-channel-idx="6"], .dash-channel-bar-swatch[data-channel-idx="6"] { background: #0891b2; }
+.dash-channel-bar-segment[data-channel-idx="7"], .dash-channel-bar-swatch[data-channel-idx="7"] { background: #d97706; }
+
+/* ---- .dash-status-chip: generic status pill. ----------------- */
+.dash-status-chip {
+	display: inline-flex;
+	align-items: center;
+	gap: 5px;
+	font-size: 10.5px;
+	font-weight: 500;
+	letter-spacing: 0.03em;
+	text-transform: uppercase;
+	padding: 3px 8px;
+	border-radius: var(--radius-pill);
+	background: color-mix(in oklab, var(--color-base-content) 7%, transparent);
+	color: color-mix(in oklab, var(--color-base-content) 65%, transparent);
+	font-family: Inter, sans-serif;
+	white-space: nowrap;
+}
+.dash-status-chip::before {
+	content: '';
+	width: 5px;
+	height: 5px;
+	border-radius: 50%;
+	background: currentColor;
+	opacity: 0.85;
+	flex-shrink: 0;
+}
+.dash-status-chip-active {
+	background: color-mix(in oklab, var(--color-success) 14%, transparent);
+	color: var(--color-success);
+}
+.dash-status-chip-expired {
+	background: color-mix(in oklab, var(--color-base-content) 8%, transparent);
+	color: color-mix(in oklab, var(--color-base-content) 55%, transparent);
+}
+.dash-status-chip-error {
+	background: color-mix(in oklab, var(--color-error) 14%, transparent);
+	color: var(--color-error);
+}
+.dash-status-chip-paused {
+	background: color-mix(in oklab, var(--color-warning) 14%, transparent);
+	color: var(--color-warning);
+}
+.dash-status-chip-info {
+	background: color-mix(in oklab, var(--color-info) 14%, transparent);
+	color: var(--color-info);
+}
+
+/* ---- .dash-table: generic data table with sortable columns. -- */
+.dash-table-wrap {
+	border: 1px solid var(--color-base-300);
+	border-radius: var(--radius-md);
+	background: var(--color-base-200);
+	overflow: hidden;
+}
+.dash-table {
+	width: 100%;
+	border-collapse: collapse;
+	font-size: 13px;
+	font-variant-numeric: tabular-nums;
+}
+.dash-table-head {
+	background: color-mix(in oklab, var(--color-base-100) 60%, var(--color-base-200));
+	border-bottom: 1px solid var(--color-base-300);
+}
+.dash-table-head-cell {
+	text-align: left;
+	padding: 10px 14px;
+	font-size: 10.5px;
+	font-weight: 600;
+	letter-spacing: 0.09em;
+	text-transform: uppercase;
+	color: color-mix(in oklab, var(--color-base-content) 55%, transparent);
+	white-space: nowrap;
+	user-select: none;
+}
+.dash-table-head-cell[data-sortable="true"] {
+	cursor: pointer;
+	transition: color var(--motion-fast) var(--ease-out);
+}
+.dash-table-head-cell[data-sortable="true"]:hover {
+	color: var(--color-base-content);
+}
+.dash-table-head-cell[data-sort-active="true"] {
+	color: var(--color-primary);
+}
+.dash-table-sort-arrow {
+	display: inline-block;
+	margin-left: 4px;
+	font-size: 9px;
+	opacity: 0.8;
+}
+.dash-table-head-cell-numeric {
+	text-align: right;
+}
+.dash-table-row {
+	border-bottom: 1px solid color-mix(in oklab, var(--color-base-300) 55%, transparent);
+	transition: background-color var(--motion-fast) var(--ease-out);
+}
+.dash-table-row:last-child {
+	border-bottom: none;
+}
+.dash-table-row[data-clickable="true"] {
+	cursor: pointer;
+}
+.dash-table-row[data-clickable="true"]:hover {
+	background: color-mix(in oklab, var(--color-primary) 5%, transparent);
+}
+.dash-table-row:focus-visible {
+	outline: none;
+	background: color-mix(in oklab, var(--color-primary) 8%, transparent);
+	box-shadow: inset 3px 0 0 var(--color-primary);
+}
+.dash-table-cell {
+	padding: 11px 14px;
+	color: var(--color-base-content);
+	vertical-align: middle;
+}
+.dash-table-cell-numeric {
+	text-align: right;
+	font-family: 'JetBrains Mono', monospace;
+	font-size: 12.5px;
+}
+.dash-table-cell-mono {
+	font-family: 'JetBrains Mono', monospace;
+	font-size: 12px;
+	color: color-mix(in oklab, var(--color-base-content) 80%, transparent);
+	min-width: 0;
+	max-width: 280px;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+.dash-table-cell-muted {
+	color: color-mix(in oklab, var(--color-base-content) 55%, transparent);
+}
+.dash-table-empty {
+	padding: var(--space-10) var(--space-5);
+	text-align: center;
+	color: color-mix(in oklab, var(--color-base-content) 55%, transparent);
+	font-size: 13px;
+}
+.dash-table-skeleton-row td {
+	padding: 11px 14px;
+}
+.dash-table-skeleton-pill {
+	height: 12px;
+	border-radius: 6px;
+	background: linear-gradient(90deg,
+		var(--color-base-300) 25%,
+		color-mix(in oklab, var(--color-base-300) 50%, transparent) 50%,
+		var(--color-base-300) 75%);
+	background-size: 200% 100%;
+	animation: dash-shimmer 1.5s infinite;
+}
+
+/* Channel glyph + label cell (reused by Sessions channel column). */
+.dash-channel-glyph {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	font-size: 12.5px;
+	color: var(--color-base-content);
+}
+.dash-channel-glyph-dot {
+	width: 6px;
+	height: 6px;
+	border-radius: 50%;
+	flex-shrink: 0;
+}
+
+/* Mobile: table sheds lower-priority cells at 540px. */
+@media (max-width: 540px) {
+	.dash-table-hide-sm { display: none; }
+}
+
+/* ---- .dash-drawer: right-slide dialog. ----------------------- */
+@keyframes dash-drawer-in {
+	from { transform: translateX(100%); }
+	to { transform: translateX(0); }
+}
+@keyframes dash-drawer-backdrop-in {
+	from { opacity: 0; }
+	to { opacity: 1; }
+}
+.dash-drawer-backdrop {
+	position: fixed;
+	inset: 0;
+	background: color-mix(in oklab, var(--color-base-100) 70%, transparent);
+	backdrop-filter: blur(4px);
+	-webkit-backdrop-filter: blur(4px);
+	z-index: 150;
+	animation: dash-drawer-backdrop-in var(--motion-base) var(--ease-reveal);
+}
+.dash-drawer {
+	position: fixed;
+	top: 0;
+	right: 0;
+	bottom: 0;
+	width: min(560px, 52vw);
+	background: var(--color-base-100);
+	border-left: 1px solid var(--color-base-300);
+	box-shadow: -20px 0 60px rgba(0, 0, 0, 0.12), -4px 0 16px rgba(0, 0, 0, 0.05);
+	z-index: 160;
+	display: flex;
+	flex-direction: column;
+	animation: dash-drawer-in var(--motion-slow) var(--ease-reveal);
+	will-change: transform;
+}
+@media (max-width: 720px) {
+	.dash-drawer {
+		width: 100%;
+		max-width: 100%;
+	}
+}
+.dash-drawer-header {
+	display: flex;
+	align-items: flex-start;
+	justify-content: space-between;
+	gap: var(--space-4);
+	padding: var(--space-5) var(--space-5) var(--space-4);
+	border-bottom: 1px solid var(--color-base-300);
+	flex-shrink: 0;
+}
+.dash-drawer-title-wrap {
+	flex: 1;
+	min-width: 0;
+}
+.dash-drawer-eyebrow {
+	font-size: 10px;
+	font-weight: 600;
+	letter-spacing: 0.09em;
+	text-transform: uppercase;
+	color: color-mix(in oklab, var(--color-base-content) 48%, transparent);
+	margin: 0 0 6px;
+}
+.dash-drawer-title {
+	font-family: 'JetBrains Mono', monospace;
+	font-size: 14px;
+	font-weight: 500;
+	margin: 0;
+	word-break: break-all;
+	line-height: 1.3;
+}
+.dash-drawer-subtitle {
+	display: flex;
+	align-items: center;
+	gap: var(--space-2);
+	margin-top: var(--space-2);
+	font-size: 12px;
+	color: color-mix(in oklab, var(--color-base-content) 60%, transparent);
+	flex-wrap: wrap;
+}
+.dash-drawer-close {
+	flex-shrink: 0;
+	width: 32px;
+	height: 32px;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	border: 1px solid var(--color-base-300);
+	border-radius: var(--radius-sm);
+	background: var(--color-base-200);
+	color: var(--color-base-content);
+	cursor: pointer;
+	transition: border-color var(--motion-fast) var(--ease-out),
+		background-color var(--motion-fast) var(--ease-out);
+}
+.dash-drawer-close:hover {
+	border-color: color-mix(in oklab, var(--color-primary) 30%, var(--color-base-300));
+	background: color-mix(in oklab, var(--color-primary) 5%, var(--color-base-200));
+}
+.dash-drawer-close:focus-visible {
+	outline: none;
+	border-color: var(--color-primary);
+	box-shadow: 0 0 0 3px color-mix(in oklab, var(--color-primary) 18%, transparent);
+}
+.dash-drawer-close svg {
+	width: 16px;
+	height: 16px;
+}
+.dash-drawer-body {
+	flex: 1;
+	overflow-y: auto;
+	padding: var(--space-5);
+	display: flex;
+	flex-direction: column;
+	gap: var(--space-5);
+}
+.dash-drawer-section {
+	display: flex;
+	flex-direction: column;
+	gap: var(--space-3);
+}
+.dash-drawer-section-label {
+	font-size: 10px;
+	font-weight: 600;
+	letter-spacing: 0.09em;
+	text-transform: uppercase;
+	color: color-mix(in oklab, var(--color-base-content) 48%, transparent);
+	margin: 0;
+}
+.dash-drawer-kv {
+	display: grid;
+	grid-template-columns: minmax(120px, auto) 1fr;
+	gap: 8px 16px;
+	font-size: 12.5px;
+	line-height: 1.55;
+}
+.dash-drawer-kv-key {
+	font-size: 11px;
+	color: color-mix(in oklab, var(--color-base-content) 55%, transparent);
+	font-weight: 500;
+	text-transform: uppercase;
+	letter-spacing: 0.04em;
+}
+.dash-drawer-kv-value {
+	color: var(--color-base-content);
+	font-family: 'JetBrains Mono', monospace;
+	font-size: 12px;
+	word-break: break-word;
+	min-width: 0;
+}
+.dash-drawer-kv-value-plain {
+	font-family: Inter, sans-serif;
+	font-size: 13px;
+}
+.dash-drawer-footer {
+	display: flex;
+	gap: var(--space-2);
+	align-items: center;
+	padding: var(--space-4) var(--space-5);
+	border-top: 1px solid var(--color-base-300);
+	background: var(--color-base-200);
+	flex-shrink: 0;
+}
+.dash-drawer-error {
+	padding: var(--space-4);
+	border: 1px solid color-mix(in oklab, var(--color-error) 40%, var(--color-base-300));
+	border-radius: var(--radius-md);
+	background: color-mix(in oklab, var(--color-error) 5%, transparent);
+	color: color-mix(in oklab, var(--color-error) 90%, var(--color-base-content));
+	font-size: 13px;
+	line-height: 1.5;
+}
+
+/* Respect reduced motion: snap drawer in, skip shimmer. */
+@media (prefers-reduced-motion: reduce) {
+	.dash-drawer {
+		animation: none;
+	}
+	.dash-drawer-backdrop {
+		animation: none;
+	}
+	.dash-metric-card.dash-metric-skeleton .dash-metric-label,
+	.dash-metric-card.dash-metric-skeleton .dash-metric-value,
+	.dash-table-skeleton-pill {
+		animation: none;
+	}
+}

--- a/public/dashboard/dashboard.js
+++ b/public/dashboard/dashboard.js
@@ -209,11 +209,6 @@
 		if (!container) return;
 		container.setAttribute("data-active", "true");
 		var labels = {
-			sessions: {
-				eyebrow: "soon",
-				title: "Sessions",
-				body: "A live view of every session the agent has had, with channels, costs, turn counts, and outcomes. Click through for full transcripts and the memories consolidated from each run.",
-			},
 			cost: {
 				eyebrow: "soon",
 				title: "Cost",
@@ -270,8 +265,8 @@
 		var name = parsed.route;
 		deactivateAllRoutes();
 
-		var liveRoutes = ["skills", "memory-files", "plugins", "subagents", "hooks", "settings"];
-		var comingSoon = ["sessions", "cost", "scheduler", "evolution", "memory"];
+		var liveRoutes = ["skills", "memory-files", "plugins", "subagents", "hooks", "settings", "sessions"];
+		var comingSoon = ["cost", "scheduler", "evolution", "memory"];
 
 		if (liveRoutes.indexOf(name) >= 0 && routes[name]) {
 			var containerId = "route-" + name;

--- a/public/dashboard/index.html
+++ b/public/dashboard/index.html
@@ -60,15 +60,14 @@
         <svg class="dash-sidebar-icon" fill="none" viewBox="0 0 24 24" stroke-width="1.6" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M10.343 3.94c.09-.542.56-.94 1.11-.94h1.093c.55 0 1.02.398 1.11.94l.149.894c.07.424.384.764.78.93.398.164.855.142 1.205-.108l.737-.527a1.125 1.125 0 0 1 1.45.12l.773.774c.39.389.44 1.002.12 1.45l-.527.737c-.25.35-.272.806-.107 1.204.165.397.505.71.93.78l.893.15c.543.09.94.559.94 1.109v1.094c0 .55-.397 1.02-.94 1.11l-.893.149c-.425.07-.765.383-.93.78-.165.398-.143.854.107 1.204l.527.738c.32.447.269 1.06-.12 1.45l-.774.773a1.125 1.125 0 0 1-1.449.12l-.738-.527c-.35-.25-.806-.272-1.203-.107-.397.165-.71.505-.781.929l-.149.894c-.09.542-.56.94-1.11.94h-1.094c-.55 0-1.019-.398-1.11-.94l-.148-.894c-.071-.424-.384-.764-.781-.93-.398-.164-.854-.142-1.204.108l-.738.527c-.447.32-1.06.269-1.45-.12l-.773-.774a1.125 1.125 0 0 1-.12-1.45l.527-.737c.25-.35.272-.806.108-1.204-.165-.397-.506-.71-.93-.78l-.894-.15c-.542-.09-.94-.56-.94-1.109v-1.094c0-.55.398-1.02.94-1.11l.894-.149c.424-.07.765-.383.93-.78.165-.398.143-.854-.107-1.204l-.527-.738a1.125 1.125 0 0 1 .12-1.45l.773-.773a1.125 1.125 0 0 1 1.45-.12l.737.527c.35.25.807.272 1.204.107.397-.165.71-.505.78-.929l.15-.894Z"/><path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z"/></svg>
         <span>Settings</span>
       </a>
+      <a href="#/sessions" class="dash-sidebar-item" data-route="sessions">
+        <svg class="dash-sidebar-icon" fill="none" viewBox="0 0 24 24" stroke-width="1.6" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M20.25 14.15v4.098a2.25 2.25 0 0 1-2.25 2.25h-12a2.25 2.25 0 0 1-2.25-2.25V5.625a2.25 2.25 0 0 1 2.25-2.25h8.25M15.75 9l3.75-3.75m0 0L23.25 9m-3.75-3.75v9"/></svg>
+        <span>Sessions</span>
+      </a>
     </nav>
 
     <div class="dash-sidebar-eyebrow" style="margin-top:var(--space-5);">Coming soon</div>
     <nav class="dash-sidebar-nav">
-      <a href="#/sessions" class="dash-sidebar-item dash-sidebar-item-soon" data-route="sessions">
-        <svg class="dash-sidebar-icon" fill="none" viewBox="0 0 24 24" stroke-width="1.6" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M20.25 14.15v4.098a2.25 2.25 0 0 1-2.25 2.25h-12a2.25 2.25 0 0 1-2.25-2.25V5.625a2.25 2.25 0 0 1 2.25-2.25h8.25M15.75 9l3.75-3.75m0 0L23.25 9m-3.75-3.75v9"/></svg>
-        <span>Sessions</span>
-        <span class="dash-sidebar-soon-pill">soon</span>
-      </a>
       <a href="#/cost" class="dash-sidebar-item dash-sidebar-item-soon" data-route="cost">
         <svg class="dash-sidebar-icon" fill="none" viewBox="0 0 24 24" stroke-width="1.6" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M2.25 18 9 11.25l4.306 4.306a11.95 11.95 0 0 1 5.814-5.518l2.74-1.22m0 0-5.94-2.281m5.94 2.28-2.28 5.941"/></svg>
         <span>Cost</span>
@@ -104,6 +103,7 @@
     <div id="route-subagents" class="dash-route" hidden></div>
     <div id="route-hooks" class="dash-route" hidden></div>
     <div id="route-settings" class="dash-route" hidden></div>
+    <div id="route-sessions" class="dash-route" hidden></div>
     <div id="route-soon" class="dash-route" hidden></div>
   </main>
 
@@ -118,6 +118,7 @@
 <script src="/ui/dashboard/subagents.js"></script>
 <script src="/ui/dashboard/hooks.js"></script>
 <script src="/ui/dashboard/settings.js"></script>
+<script src="/ui/dashboard/sessions.js"></script>
 <script>window.PhantomDashboard.init();</script>
 </body>
 </html>

--- a/public/dashboard/sessions.js
+++ b/public/dashboard/sessions.js
@@ -1,0 +1,934 @@
+// Sessions tab: read-only view of every conversation across every channel.
+//
+// Module contract: registers with PhantomDashboard via
+// registerRoute('sessions', { mount }). mount(container, arg, ctx) is called
+// on hash change. When arg is present the detail drawer opens immediately
+// with a skeleton, then fills once the detail fetch returns.
+//
+// All values from the API flow through ctx.esc() or textContent. No data
+// concatenation into innerHTML. Operator-controlled fields include
+// conversation_id, session_key, chat title, sdk_session_id, agent name.
+
+(function () {
+	var CHANNELS = ["slack", "chat", "telegram", "email", "webhook", "scheduler", "cli", "mcp", "trigger"];
+	var COLOR_PALETTE_LENGTH = 8;
+	var SEARCH_DEBOUNCE_MS = 250;
+
+	var state = {
+		initialized: false,
+		loading: false,
+		detailLoading: false,
+		listError: null,
+		detailError: null,
+		list: null,
+		detail: null,
+		openKey: null,
+		sort: { column: "last_active_at", direction: "desc" },
+		filter: { channel: "all", days: "7", status: "all", q: "" },
+	};
+	var ctx = null;
+	var root = null;
+	var searchDebounceTimer = null;
+	var drawerRoot = null;
+	var drawerKeyHandler = null;
+	var drawerTrapHandler = null;
+	var drawerFocusRestore = null;
+	var documentKeyHandler = null;
+
+	function esc(s) { return ctx.esc(s); }
+
+	function channelGlyph(channelId) {
+		var map = {
+			slack: "\u0023", // hash
+			chat: "\u25CF", // filled circle
+			telegram: "\u2709", // envelope
+			email: "\u2709",
+			webhook: "\u21AA", // hook arrow
+			scheduler: "\u231A", // watch
+			cli: "\u203A", // prompt
+			mcp: "\u29BE", // circle with dot
+			trigger: "\u26A1", // bolt
+		};
+		return map[channelId] || "\u25A1"; // square
+	}
+
+	function channelColorIdx(channelId) {
+		var idx = CHANNELS.indexOf(channelId);
+		if (idx < 0) idx = Math.abs(hashString(channelId));
+		return idx % COLOR_PALETTE_LENGTH;
+	}
+
+	function hashString(s) {
+		var h = 0;
+		for (var i = 0; i < s.length; i++) {
+			h = ((h << 5) - h + s.charCodeAt(i)) | 0;
+		}
+		return h;
+	}
+
+	function formatCost(n) {
+		if (typeof n !== "number" || !isFinite(n)) return "$0.00";
+		if (n < 0.01 && n > 0) return "<$0.01";
+		return "$" + n.toFixed(2);
+	}
+
+	function formatInt(n) {
+		if (typeof n !== "number" || !isFinite(n)) return "0";
+		return Math.round(n).toLocaleString();
+	}
+
+	function parseSqlDate(s) {
+		if (!s) return null;
+		// SQLite "YYYY-MM-DD HH:MM:SS" is treated as UTC by phantom's storage.
+		var iso = String(s).replace(" ", "T") + "Z";
+		var d = new Date(iso);
+		if (isNaN(d.getTime())) {
+			d = new Date(s);
+			if (isNaN(d.getTime())) return null;
+		}
+		return d;
+	}
+
+	function relativeTime(s) {
+		var d = parseSqlDate(s);
+		if (!d) return "";
+		var diff = Date.now() - d.getTime();
+		if (diff < 0) diff = 0;
+		var sec = Math.floor(diff / 1000);
+		if (sec < 60) return sec + "s ago";
+		var min = Math.floor(sec / 60);
+		if (min < 60) return min + "m ago";
+		var hr = Math.floor(min / 60);
+		if (hr < 24) return hr + "h ago";
+		var day = Math.floor(hr / 24);
+		if (day < 30) return day + "d ago";
+		var mo = Math.floor(day / 30);
+		if (mo < 12) return mo + "mo ago";
+		var yr = Math.floor(day / 365);
+		return yr + "y ago";
+	}
+
+	function absoluteTime(s) {
+		var d = parseSqlDate(s);
+		if (!d) return "";
+		return d.toISOString().replace("T", " ").slice(0, 19) + " UTC";
+	}
+
+	function conversationCell(row) {
+		if (row.channel_id === "chat") {
+			var title = row.chat && row.chat.title ? row.chat.title : row.conversation_id;
+			return esc(title);
+		}
+		if (row.channel_id === "slack") {
+			var parts = String(row.conversation_id || "").split("/");
+			if (parts.length >= 2) {
+				return '<span class="phantom-muted">' + esc(parts[0]) + ' / </span>' + esc(parts.slice(1).join("/"));
+			}
+			return esc(row.conversation_id);
+		}
+		return esc(row.conversation_id);
+	}
+
+	function renderHeader() {
+		return (
+			'<div class="dash-header">' +
+			'<p class="dash-header-eyebrow">Sessions</p>' +
+			'<h1 class="dash-header-title">Sessions</h1>' +
+			'<p class="dash-header-lead">Every conversation your agent has had, across every channel. Click a row for cost events, tokens, and a jump link back to where it started.</p>' +
+			'<div class="dash-header-actions">' +
+			'<button class="dash-btn dash-btn-ghost" id="sessions-export-btn">Export CSV</button>' +
+			'</div>' +
+			'</div>'
+		);
+	}
+
+	function renderFilterBar() {
+		var channelOpts = ['<option value="all">All channels</option>'];
+		var present = {};
+		CHANNELS.forEach(function (c) {
+			present[c] = true;
+			channelOpts.push('<option value="' + esc(c) + '"' + (state.filter.channel === c ? " selected" : "") + '>' + esc(c) + '</option>');
+		});
+		if (state.list && Array.isArray(state.list.summary && state.list.summary.by_channel)) {
+			state.list.summary.by_channel.forEach(function (bc) {
+				if (!present[bc.channel_id]) {
+					present[bc.channel_id] = true;
+					channelOpts.push('<option value="' + esc(bc.channel_id) + '"' + (state.filter.channel === bc.channel_id ? " selected" : "") + '>' + esc(bc.channel_id) + '</option>');
+				}
+			});
+		}
+
+		var daysOpts = [
+			{ v: "1", l: "Last 24h" },
+			{ v: "7", l: "Last 7 days" },
+			{ v: "30", l: "Last 30 days" },
+			{ v: "90", l: "Last 90 days" },
+			{ v: "all", l: "All time" },
+		].map(function (o) {
+			return '<option value="' + o.v + '"' + (state.filter.days === o.v ? " selected" : "") + '>' + esc(o.l) + '</option>';
+		}).join("");
+
+		var statusOpts = [
+			{ v: "all", l: "All statuses" },
+			{ v: "active", l: "Active" },
+			{ v: "expired", l: "Expired" },
+		].map(function (o) {
+			return '<option value="' + o.v + '"' + (state.filter.status === o.v ? " selected" : "") + '>' + esc(o.l) + '</option>';
+		}).join("");
+
+		return (
+			'<div class="dash-filter-bar" role="group" aria-label="Session filters">' +
+			'<div class="dash-filter-group">' +
+			'<label class="dash-filter-label" for="sessions-filter-channel">Channel</label>' +
+			'<select class="dash-filter-select" id="sessions-filter-channel">' + channelOpts.join("") + '</select>' +
+			'</div>' +
+			'<div class="dash-filter-group">' +
+			'<label class="dash-filter-label" for="sessions-filter-days">Window</label>' +
+			'<select class="dash-filter-select" id="sessions-filter-days">' + daysOpts + '</select>' +
+			'</div>' +
+			'<div class="dash-filter-group">' +
+			'<label class="dash-filter-label" for="sessions-filter-status">Status</label>' +
+			'<select class="dash-filter-select" id="sessions-filter-status">' + statusOpts + '</select>' +
+			'</div>' +
+			'<div class="dash-filter-search">' +
+			'<svg fill="none" viewBox="0 0 24 24" stroke-width="1.8" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z"/></svg>' +
+			'<input type="search" id="sessions-filter-q" placeholder="Search conversation or session key" value="' + esc(state.filter.q) + '" aria-label="Search conversation or session key">' +
+			'</div>' +
+			'</div>'
+		);
+	}
+
+	function renderMetricStrip(summary) {
+		if (!summary) {
+			return (
+				'<div class="dash-metric-strip" aria-busy="true">' +
+				skeletonMetricCard() + skeletonMetricCard() + skeletonMetricCard() + skeletonMetricCard() +
+				'</div>'
+			);
+		}
+		var s = summary;
+		return (
+			'<div class="dash-metric-strip">' +
+			metricCard("Total sessions", formatInt(s.total_sessions)) +
+			metricCard("Total cost", formatCost(s.total_cost_usd || 0)) +
+			metricCard("Avg turns", (s.avg_turns || 0).toFixed(1)) +
+			metricCard("Active", formatInt(s.active_count || 0)) +
+			'</div>'
+		);
+	}
+
+	function metricCard(label, value) {
+		return (
+			'<div class="dash-metric-card">' +
+			'<p class="dash-metric-label">' + esc(label) + '</p>' +
+			'<p class="dash-metric-value">' + esc(value) + '</p>' +
+			'</div>'
+		);
+	}
+
+	function skeletonMetricCard() {
+		return (
+			'<div class="dash-metric-card dash-metric-skeleton" aria-hidden="true">' +
+			'<p class="dash-metric-label">.</p>' +
+			'<p class="dash-metric-value">.</p>' +
+			'</div>'
+		);
+	}
+
+	function renderChannelBar(summary) {
+		if (!summary) return "";
+		var by = (summary.by_channel || []).filter(function (b) { return b.count > 0; });
+		if (by.length === 0) return "";
+		var total = by.reduce(function (acc, b) { return acc + (b.count || 0); }, 0) || 1;
+		var segs = by.map(function (b) {
+			var pct = ((b.count / total) * 100).toFixed(3);
+			var idx = channelColorIdx(b.channel_id);
+			return '<div class="dash-channel-bar-segment" data-channel-idx="' + idx + '" style="width:' + pct + '%;" title="' + esc(b.channel_id + ": " + b.count) + '" aria-label="' + esc(b.channel_id + ": " + b.count + " sessions") + '"></div>';
+		}).join("");
+		var legend = by.map(function (b) {
+			var idx = channelColorIdx(b.channel_id);
+			return (
+				'<span class="dash-channel-bar-label">' +
+				'<span class="dash-channel-bar-swatch" data-channel-idx="' + idx + '"></span>' +
+				'<span class="dash-channel-bar-label-name">' + esc(b.channel_id) + '</span>' +
+				'<span class="dash-channel-bar-label-count">' + formatInt(b.count) + '</span>' +
+				'</span>'
+			);
+		}).join("");
+		return (
+			'<div class="dash-channel-bar">' +
+			'<div class="dash-channel-bar-track" role="img" aria-label="Sessions by channel">' + segs + '</div>' +
+			'<div class="dash-channel-bar-legend">' + legend + '</div>' +
+			'</div>'
+		);
+	}
+
+	function sortRows(rows) {
+		var copy = rows.slice();
+		var col = state.sort.column;
+		var dir = state.sort.direction === "asc" ? 1 : -1;
+		copy.sort(function (a, b) {
+			var av = a[col];
+			var bv = b[col];
+			if (col === "last_active_at" || col === "created_at") {
+				av = parseSqlDate(av);
+				bv = parseSqlDate(bv);
+				av = av ? av.getTime() : 0;
+				bv = bv ? bv.getTime() : 0;
+			} else if (typeof av === "string" && typeof bv === "string") {
+				av = av.toLowerCase();
+				bv = bv.toLowerCase();
+			}
+			if (av < bv) return -1 * dir;
+			if (av > bv) return 1 * dir;
+			return 0;
+		});
+		return copy;
+	}
+
+	function sortArrow(column) {
+		if (state.sort.column !== column) return "";
+		return '<span class="dash-table-sort-arrow">' + (state.sort.direction === "asc" ? "\u25B2" : "\u25BC") + "</span>";
+	}
+
+	function headCell(label, column, extraClass) {
+		var numericClass = extraClass === "numeric" ? " dash-table-head-cell-numeric" : "";
+		var hideSm = extraClass === "hide-sm" ? " dash-table-hide-sm" : "";
+		var active = state.sort.column === column ? ' data-sort-active="true"' : "";
+		return (
+			'<th class="dash-table-head-cell' + numericClass + hideSm + '" data-sortable="true" data-sort-col="' + esc(column) + '"' + active + ' scope="col" aria-sort="' + (state.sort.column === column ? state.sort.direction + "ending" : "none") + '">' +
+			esc(label) + sortArrow(column) +
+			'</th>'
+		);
+	}
+
+	function renderTable(list, loading, error) {
+		var rowsHtml;
+		if (loading && !list) {
+			rowsHtml = skeletonRows(6);
+		} else if (error) {
+			rowsHtml = '<tr><td colspan="6"><div class="dash-table-empty"><p>Could not load sessions.</p><p style="margin-top:var(--space-2);"><button class="dash-btn dash-btn-ghost dash-btn-sm" id="sessions-retry-btn">Retry</button></p></div></td></tr>';
+		} else {
+			var rows = (list && list.sessions) || [];
+			if (rows.length === 0) {
+				rowsHtml = '<tr><td colspan="6">' + renderEmptyStateInner() + '</td></tr>';
+			} else {
+				rows = sortRows(rows);
+				rowsHtml = rows.map(renderRow).join("");
+			}
+		}
+
+		return (
+			'<div class="dash-table-wrap">' +
+			'<table class="dash-table" aria-label="Sessions" aria-busy="' + (loading ? "true" : "false") + '">' +
+			'<thead class="dash-table-head"><tr>' +
+			headCell("Channel", "channel_id") +
+			headCell("Conversation", "conversation_id") +
+			headCell("Turns", "turn_count", "numeric") +
+			headCell("Cost", "total_cost_usd", "numeric") +
+			headCell("Last active", "last_active_at") +
+			headCell("Status", "status", "hide-sm") +
+			'</tr></thead>' +
+			'<tbody id="sessions-tbody">' + rowsHtml + '</tbody>' +
+			'</table>' +
+			'</div>'
+		);
+	}
+
+	function renderRow(row) {
+		var idx = channelColorIdx(row.channel_id);
+		var statusClass = row.status === "active" ? "dash-status-chip-active" : row.status === "expired" ? "dash-status-chip-expired" : "";
+		var keyAttr = encodeURIComponent(row.session_key);
+		return (
+			'<tr class="dash-table-row" data-clickable="true" data-session-key="' + esc(row.session_key) + '" data-session-key-encoded="' + esc(keyAttr) + '" tabindex="0" role="button" aria-label="Open session ' + esc(row.session_key) + '">' +
+			'<td class="dash-table-cell">' +
+			'<span class="dash-channel-glyph"><span class="dash-channel-glyph-dot" data-channel-idx="' + idx + '"></span>' + esc(row.channel_id) + '</span>' +
+			'</td>' +
+			'<td class="dash-table-cell dash-table-cell-mono">' + conversationCell(row) + '</td>' +
+			'<td class="dash-table-cell dash-table-cell-numeric">' + formatInt(row.turn_count) + '</td>' +
+			'<td class="dash-table-cell dash-table-cell-numeric">' + esc(formatCost(row.total_cost_usd)) + '</td>' +
+			'<td class="dash-table-cell dash-table-cell-muted" title="' + esc(absoluteTime(row.last_active_at)) + '">' + esc(relativeTime(row.last_active_at)) + '</td>' +
+			'<td class="dash-table-cell dash-table-hide-sm">' + (statusClass ? '<span class="dash-status-chip ' + statusClass + '">' + esc(row.status) + '</span>' : esc(row.status)) + '</td>' +
+			'</tr>'
+		);
+	}
+
+	function skeletonRows(n) {
+		var out = [];
+		for (var i = 0; i < n; i++) {
+			out.push(
+				'<tr class="dash-table-skeleton-row" aria-hidden="true">' +
+				'<td><div class="dash-table-skeleton-pill" style="width:50%;"></div></td>' +
+				'<td><div class="dash-table-skeleton-pill" style="width:80%;"></div></td>' +
+				'<td><div class="dash-table-skeleton-pill" style="width:30%; margin-left:auto;"></div></td>' +
+				'<td><div class="dash-table-skeleton-pill" style="width:40%; margin-left:auto;"></div></td>' +
+				'<td><div class="dash-table-skeleton-pill" style="width:45%;"></div></td>' +
+				'<td class="dash-table-hide-sm"><div class="dash-table-skeleton-pill" style="width:55%;"></div></td>' +
+				'</tr>',
+			);
+		}
+		return out.join("");
+	}
+
+	function renderEmptyStateInner() {
+		return (
+			'<div class="dash-empty" style="border:none; padding:var(--space-10) var(--space-5);">' +
+			'<svg class="dash-empty-icon" fill="none" viewBox="0 0 24 24" stroke-width="1.2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M20.25 14.15v4.098a2.25 2.25 0 0 1-2.25 2.25h-12a2.25 2.25 0 0 1-2.25-2.25V5.625a2.25 2.25 0 0 1 2.25-2.25h8.25M15.75 9l3.75-3.75m0 0L23.25 9m-3.75-3.75v9"/></svg>' +
+			'<h3 class="dash-empty-title">No sessions yet</h3>' +
+			'<p class="dash-empty-body">When someone messages your agent on Slack, chat, or via the CLI, each conversation shows up here with its cost, turn count, and outcome. Try clearing filters if you expected to see rows.</p>' +
+			'</div>'
+		);
+	}
+
+	function render() {
+		if (!root) return;
+		var header = renderHeader();
+		var filterBar = renderFilterBar();
+		var summary = state.list && state.list.summary ? state.list.summary : null;
+		var metricStrip = renderMetricStrip(summary);
+		var channelBar = renderChannelBar(summary);
+		var table = renderTable(state.list, state.loading, state.listError);
+		root.innerHTML = header + filterBar + metricStrip + channelBar + table;
+
+		wireFilterBar();
+		wireExport();
+		wireTableInteractions();
+	}
+
+
+	function wireFilterBar() {
+		var channelEl = document.getElementById("sessions-filter-channel");
+		var daysEl = document.getElementById("sessions-filter-days");
+		var statusEl = document.getElementById("sessions-filter-status");
+		var qEl = document.getElementById("sessions-filter-q");
+		if (channelEl) {
+			channelEl.addEventListener("change", function () {
+				state.filter.channel = channelEl.value;
+				loadList();
+			});
+		}
+		if (daysEl) {
+			daysEl.addEventListener("change", function () {
+				state.filter.days = daysEl.value;
+				loadList();
+			});
+		}
+		if (statusEl) {
+			statusEl.addEventListener("change", function () {
+				state.filter.status = statusEl.value;
+				loadList();
+			});
+		}
+		if (qEl) {
+			qEl.addEventListener("input", function () {
+				if (searchDebounceTimer) clearTimeout(searchDebounceTimer);
+				var val = qEl.value;
+				searchDebounceTimer = setTimeout(function () {
+					state.filter.q = val;
+					loadList();
+				}, SEARCH_DEBOUNCE_MS);
+			});
+		}
+	}
+
+	function wireExport() {
+		var btn = document.getElementById("sessions-export-btn");
+		if (!btn) return;
+		btn.addEventListener("click", exportCsv);
+	}
+
+	function wireTableInteractions() {
+		var tbody = document.getElementById("sessions-tbody");
+		if (tbody) {
+			var rows = tbody.querySelectorAll(".dash-table-row[data-clickable]");
+			for (var i = 0; i < rows.length; i++) {
+				var row = rows[i];
+				row.addEventListener("click", onRowActivate);
+				row.addEventListener("keydown", onRowKeyDown);
+			}
+		}
+		var retry = document.getElementById("sessions-retry-btn");
+		if (retry) retry.addEventListener("click", function () { loadList(); });
+
+		var heads = root.querySelectorAll(".dash-table-head-cell[data-sortable='true']");
+		for (var j = 0; j < heads.length; j++) {
+			var head = heads[j];
+			head.addEventListener("click", onHeadClick);
+		}
+	}
+
+	function onRowActivate(e) {
+		var row = e.currentTarget;
+		var key = row.getAttribute("data-session-key");
+		if (!key) return;
+		var encoded = row.getAttribute("data-session-key-encoded");
+		ctx.navigate("#/sessions/" + encoded);
+	}
+
+	function onRowKeyDown(e) {
+		if (e.key === "Enter" || e.key === " ") {
+			e.preventDefault();
+			onRowActivate(e);
+		}
+	}
+
+	function onHeadClick(e) {
+		var col = e.currentTarget.getAttribute("data-sort-col");
+		if (!col) return;
+		if (state.sort.column === col) {
+			state.sort.direction = state.sort.direction === "asc" ? "desc" : "asc";
+		} else {
+			state.sort.column = col;
+			state.sort.direction = col === "last_active_at" || col === "created_at" || col === "turn_count" || col === "total_cost_usd" ? "desc" : "asc";
+		}
+		renderTableOnly();
+	}
+
+	function renderTableOnly() {
+		var wrap = root.querySelector(".dash-table-wrap");
+		if (!wrap) { render(); return; }
+		var temp = document.createElement("div");
+		temp.innerHTML = renderTable(state.list, state.loading, state.listError);
+		if (temp.firstChild) wrap.parentNode.replaceChild(temp.firstChild, wrap);
+		wireTableInteractions();
+	}
+
+	// ---- List loading ----
+
+	function buildListQuery() {
+		var params = new URLSearchParams();
+		if (state.filter.channel && state.filter.channel !== "all") {
+			params.set("channel", state.filter.channel);
+		}
+		if (state.filter.days) params.set("days", state.filter.days);
+		if (state.filter.status) params.set("status", state.filter.status);
+		var q = (state.filter.q || "").trim();
+		if (q) params.set("q", q);
+		var s = params.toString();
+		return s ? "?" + s : "";
+	}
+
+	function loadList() {
+		state.loading = true;
+		state.listError = null;
+		// Re-render table to show loading state.
+		renderTableOnly();
+		return ctx.api("GET", "/ui/api/sessions" + buildListQuery()).then(function (res) {
+			state.list = res;
+			state.loading = false;
+			render();
+			// Refresh the drawer if open.
+			if (state.openKey && drawerRoot) {
+				// Drawer has its own data; no re-fetch on list refresh.
+			}
+		}).catch(function (err) {
+			state.loading = false;
+			state.listError = err;
+			state.list = null;
+			render();
+			ctx.toast("error", "Failed to load sessions", err.message || String(err));
+		});
+	}
+
+	// ---- Drawer ----
+
+	function openDrawer(sessionKey) {
+		state.openKey = sessionKey;
+		state.detailLoading = true;
+		state.detailError = null;
+		state.detail = null;
+		renderDrawer();
+		return ctx.api("GET", "/ui/api/sessions/" + encodeURIComponent(sessionKey))
+			.then(function (res) {
+				state.detailLoading = false;
+				state.detail = res;
+				if (state.openKey === sessionKey) renderDrawer();
+			})
+			.catch(function (err) {
+				state.detailLoading = false;
+				state.detailError = err;
+				state.detail = null;
+				if (state.openKey === sessionKey) renderDrawer();
+				if (err.status === 404) {
+					ctx.toast("error", "Session not found", sessionKey);
+				} else {
+					ctx.toast("error", "Failed to load session", err.message || String(err));
+				}
+			});
+	}
+
+	function closeDrawer(skipHashUpdate) {
+		state.openKey = null;
+		state.detail = null;
+		state.detailError = null;
+		removeDrawerDom();
+		if (!skipHashUpdate && window.location.hash.indexOf("#/sessions/") === 0) {
+			ctx.navigate("#/sessions");
+		}
+	}
+
+	function removeDrawerDom() {
+		if (drawerRoot && drawerRoot.parentNode) drawerRoot.parentNode.removeChild(drawerRoot);
+		drawerRoot = null;
+		if (drawerKeyHandler) document.removeEventListener("keydown", drawerKeyHandler, true);
+		drawerKeyHandler = null;
+		drawerTrapHandler = null;
+		if (drawerFocusRestore && typeof drawerFocusRestore.focus === "function") {
+			try { drawerFocusRestore.focus(); } catch (_) { /* ignore */ }
+		}
+		drawerFocusRestore = null;
+	}
+
+	function renderDrawer() {
+		if (!state.openKey) { removeDrawerDom(); return; }
+
+		var firstOpen = !drawerRoot;
+		if (firstOpen) {
+			drawerFocusRestore = document.activeElement;
+			drawerRoot = document.createElement("div");
+			drawerRoot.setAttribute("data-sessions-drawer", "true");
+			document.body.appendChild(drawerRoot);
+		}
+
+		var contentBody;
+		if (state.detailError) {
+			contentBody = (
+				'<div class="dash-drawer-body">' +
+				'<div class="dash-drawer-error">' +
+				'<p style="margin:0 0 var(--space-2); font-weight:600;">Could not load session.</p>' +
+				'<p style="margin:0 0 var(--space-3);">' + esc(state.detailError.message || String(state.detailError)) + '</p>' +
+				'<button class="dash-btn dash-btn-ghost dash-btn-sm" id="sessions-drawer-retry">Retry</button>' +
+				'</div>' +
+				'</div>'
+			);
+		} else if (!state.detail || state.detailLoading) {
+			contentBody = renderDrawerSkeleton();
+		} else {
+			contentBody = renderDrawerContent(state.detail);
+		}
+
+		var session = state.detail && state.detail.session;
+		var chip = "";
+		if (session) {
+			var cls = session.status === "active" ? "dash-status-chip-active" : session.status === "expired" ? "dash-status-chip-expired" : "";
+			chip = '<span class="dash-status-chip ' + cls + '">' + esc(session.status) + '</span>';
+		}
+
+		var channel = session ? session.channel_id : state.openKey.split(":")[0] || "";
+
+		drawerRoot.innerHTML = (
+			'<div class="dash-drawer-backdrop" data-drawer-backdrop="true" aria-hidden="true"></div>' +
+			'<aside class="dash-drawer" role="dialog" aria-modal="true" aria-labelledby="sessions-drawer-title" tabindex="-1">' +
+			'<header class="dash-drawer-header">' +
+			'<div class="dash-drawer-title-wrap">' +
+			'<p class="dash-drawer-eyebrow">Session</p>' +
+			'<h2 class="dash-drawer-title" id="sessions-drawer-title">' + esc(state.openKey) + '</h2>' +
+			'<div class="dash-drawer-subtitle">' +
+			'<span class="phantom-muted">' + esc(channel) + '</span>' +
+			(chip ? chip : "") +
+			'</div>' +
+			'</div>' +
+			'<button class="dash-drawer-close" type="button" aria-label="Close" id="sessions-drawer-close">' +
+			'<svg fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12"/></svg>' +
+			'</button>' +
+			'</header>' +
+			contentBody +
+			'</aside>'
+		);
+
+		wireDrawerInteractions();
+		if (firstOpen) trapFocus();
+	}
+
+	function renderDrawerSkeleton() {
+		var pill = '<div class="dash-table-skeleton-pill"></div>';
+		return (
+			'<div class="dash-drawer-body" aria-busy="true">' +
+			'<section class="dash-drawer-section">' +
+			'<p class="dash-drawer-section-label">Overview</p>' +
+			'<div class="dash-drawer-kv">' +
+			'<span class="dash-drawer-kv-key">Created</span><span class="dash-drawer-kv-value" style="min-width:120px; height:14px;">' + pill + '</span>' +
+			'<span class="dash-drawer-kv-key">Last active</span><span class="dash-drawer-kv-value" style="min-width:120px; height:14px;">' + pill + '</span>' +
+			'<span class="dash-drawer-kv-key">SDK session</span><span class="dash-drawer-kv-value" style="min-width:160px; height:14px;">' + pill + '</span>' +
+			'<span class="dash-drawer-kv-key">Turns</span><span class="dash-drawer-kv-value" style="min-width:60px; height:14px;">' + pill + '</span>' +
+			'<span class="dash-drawer-kv-key">Input tokens</span><span class="dash-drawer-kv-value" style="min-width:80px; height:14px;">' + pill + '</span>' +
+			'<span class="dash-drawer-kv-key">Output tokens</span><span class="dash-drawer-kv-value" style="min-width:80px; height:14px;">' + pill + '</span>' +
+			'<span class="dash-drawer-kv-key">Total cost</span><span class="dash-drawer-kv-value" style="min-width:80px; height:14px;">' + pill + '</span>' +
+			'</div>' +
+			'</section>' +
+			'<section class="dash-drawer-section">' +
+			'<p class="dash-drawer-section-label">Cost events</p>' +
+			'<div style="display:flex; flex-direction:column; gap:8px;">' +
+			pill + pill + pill +
+			'</div>' +
+			'</section>' +
+			'</div>'
+		);
+	}
+
+	function renderDrawerContent(detail) {
+		var s = detail.session;
+		var events = detail.cost_events || [];
+
+		var kv = [];
+		kv.push(kvRow("Created", absoluteTime(s.created_at), "plain"));
+		kv.push(kvRow("Last active", absoluteTime(s.last_active_at) + " (" + relativeTime(s.last_active_at) + ")", "plain"));
+		kv.push(kvRow("SDK session", s.sdk_session_id || "none"));
+		kv.push(kvRow("Turns", formatInt(s.turn_count), "plain"));
+		kv.push(kvRow("Input tokens", formatInt(s.input_tokens), "plain"));
+		kv.push(kvRow("Output tokens", formatInt(s.output_tokens), "plain"));
+		kv.push(kvRow("Total cost", formatCost(s.total_cost_usd), "plain"));
+
+		var chatSection = "";
+		if (s.chat) {
+			var c = s.chat;
+			var chatKv = [];
+			chatKv.push(kvRow("Title", c.title || "(untitled)", "plain"));
+			chatKv.push(kvRow("Messages", formatInt(c.message_count), "plain"));
+			chatKv.push(kvRow("Pinned", c.pinned ? "yes" : "no", "plain"));
+			if (c.deleted_at) chatKv.push(kvRow("Deleted", absoluteTime(c.deleted_at), "plain"));
+			if (c.forked_from_session_id) {
+				chatKv.push(kvRow("Forked from", c.forked_from_session_id + (c.forked_from_message_seq ? " #" + c.forked_from_message_seq : "")));
+			}
+			chatSection = (
+				'<section class="dash-drawer-section">' +
+				'<p class="dash-drawer-section-label">Chat</p>' +
+				'<div class="dash-drawer-kv">' + chatKv.join("") + '</div>' +
+				'</section>'
+			);
+		}
+
+		var eventsSection;
+		if (events.length === 0) {
+			eventsSection = (
+				'<section class="dash-drawer-section">' +
+				'<p class="dash-drawer-section-label">Cost events</p>' +
+				'<p style="font-size:12px; color:color-mix(in oklab, var(--color-base-content) 55%, transparent); margin:0;">No cost events recorded for this session.</p>' +
+				'</section>'
+			);
+		} else {
+			var rows = events.map(function (ev) {
+				return (
+					'<tr class="dash-table-row">' +
+					'<td class="dash-table-cell dash-table-cell-muted" title="' + esc(absoluteTime(ev.created_at)) + '">' + esc(absoluteTime(ev.created_at).slice(11, 19)) + '</td>' +
+					'<td class="dash-table-cell dash-table-cell-mono">' + esc(ev.model) + '</td>' +
+					'<td class="dash-table-cell dash-table-cell-numeric">' + formatInt(ev.input_tokens) + '</td>' +
+					'<td class="dash-table-cell dash-table-cell-numeric">' + formatInt(ev.output_tokens) + '</td>' +
+					'<td class="dash-table-cell dash-table-cell-numeric">' + esc(formatCost(ev.cost_usd)) + '</td>' +
+					'</tr>'
+				);
+			}).join("");
+			eventsSection = (
+				'<section class="dash-drawer-section">' +
+				'<p class="dash-drawer-section-label">Cost events (' + events.length + ')</p>' +
+				'<div class="dash-table-wrap">' +
+				'<table class="dash-table" aria-label="Cost events">' +
+				'<thead class="dash-table-head"><tr>' +
+				'<th class="dash-table-head-cell" scope="col">Time</th>' +
+				'<th class="dash-table-head-cell" scope="col">Model</th>' +
+				'<th class="dash-table-head-cell dash-table-head-cell-numeric" scope="col">In</th>' +
+				'<th class="dash-table-head-cell dash-table-head-cell-numeric" scope="col">Out</th>' +
+				'<th class="dash-table-head-cell dash-table-head-cell-numeric" scope="col">Cost</th>' +
+				'</tr></thead>' +
+				'<tbody>' + rows + '</tbody>' +
+				'</table>' +
+				'</div>' +
+				'</section>'
+			);
+		}
+
+		var footer = "";
+		if (s.channel_id === "slack") {
+			var parts = String(s.conversation_id || "").split("/");
+			var channelId = parts[0];
+			var ts = parts.slice(1).join("/");
+			if (channelId && ts) {
+				footer = '<a class="dash-btn dash-btn-ghost dash-btn-sm" href="slack://channel?id=' + encodeURIComponent(channelId) + '&message=' + encodeURIComponent(ts) + '">Open in Slack</a>';
+			}
+		} else if (s.channel_id === "chat") {
+			footer = '<a class="dash-btn dash-btn-ghost dash-btn-sm" href="/chat/?session=' + encodeURIComponent(s.conversation_id) + '">Open chat session</a>';
+		}
+
+		return (
+			'<div class="dash-drawer-body">' +
+			'<section class="dash-drawer-section">' +
+			'<p class="dash-drawer-section-label">Overview</p>' +
+			'<div class="dash-drawer-kv">' + kv.join("") + '</div>' +
+			'</section>' +
+			chatSection +
+			eventsSection +
+			'</div>' +
+			(footer ? '<footer class="dash-drawer-footer">' + footer + '</footer>' : "")
+		);
+	}
+
+	function kvRow(key, value, variant) {
+		var valueClass = variant === "plain" ? " dash-drawer-kv-value-plain" : "";
+		return (
+			'<span class="dash-drawer-kv-key">' + esc(key) + '</span>' +
+			'<span class="dash-drawer-kv-value' + valueClass + '">' + esc(value) + '</span>'
+		);
+	}
+
+	function wireDrawerInteractions() {
+		if (!drawerRoot) return;
+		var closeBtn = drawerRoot.querySelector("#sessions-drawer-close");
+		var backdrop = drawerRoot.querySelector("[data-drawer-backdrop]");
+		var retry = drawerRoot.querySelector("#sessions-drawer-retry");
+		if (closeBtn) closeBtn.addEventListener("click", function () { closeDrawer(false); });
+		if (backdrop) backdrop.addEventListener("click", function () { closeDrawer(false); });
+		if (retry) retry.addEventListener("click", function () {
+			if (state.openKey) openDrawer(state.openKey);
+		});
+
+		// ARIA keyboard handling: Esc closes, Tab trap cycles.
+		drawerKeyHandler = function (e) {
+			if (e.key === "Escape") {
+				e.preventDefault();
+				e.stopPropagation();
+				closeDrawer(false);
+				return;
+			}
+			if (e.key === "Tab") {
+				handleTab(e);
+			}
+		};
+		document.addEventListener("keydown", drawerKeyHandler, true);
+	}
+
+	function getFocusable() {
+		if (!drawerRoot) return [];
+		var panel = drawerRoot.querySelector(".dash-drawer");
+		if (!panel) return [];
+		var selector = 'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]):not([type="hidden"]), select:not([disabled]), [tabindex]:not([tabindex="-1"])';
+		var nodes = panel.querySelectorAll(selector);
+		var visible = [];
+		for (var i = 0; i < nodes.length; i++) {
+			var n = nodes[i];
+			if (n.offsetParent !== null || n === document.activeElement) visible.push(n);
+		}
+		return visible;
+	}
+
+	function handleTab(e) {
+		var focusable = getFocusable();
+		if (focusable.length === 0) {
+			e.preventDefault();
+			var panel = drawerRoot && drawerRoot.querySelector(".dash-drawer");
+			if (panel) panel.focus();
+			return;
+		}
+		var first = focusable[0];
+		var last = focusable[focusable.length - 1];
+		if (e.shiftKey && document.activeElement === first) {
+			e.preventDefault();
+			last.focus();
+		} else if (!e.shiftKey && document.activeElement === last) {
+			e.preventDefault();
+			first.focus();
+		}
+	}
+
+	function trapFocus() {
+		if (!drawerRoot) return;
+		var panel = drawerRoot.querySelector(".dash-drawer");
+		if (!panel) return;
+		// Move focus to the close button (first interactive element) after paint.
+		setTimeout(function () {
+			var close = drawerRoot && drawerRoot.querySelector("#sessions-drawer-close");
+			if (close) close.focus();
+			else panel.focus();
+		}, 40);
+	}
+
+	// ---- CSV export ----
+
+	function exportCsv() {
+		if (!state.list || !state.list.sessions || state.list.sessions.length === 0) {
+			ctx.toast("error", "Nothing to export", "No sessions in the current view.");
+			return;
+		}
+		var headers = ["session_key", "channel_id", "conversation_id", "status", "turn_count", "total_cost_usd", "input_tokens", "output_tokens", "created_at", "last_active_at"];
+		var rows = [headers.join(",")];
+		state.list.sessions.forEach(function (s) {
+			var fields = headers.map(function (h) {
+				var v = s[h];
+				if (v == null) return "";
+				return csvEscape(String(v));
+			});
+			rows.push(fields.join(","));
+		});
+		var csv = rows.join("\n");
+		var blob = new Blob([csv], { type: "text/csv;charset=utf-8" });
+		var url = URL.createObjectURL(blob);
+		var a = document.createElement("a");
+		a.href = url;
+		a.download = "sessions-" + new Date().toISOString().slice(0, 10) + ".csv";
+		document.body.appendChild(a);
+		a.click();
+		setTimeout(function () {
+			URL.revokeObjectURL(url);
+			if (a.parentNode) a.parentNode.removeChild(a);
+		}, 100);
+	}
+
+	function csvEscape(s) {
+		if (/[",\n\r]/.test(s)) {
+			return '"' + s.replace(/"/g, '""') + '"';
+		}
+		return s;
+	}
+
+	// ---- Global key handler ----
+
+	function installGlobalKeys() {
+		if (documentKeyHandler) return;
+		documentKeyHandler = function (e) {
+			if (e.key !== "/") return;
+			var tag = (document.activeElement && document.activeElement.tagName) || "";
+			var isTypingIn = tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT";
+			if (isTypingIn) return;
+			if (e.metaKey || e.ctrlKey || e.altKey) return;
+			var hash = window.location.hash || "";
+			if (hash.indexOf("#/sessions") !== 0) return;
+			var search = document.getElementById("sessions-filter-q");
+			if (search) {
+				e.preventDefault();
+				search.focus();
+				search.select();
+			}
+		};
+		document.addEventListener("keydown", documentKeyHandler);
+	}
+
+	// ---- Mount ----
+
+	function mount(container, arg, dashCtx) {
+		ctx = dashCtx;
+		root = container;
+		ctx.setBreadcrumb("Sessions");
+		installGlobalKeys();
+
+		// Synchronous render: chrome + skeleton for list and (if arg) drawer.
+		render();
+		if (arg) {
+			// Skeleton drawer first, then fill.
+			openDrawer(arg);
+		} else if (drawerRoot) {
+			// Arg cleared by back-nav: close any existing drawer.
+			closeDrawer(true);
+		}
+
+		// Fire list fetch.
+		return loadList().then(function () {
+			// If the deep-link requested a key that's not in the loaded list, the
+			// drawer still opens because detail has its own endpoint. That's the
+			// point of a separate detail endpoint: deep-links work even when the
+			// filter excludes the row.
+		});
+	}
+
+	if (window.PhantomDashboard && window.PhantomDashboard.registerRoute) {
+		window.PhantomDashboard.registerRoute("sessions", { mount: mount });
+	}
+})();

--- a/public/dashboard/sessions.js
+++ b/public/dashboard/sessions.js
@@ -15,7 +15,6 @@
 	var SEARCH_DEBOUNCE_MS = 250;
 
 	var state = {
-		initialized: false,
 		loading: false,
 		detailLoading: false,
 		listError: null,
@@ -31,8 +30,8 @@
 	var searchDebounceTimer = null;
 	var drawerRoot = null;
 	var drawerKeyHandler = null;
-	var drawerTrapHandler = null;
 	var drawerFocusRestore = null;
+	var prevBodyOverflow = null;
 	var documentKeyHandler = null;
 
 	function esc(s) { return ctx.esc(s); }
@@ -568,11 +567,13 @@
 	}
 
 	function removeDrawerDom() {
-		if (drawerRoot && drawerRoot.parentNode) drawerRoot.parentNode.removeChild(drawerRoot);
+		if (!drawerRoot) return;
+		if (drawerRoot.parentNode) drawerRoot.parentNode.removeChild(drawerRoot);
 		drawerRoot = null;
 		if (drawerKeyHandler) document.removeEventListener("keydown", drawerKeyHandler, true);
 		drawerKeyHandler = null;
-		drawerTrapHandler = null;
+		document.body.style.overflow = prevBodyOverflow || "";
+		prevBodyOverflow = null;
 		if (drawerFocusRestore && typeof drawerFocusRestore.focus === "function") {
 			try { drawerFocusRestore.focus(); } catch (_) { /* ignore */ }
 		}
@@ -588,6 +589,8 @@
 			drawerRoot = document.createElement("div");
 			drawerRoot.setAttribute("data-sessions-drawer", "true");
 			document.body.appendChild(drawerRoot);
+			prevBodyOverflow = document.body.style.overflow;
+			document.body.style.overflow = "hidden";
 		}
 
 		var contentBody;
@@ -781,7 +784,10 @@
 			if (state.openKey) openDrawer(state.openKey);
 		});
 
-		// ARIA keyboard handling: Esc closes, Tab trap cycles.
+		// renderDrawer fires twice per open (skeleton then content), so detach
+		// the previous keydown handler before installing a new one to prevent
+		// document-level listener accumulation across the page lifetime.
+		if (drawerKeyHandler) document.removeEventListener("keydown", drawerKeyHandler, true);
 		drawerKeyHandler = function (e) {
 			if (e.key === "Escape") {
 				e.preventDefault();

--- a/src/ui/api/__tests__/sessions.test.ts
+++ b/src/ui/api/__tests__/sessions.test.ts
@@ -1,0 +1,500 @@
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { resolve } from "node:path";
+import { MIGRATIONS } from "../../../db/schema.ts";
+import { handleUiRequest, setDashboardDb, setPublicDir } from "../../serve.ts";
+import { createSession, revokeAllSessions } from "../../session.ts";
+
+setPublicDir(resolve(import.meta.dir, "../../../../public"));
+
+let db: Database;
+let sessionToken: string;
+
+function runMigrations(target: Database): void {
+	for (const migration of MIGRATIONS) {
+		try {
+			target.run(migration);
+		} catch {
+			// ignore ALTER TABLE duplicate failures
+		}
+	}
+}
+
+function seedSession(
+	target: Database,
+	row: {
+		session_key: string;
+		sdk_session_id?: string | null;
+		channel_id: string;
+		conversation_id: string;
+		status?: string;
+		total_cost_usd?: number;
+		input_tokens?: number;
+		output_tokens?: number;
+		turn_count?: number;
+		created_at?: string;
+		last_active_at?: string;
+	},
+): void {
+	target
+		.query(
+			`INSERT INTO sessions (session_key, sdk_session_id, channel_id, conversation_id, status,
+				total_cost_usd, input_tokens, output_tokens, turn_count, created_at, last_active_at)
+				VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		)
+		.run(
+			row.session_key,
+			row.sdk_session_id ?? null,
+			row.channel_id,
+			row.conversation_id,
+			row.status ?? "active",
+			row.total_cost_usd ?? 0,
+			row.input_tokens ?? 0,
+			row.output_tokens ?? 0,
+			row.turn_count ?? 0,
+			row.created_at ?? new Date().toISOString().replace("T", " ").slice(0, 19),
+			row.last_active_at ?? new Date().toISOString().replace("T", " ").slice(0, 19),
+		);
+}
+
+function seedCostEvent(
+	target: Database,
+	row: {
+		session_key: string;
+		cost_usd: number;
+		input_tokens: number;
+		output_tokens: number;
+		model: string;
+		created_at?: string;
+	},
+): void {
+	target
+		.query(
+			`INSERT INTO cost_events (session_key, cost_usd, input_tokens, output_tokens, model, created_at)
+				VALUES (?, ?, ?, ?, ?, ?)`,
+		)
+		.run(
+			row.session_key,
+			row.cost_usd,
+			row.input_tokens,
+			row.output_tokens,
+			row.model,
+			row.created_at ?? new Date().toISOString().replace("T", " ").slice(0, 19),
+		);
+}
+
+function seedChatSession(
+	target: Database,
+	row: {
+		id: string;
+		title?: string | null;
+		message_count?: number;
+		pinned?: number;
+		deleted_at?: string | null;
+		forked_from_session_id?: string | null;
+		forked_from_message_seq?: number | null;
+	},
+): void {
+	target
+		.query(
+			`INSERT INTO chat_sessions (id, title, message_count, pinned, deleted_at,
+				forked_from_session_id, forked_from_message_seq)
+				VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		)
+		.run(
+			row.id,
+			row.title ?? null,
+			row.message_count ?? 0,
+			row.pinned ?? 0,
+			row.deleted_at ?? null,
+			row.forked_from_session_id ?? null,
+			row.forked_from_message_seq ?? null,
+		);
+}
+
+function relativeHours(h: number): string {
+	const d = new Date(Date.now() - h * 3600 * 1000);
+	return d.toISOString().replace("T", " ").slice(0, 19);
+}
+
+function relativeDays(days: number): string {
+	return relativeHours(days * 24);
+}
+
+beforeEach(() => {
+	db = new Database(":memory:");
+	runMigrations(db);
+	setDashboardDb(db);
+	sessionToken = createSession().sessionToken;
+});
+
+afterEach(() => {
+	db.close();
+	revokeAllSessions();
+});
+
+function req(path: string, init?: RequestInit): Request {
+	return new Request(`http://localhost${path}`, {
+		...init,
+		headers: {
+			Cookie: `phantom_session=${encodeURIComponent(sessionToken)}`,
+			Accept: "application/json",
+			...((init?.headers as Record<string, string>) ?? {}),
+		},
+	});
+}
+
+describe("sessions API", () => {
+	test("401 without session cookie", async () => {
+		const res = await handleUiRequest(
+			new Request("http://localhost/ui/api/sessions", { headers: { Accept: "application/json" } }),
+		);
+		expect(res.status).toBe(401);
+	});
+
+	test("GET list with no filters returns all sessions sorted by last_active_at DESC", async () => {
+		seedSession(db, {
+			session_key: "slack:C04X:100",
+			channel_id: "slack",
+			conversation_id: "C04X/100",
+			last_active_at: relativeHours(2),
+		});
+		seedSession(db, {
+			session_key: "slack:C04X:200",
+			channel_id: "slack",
+			conversation_id: "C04X/200",
+			last_active_at: relativeHours(1),
+		});
+		seedSession(db, {
+			session_key: "chat:abc",
+			channel_id: "chat",
+			conversation_id: "abc",
+			last_active_at: relativeHours(5),
+		});
+
+		const res = await handleUiRequest(req("/ui/api/sessions?days=all"));
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as { sessions: Array<{ session_key: string }> };
+		expect(body.sessions.length).toBe(3);
+		expect(body.sessions[0].session_key).toBe("slack:C04X:200");
+		expect(body.sessions[1].session_key).toBe("slack:C04X:100");
+		expect(body.sessions[2].session_key).toBe("chat:abc");
+	});
+
+	test("filter by channel=slack returns only slack rows", async () => {
+		seedSession(db, { session_key: "slack:A:1", channel_id: "slack", conversation_id: "A/1" });
+		seedSession(db, { session_key: "chat:B", channel_id: "chat", conversation_id: "B" });
+		seedSession(db, { session_key: "slack:A:2", channel_id: "slack", conversation_id: "A/2" });
+
+		const res = await handleUiRequest(req("/ui/api/sessions?channel=slack&days=all"));
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as { sessions: Array<{ channel_id: string }> };
+		expect(body.sessions.length).toBe(2);
+		expect(body.sessions.every((s) => s.channel_id === "slack")).toBe(true);
+	});
+
+	test("filter by channel=all returns all rows", async () => {
+		seedSession(db, { session_key: "slack:A:1", channel_id: "slack", conversation_id: "A/1" });
+		seedSession(db, { session_key: "chat:B", channel_id: "chat", conversation_id: "B" });
+
+		const res = await handleUiRequest(req("/ui/api/sessions?channel=all&days=all"));
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as { sessions: unknown[] };
+		expect(body.sessions.length).toBe(2);
+	});
+
+	test("filter by days=7 excludes older sessions", async () => {
+		seedSession(db, {
+			session_key: "recent",
+			channel_id: "slack",
+			conversation_id: "r",
+			last_active_at: relativeDays(2),
+		});
+		seedSession(db, {
+			session_key: "old",
+			channel_id: "slack",
+			conversation_id: "o",
+			last_active_at: relativeDays(20),
+		});
+
+		const res = await handleUiRequest(req("/ui/api/sessions?days=7"));
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as { sessions: Array<{ session_key: string }> };
+		expect(body.sessions.length).toBe(1);
+		expect(body.sessions[0].session_key).toBe("recent");
+	});
+
+	test("filter by status=active excludes expired", async () => {
+		seedSession(db, {
+			session_key: "active:1",
+			channel_id: "slack",
+			conversation_id: "a1",
+			status: "active",
+		});
+		seedSession(db, {
+			session_key: "expired:1",
+			channel_id: "slack",
+			conversation_id: "e1",
+			status: "expired",
+		});
+
+		const res = await handleUiRequest(req("/ui/api/sessions?status=active&days=all"));
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as { sessions: Array<{ status: string }> };
+		expect(body.sessions.length).toBe(1);
+		expect(body.sessions[0].status).toBe("active");
+	});
+
+	test("filter by q matches conversation_id case insensitively", async () => {
+		seedSession(db, {
+			session_key: "slack:Match:1",
+			channel_id: "slack",
+			conversation_id: "MatchThis",
+		});
+		seedSession(db, {
+			session_key: "slack:Other:1",
+			channel_id: "slack",
+			conversation_id: "OtherThread",
+		});
+
+		const res = await handleUiRequest(req("/ui/api/sessions?q=match&days=all"));
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as { sessions: Array<{ session_key: string }> };
+		expect(body.sessions.length).toBe(1);
+		expect(body.sessions[0].session_key).toBe("slack:Match:1");
+	});
+
+	test("filter by q matches session_key case insensitively", async () => {
+		seedSession(db, {
+			session_key: "NEEDLE:abc",
+			channel_id: "slack",
+			conversation_id: "abc",
+		});
+		seedSession(db, {
+			session_key: "haystack:def",
+			channel_id: "slack",
+			conversation_id: "def",
+		});
+
+		const res = await handleUiRequest(req("/ui/api/sessions?q=NEEDLE&days=all"));
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as { sessions: Array<{ session_key: string }> };
+		expect(body.sessions.length).toBe(1);
+		expect(body.sessions[0].session_key).toBe("NEEDLE:abc");
+	});
+
+	test("summary totals are correct", async () => {
+		seedSession(db, {
+			session_key: "s1",
+			channel_id: "slack",
+			conversation_id: "1",
+			total_cost_usd: 1.5,
+			turn_count: 4,
+			status: "active",
+		});
+		seedSession(db, {
+			session_key: "s2",
+			channel_id: "slack",
+			conversation_id: "2",
+			total_cost_usd: 2.5,
+			turn_count: 8,
+			status: "expired",
+		});
+		seedSession(db, {
+			session_key: "s3",
+			channel_id: "chat",
+			conversation_id: "3",
+			total_cost_usd: 1.0,
+			turn_count: 6,
+			status: "active",
+		});
+
+		const res = await handleUiRequest(req("/ui/api/sessions?days=all"));
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as {
+			summary: {
+				total_sessions: number;
+				total_cost_usd: number;
+				avg_turns: number;
+				active_count: number;
+			};
+		};
+		expect(body.summary.total_sessions).toBe(3);
+		expect(body.summary.total_cost_usd).toBeCloseTo(5.0, 2);
+		expect(body.summary.avg_turns).toBeCloseTo(6.0, 2);
+		expect(body.summary.active_count).toBe(2);
+	});
+
+	test("summary by_channel groups correctly", async () => {
+		seedSession(db, {
+			session_key: "s1",
+			channel_id: "slack",
+			conversation_id: "1",
+			total_cost_usd: 1.0,
+		});
+		seedSession(db, {
+			session_key: "s2",
+			channel_id: "slack",
+			conversation_id: "2",
+			total_cost_usd: 2.0,
+		});
+		seedSession(db, {
+			session_key: "s3",
+			channel_id: "chat",
+			conversation_id: "3",
+			total_cost_usd: 0.5,
+		});
+
+		const res = await handleUiRequest(req("/ui/api/sessions?days=all"));
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as {
+			summary: { by_channel: Array<{ channel_id: string; count: number; cost_usd: number }> };
+		};
+		const bySlack = body.summary.by_channel.find((b) => b.channel_id === "slack");
+		const byChat = body.summary.by_channel.find((b) => b.channel_id === "chat");
+		expect(bySlack).toBeDefined();
+		expect(bySlack?.count).toBe(2);
+		expect(bySlack?.cost_usd).toBeCloseTo(3.0, 2);
+		expect(byChat).toBeDefined();
+		expect(byChat?.count).toBe(1);
+		expect(byChat?.cost_usd).toBeCloseTo(0.5, 2);
+	});
+
+	test("chat enrichment: chat session returns chat object", async () => {
+		seedChatSession(db, {
+			id: "chat-abc",
+			title: "Refactoring the scheduler",
+			message_count: 12,
+			pinned: 1,
+			deleted_at: null,
+			forked_from_session_id: "chat-parent",
+			forked_from_message_seq: 3,
+		});
+		seedSession(db, {
+			session_key: "chat:chat-abc",
+			channel_id: "chat",
+			conversation_id: "chat-abc",
+		});
+
+		const res = await handleUiRequest(req("/ui/api/sessions?days=all"));
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as {
+			sessions: Array<{ channel_id: string; chat?: Record<string, unknown> }>;
+		};
+		expect(body.sessions.length).toBe(1);
+		const chatSession = body.sessions[0];
+		expect(chatSession.chat).toBeDefined();
+		expect(chatSession.chat?.title).toBe("Refactoring the scheduler");
+		expect(chatSession.chat?.message_count).toBe(12);
+		expect(chatSession.chat?.pinned).toBe(true);
+		expect(chatSession.chat?.deleted_at).toBeNull();
+		expect(chatSession.chat?.forked_from_session_id).toBe("chat-parent");
+		expect(chatSession.chat?.forked_from_message_seq).toBe(3);
+	});
+
+	test("non-chat session does NOT include chat", async () => {
+		seedSession(db, {
+			session_key: "slack:X:1",
+			channel_id: "slack",
+			conversation_id: "X/1",
+		});
+
+		const res = await handleUiRequest(req("/ui/api/sessions?days=all"));
+		const body = (await res.json()) as { sessions: Array<{ chat?: unknown }> };
+		expect(body.sessions.length).toBe(1);
+		expect(body.sessions[0].chat).toBeUndefined();
+	});
+
+	test("GET detail by session_key returns session + cost_events", async () => {
+		seedSession(db, {
+			session_key: "slack:C:1",
+			channel_id: "slack",
+			conversation_id: "C/1",
+			total_cost_usd: 0.5,
+		});
+		seedCostEvent(db, {
+			session_key: "slack:C:1",
+			cost_usd: 0.2,
+			input_tokens: 100,
+			output_tokens: 50,
+			model: "claude-opus-4-7",
+			created_at: relativeHours(3),
+		});
+		seedCostEvent(db, {
+			session_key: "slack:C:1",
+			cost_usd: 0.3,
+			input_tokens: 200,
+			output_tokens: 80,
+			model: "claude-opus-4-7",
+			created_at: relativeHours(1),
+		});
+
+		const res = await handleUiRequest(req(`/ui/api/sessions/${encodeURIComponent("slack:C:1")}`));
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as {
+			session: { session_key: string; total_cost_usd: number };
+			cost_events: Array<{ cost_usd: number }>;
+		};
+		expect(body.session.session_key).toBe("slack:C:1");
+		expect(body.cost_events.length).toBe(2);
+		// Events sorted ASC by created_at.
+		expect(body.cost_events[0].cost_usd).toBeCloseTo(0.2, 2);
+		expect(body.cost_events[1].cost_usd).toBeCloseTo(0.3, 2);
+	});
+
+	test("GET detail by missing key returns 404", async () => {
+		const res = await handleUiRequest(req(`/ui/api/sessions/${encodeURIComponent("does-not-exist")}`));
+		expect(res.status).toBe(404);
+		const body = (await res.json()) as { error: string };
+		expect(body.error).toBe("Session not found");
+	});
+
+	test("SQL injection attempt on q is parameterized", async () => {
+		seedSession(db, {
+			session_key: "normal:1",
+			channel_id: "slack",
+			conversation_id: "safe",
+		});
+		// Verify the sessions table exists before the attack.
+		const beforeCount = (db.query("SELECT COUNT(*) as n FROM sessions").get() as { n: number }).n;
+		expect(beforeCount).toBe(1);
+
+		const payload = "x'; DROP TABLE sessions; --";
+		const res = await handleUiRequest(req(`/ui/api/sessions?q=${encodeURIComponent(payload)}&days=all`));
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as { sessions: unknown[] };
+		// No rows match the literal payload.
+		expect(body.sessions.length).toBe(0);
+
+		// Critical: the sessions table still exists (the payload was treated as a literal).
+		const afterCount = (db.query("SELECT COUNT(*) as n FROM sessions").get() as { n: number }).n;
+		expect(afterCount).toBe(1);
+	});
+
+	test("invalid days value returns 422", async () => {
+		const res = await handleUiRequest(req("/ui/api/sessions?days=999"));
+		expect(res.status).toBe(422);
+	});
+
+	test("invalid status value returns 422", async () => {
+		const res = await handleUiRequest(req("/ui/api/sessions?status=bogus"));
+		expect(res.status).toBe(422);
+	});
+
+	test("q over max length returns 422", async () => {
+		const long = "a".repeat(101);
+		const res = await handleUiRequest(req(`/ui/api/sessions?q=${long}`));
+		expect(res.status).toBe(422);
+	});
+
+	test("POST on sessions returns 405", async () => {
+		const res = await handleUiRequest(
+			req("/ui/api/sessions", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: "{}",
+			}),
+		);
+		expect(res.status).toBe(405);
+	});
+});

--- a/src/ui/api/__tests__/sessions.test.ts
+++ b/src/ui/api/__tests__/sessions.test.ts
@@ -325,6 +325,25 @@ describe("sessions API", () => {
 		expect(body.summary.active_count).toBe(2);
 	});
 
+	test("summary fields are 0 (not null) when no rows match", async () => {
+		seedSession(db, { session_key: "s1", channel_id: "slack", conversation_id: "1" });
+
+		const res = await handleUiRequest(req("/ui/api/sessions?channel=email"));
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as {
+			summary: {
+				total_sessions: number;
+				total_cost_usd: number;
+				avg_turns: number;
+				active_count: number;
+			};
+		};
+		expect(body.summary.total_sessions).toBe(0);
+		expect(body.summary.total_cost_usd).toBe(0);
+		expect(body.summary.avg_turns).toBe(0);
+		expect(body.summary.active_count).toBe(0);
+	});
+
 	test("summary by_channel groups correctly", async () => {
 		seedSession(db, {
 			session_key: "s1",

--- a/src/ui/api/sessions.ts
+++ b/src/ui/api/sessions.ts
@@ -1,0 +1,290 @@
+// UI API routes for the sessions dashboard tab.
+//
+// All routes live under /ui/api/sessions and are cookie-auth gated by the
+// dispatcher in src/ui/serve.ts.
+//
+//   GET  /ui/api/sessions?channel=&days=&status=&q=   -> list + summary
+//   GET  /ui/api/sessions/:session_key                -> session + cost_events
+//
+// Read-only over the sessions, cost_events, and chat_sessions tables. No
+// writes, no audit log.
+
+import type { Database } from "bun:sqlite";
+import { z } from "zod";
+
+type SessionsApiDeps = {
+	db: Database;
+};
+
+const MAX_LIST_ROWS = 500;
+const MAX_Q_LENGTH = 100;
+
+const DaysSchema = z.union([z.literal("all"), z.coerce.number().int().min(1).max(365)]);
+
+const ListQuerySchema = z.object({
+	channel: z.string().max(64).optional(),
+	days: DaysSchema.optional(),
+	status: z.enum(["active", "expired", "all"]).optional(),
+	q: z.string().max(MAX_Q_LENGTH).optional(),
+});
+
+type ListQuery = z.infer<typeof ListQuerySchema>;
+
+type SessionRow = {
+	session_key: string;
+	sdk_session_id: string | null;
+	channel_id: string;
+	conversation_id: string;
+	status: string;
+	total_cost_usd: number;
+	input_tokens: number;
+	output_tokens: number;
+	turn_count: number;
+	created_at: string;
+	last_active_at: string;
+	chat_title: string | null;
+	chat_message_count: number | null;
+	chat_pinned: number | null;
+	chat_deleted_at: string | null;
+	chat_forked_from_session_id: string | null;
+	chat_forked_from_message_seq: number | null;
+};
+
+type EnrichedSession = {
+	session_key: string;
+	sdk_session_id: string | null;
+	channel_id: string;
+	conversation_id: string;
+	status: string;
+	total_cost_usd: number;
+	input_tokens: number;
+	output_tokens: number;
+	turn_count: number;
+	created_at: string;
+	last_active_at: string;
+	chat?: {
+		title: string | null;
+		message_count: number;
+		pinned: boolean;
+		deleted_at: string | null;
+		forked_from_session_id: string | null;
+		forked_from_message_seq: number | null;
+	};
+};
+
+function json(body: unknown, init?: ResponseInit): Response {
+	return new Response(JSON.stringify(body), {
+		...init,
+		headers: {
+			"Content-Type": "application/json",
+			"Cache-Control": "no-store",
+			...((init?.headers as Record<string, string>) ?? {}),
+		},
+	});
+}
+
+function parseListQuery(url: URL): { ok: true; value: ListQuery } | { ok: false; error: string } {
+	const raw: Record<string, string> = {};
+	const channel = url.searchParams.get("channel");
+	const days = url.searchParams.get("days");
+	const status = url.searchParams.get("status");
+	const q = url.searchParams.get("q");
+	if (channel !== null && channel !== "all" && channel.length > 0) raw.channel = channel;
+	if (days !== null && days.length > 0) raw.days = days;
+	if (status !== null && status.length > 0) raw.status = status;
+	if (q !== null) raw.q = q;
+	const parsed = ListQuerySchema.safeParse(raw);
+	if (!parsed.success) {
+		const issue = parsed.error.issues[0];
+		const path = issue.path.length > 0 ? issue.path.join(".") : "query";
+		return { ok: false, error: `${path}: ${issue.message}` };
+	}
+	return { ok: true, value: parsed.data };
+}
+
+function buildWhere(filter: ListQuery): { clauses: string[]; params: Array<string | number> } {
+	const clauses: string[] = [];
+	const params: Array<string | number> = [];
+	if (filter.channel && filter.channel !== "all") {
+		clauses.push("s.channel_id = ?");
+		params.push(filter.channel);
+	}
+	const days = filter.days ?? 7;
+	if (days !== "all") {
+		clauses.push("s.last_active_at >= datetime('now', ?)");
+		params.push(`-${days} days`);
+	}
+	const status = filter.status ?? "all";
+	if (status !== "all") {
+		clauses.push("s.status = ?");
+		params.push(status);
+	}
+	if (filter.q && filter.q.length > 0) {
+		clauses.push("(LOWER(s.conversation_id) LIKE ? OR LOWER(s.session_key) LIKE ?)");
+		const needle = `%${filter.q.toLowerCase()}%`;
+		params.push(needle, needle);
+	}
+	return { clauses, params };
+}
+
+function enrich(row: SessionRow): EnrichedSession {
+	const base: EnrichedSession = {
+		session_key: row.session_key,
+		sdk_session_id: row.sdk_session_id,
+		channel_id: row.channel_id,
+		conversation_id: row.conversation_id,
+		status: row.status,
+		total_cost_usd: row.total_cost_usd,
+		input_tokens: row.input_tokens,
+		output_tokens: row.output_tokens,
+		turn_count: row.turn_count,
+		created_at: row.created_at,
+		last_active_at: row.last_active_at,
+	};
+	if (row.channel_id === "chat" && row.chat_message_count !== null) {
+		base.chat = {
+			title: row.chat_title,
+			message_count: row.chat_message_count ?? 0,
+			pinned: row.chat_pinned === 1,
+			deleted_at: row.chat_deleted_at,
+			forked_from_session_id: row.chat_forked_from_session_id,
+			forked_from_message_seq: row.chat_forked_from_message_seq,
+		};
+	}
+	return base;
+}
+
+function listHandler(db: Database, filter: ListQuery): Response {
+	const { clauses, params } = buildWhere(filter);
+	const whereSql = clauses.length > 0 ? `WHERE ${clauses.join(" AND ")}` : "";
+
+	const listSql = `
+		SELECT
+			s.session_key, s.sdk_session_id, s.channel_id, s.conversation_id, s.status,
+			s.total_cost_usd, s.input_tokens, s.output_tokens, s.turn_count,
+			s.created_at, s.last_active_at,
+			cs.title AS chat_title,
+			cs.message_count AS chat_message_count,
+			cs.pinned AS chat_pinned,
+			cs.deleted_at AS chat_deleted_at,
+			cs.forked_from_session_id AS chat_forked_from_session_id,
+			cs.forked_from_message_seq AS chat_forked_from_message_seq
+		FROM sessions s
+		LEFT JOIN chat_sessions cs ON s.channel_id = 'chat' AND s.conversation_id = cs.id
+		${whereSql}
+		ORDER BY s.last_active_at DESC
+		LIMIT ${MAX_LIST_ROWS}
+	`;
+	const rows = db.query(listSql).all(...params) as SessionRow[];
+
+	const totalsSql = `
+		SELECT
+			COUNT(*) AS total,
+			COALESCE(SUM(s.total_cost_usd), 0) AS cost,
+			COALESCE(AVG(s.turn_count), 0) AS avg_turns,
+			SUM(CASE WHEN s.status = 'active' THEN 1 ELSE 0 END) AS active
+		FROM sessions s
+		${whereSql}
+	`;
+	const totalsRow = db.query(totalsSql).get(...params) as {
+		total: number;
+		cost: number;
+		avg_turns: number;
+		active: number;
+	};
+
+	const byChannelSql = `
+		SELECT s.channel_id AS channel_id, COUNT(*) AS count, COALESCE(SUM(s.total_cost_usd), 0) AS cost_usd
+		FROM sessions s
+		${whereSql}
+		GROUP BY s.channel_id
+		ORDER BY count DESC
+	`;
+	const byChannelRows = db.query(byChannelSql).all(...params) as Array<{
+		channel_id: string;
+		count: number;
+		cost_usd: number;
+	}>;
+
+	return json({
+		sessions: rows.map(enrich),
+		summary: {
+			total_sessions: totalsRow.total,
+			total_cost_usd: totalsRow.cost,
+			avg_turns: Number(totalsRow.avg_turns.toFixed(2)),
+			active_count: totalsRow.active,
+			by_channel: byChannelRows,
+		},
+		limits: {
+			max_list_rows: MAX_LIST_ROWS,
+		},
+	});
+}
+
+function detailHandler(db: Database, sessionKey: string): Response {
+	const sessionSql = `
+		SELECT
+			s.session_key, s.sdk_session_id, s.channel_id, s.conversation_id, s.status,
+			s.total_cost_usd, s.input_tokens, s.output_tokens, s.turn_count,
+			s.created_at, s.last_active_at,
+			cs.title AS chat_title,
+			cs.message_count AS chat_message_count,
+			cs.pinned AS chat_pinned,
+			cs.deleted_at AS chat_deleted_at,
+			cs.forked_from_session_id AS chat_forked_from_session_id,
+			cs.forked_from_message_seq AS chat_forked_from_message_seq
+		FROM sessions s
+		LEFT JOIN chat_sessions cs ON s.channel_id = 'chat' AND s.conversation_id = cs.id
+		WHERE s.session_key = ?
+	`;
+	const row = db.query(sessionSql).get(sessionKey) as SessionRow | null;
+	if (!row) {
+		return json({ error: "Session not found" }, { status: 404 });
+	}
+
+	const eventsSql = `
+		SELECT created_at, model, input_tokens, output_tokens, cost_usd
+		FROM cost_events
+		WHERE session_key = ?
+		ORDER BY created_at ASC
+	`;
+	const events = db.query(eventsSql).all(sessionKey) as Array<{
+		created_at: string;
+		model: string;
+		input_tokens: number;
+		output_tokens: number;
+		cost_usd: number;
+	}>;
+
+	return json({
+		session: enrich(row),
+		cost_events: events,
+	});
+}
+
+export async function handleSessionsApi(req: Request, url: URL, deps: SessionsApiDeps): Promise<Response | null> {
+	const pathname = url.pathname;
+
+	if (pathname === "/ui/api/sessions" && req.method === "GET") {
+		const parsed = parseListQuery(url);
+		if (!parsed.ok) return json({ error: parsed.error }, { status: 422 });
+		return listHandler(deps.db, parsed.value);
+	}
+
+	const detailMatch = pathname.match(/^\/ui\/api\/sessions\/(.+)$/);
+	if (detailMatch && req.method === "GET") {
+		let sessionKey: string;
+		try {
+			sessionKey = decodeURIComponent(detailMatch[1]);
+		} catch {
+			return json({ error: "Invalid URL-encoded session_key" }, { status: 400 });
+		}
+		return detailHandler(deps.db, sessionKey);
+	}
+
+	if (detailMatch || pathname === "/ui/api/sessions") {
+		return json({ error: "Method not allowed" }, { status: 405 });
+	}
+
+	return null;
+}

--- a/src/ui/api/sessions.ts
+++ b/src/ui/api/sessions.ts
@@ -182,7 +182,7 @@ function listHandler(db: Database, filter: ListQuery): Response {
 			COUNT(*) AS total,
 			COALESCE(SUM(s.total_cost_usd), 0) AS cost,
 			COALESCE(AVG(s.turn_count), 0) AS avg_turns,
-			SUM(CASE WHEN s.status = 'active' THEN 1 ELSE 0 END) AS active
+			COALESCE(SUM(CASE WHEN s.status = 'active' THEN 1 ELSE 0 END), 0) AS active
 		FROM sessions s
 		${whereSql}
 	`;

--- a/src/ui/serve.ts
+++ b/src/ui/serve.ts
@@ -10,6 +10,7 @@ import { getSecretRequest, saveSecrets, validateMagicToken } from "../secrets/st
 import { handleHooksApi } from "./api/hooks.ts";
 import { handleMemoryFilesApi } from "./api/memory-files.ts";
 import { type PluginsApiDeps, handlePluginsApi } from "./api/plugins.ts";
+import { handleSessionsApi } from "./api/sessions.ts";
 import { handleSettingsApi } from "./api/settings.ts";
 import { handleSkillsApi } from "./api/skills.ts";
 import { handleSubagentsApi } from "./api/subagents.ts";
@@ -211,6 +212,13 @@ export async function handleUiRequest(req: Request): Promise<Response> {
 			return Response.json({ error: "Dashboard API not initialized" }, { status: 503 });
 		}
 		const apiResponse = await handleSettingsApi(req, url, { db: dashboardDb });
+		if (apiResponse) return apiResponse;
+	}
+	if (url.pathname.startsWith("/ui/api/sessions")) {
+		if (!dashboardDb) {
+			return Response.json({ error: "Dashboard API not initialized" }, { status: 503 });
+		}
+		const apiResponse = await handleSessionsApi(req, url, { db: dashboardDb });
 		if (apiResponse) return apiResponse;
 	}
 


### PR DESCRIPTION
## Summary

Read-only Sessions dashboard tab: lists every conversation across every channel (Slack, chat, scheduler, CLI, MCP, webhook, trigger, etc.) with filters, summary strip, channel breakdown, and a detail drawer with cost events.

Also establishes the shared dashboard primitives the next four Wave 2 tabs (Cost, Scheduler, Memory, Evolution) reuse: `.dash-table`, `.dash-drawer`, `.dash-metric-strip`, `.dash-metric-card`, `.dash-channel-bar`, `.dash-status-chip`, `.dash-filter-bar`. All generic, no Sessions-specific coupling at the primitive layer.

Spec: `local/2026-04-16-v0.20-next-level/research/02-wave-2-dashboard-tabs-extended.md`

## What ships

- `GET /ui/api/sessions?channel=&days=&status=&q=` - list + summary, chat-enriched rows when `channel_id = 'chat'`
- `GET /ui/api/sessions/:session_key` - session + cost_events (404 with `{ error }` for missing keys)
- Zod-validated filters; all SQL parameterized; DROP TABLE payload test proves `q` is literal
- 19 backend tests, all existing 1,610 tests still green
- `public/dashboard/sessions.js` (self-registering module) with skeleton-first render, debounced search, sortable table, deep-link drawer, CSV export
- ARIA-correct drawer: `role="dialog"`, `aria-modal="true"`, `aria-labelledby`, focus trap, focus restore on close, Esc and backdrop close
- Keyboard: `/` focuses search when not typing elsewhere, `Esc` closes the drawer
- XSS-safe: every operator-controlled field (conversation_id, session_key, chat title, sdk_session_id) flows through `ctx.esc()` or `textContent`; no `innerHTML` concatenation with raw data
- Dark theme verified, mobile responsive (drawer full-width below 720px, table sheds the Status column below 540px)

## Test plan

- [x] `bun run lint` clean
- [x] `bun run typecheck` clean
- [x] `bun test` green (1,629 pass, 0 fail)
- [x] New `sessions.test.ts` (19 tests) covers all filter combinations, summary math, chat enrichment, SQL injection parameterization, 404, 405, 422
- [x] Visual verification against a seeded SQLite DB in a local Bun server: list, filters, sort, drawer open/close, deep-link, Esc, backdrop click, search debounce, CSV export, dark theme, mobile 380px, ARIA attributes, XSS payload rendered as literal text
- [ ] Reviewer: spot-check the drawer animation on a real agent instance with live `sessions` data
- [ ] Reviewer: confirm the shared primitives feel right for Cost to reuse (same metric strip, same channel bar as model bar)

## Out of scope

- No writes anywhere on this tab (read-only over existing data)
- No cross-tab link from Cost top-sessions yet (lands with the Cost PR)
- Pagination (the 500-row cap plus filters bounds the working set for v1)