### PR TITLE
v0.20 PR 3: Cost dashboard tab

### DIFF
--- a/public/dashboard/cost.js
+++ b/public/dashboard/cost.js
@@ -1,0 +1,642 @@
+// Cost tab: read-only view of token spend and model usage over time.
+//
+// Module contract: registers with PhantomDashboard via
+// registerRoute("cost", { mount }). mount(container, arg, ctx) is called
+// on hash change. Cost does not honor `arg` (no per-item deep link); it
+// links OUT to Sessions via #/sessions/<session_key> instead.
+//
+// All values from the API flow through ctx.esc() or textContent. Operator-
+// controlled fields include model (from cost_events), channel_id,
+// conversation_id, and session_key. Audit every interpolation.
+
+(function () {
+	var CHANNELS = ["slack", "chat", "telegram", "email", "webhook", "scheduler", "cli", "mcp", "trigger"];
+	var SERIES_PALETTE_LENGTH = 8;
+
+	var state = {
+		loading: false,
+		error: null,
+		data: null,
+		range: "30",
+		groupBy: "day",
+	};
+	var ctx = null;
+	var root = null;
+	var hoverTooltipEl = null;
+
+	function esc(s) { return ctx.esc(s); }
+
+	function formatCost(n) {
+		if (typeof n !== "number" || !isFinite(n)) return "$0.00";
+		if (n === 0) return "$0.00";
+		if (n > 0 && n < 0.01) return "<$0.01";
+		if (n >= 1000) return "$" + Math.round(n).toLocaleString();
+		return "$" + n.toFixed(2);
+	}
+
+	function formatCostShort(n) {
+		if (typeof n !== "number" || !isFinite(n)) return "$0";
+		if (n === 0) return "$0";
+		if (n >= 1000) return "$" + (n / 1000).toFixed(1) + "k";
+		if (n >= 10) return "$" + Math.round(n);
+		if (n >= 1) return "$" + n.toFixed(1);
+		return "$" + n.toFixed(2);
+	}
+
+	function formatInt(n) {
+		if (typeof n !== "number" || !isFinite(n)) return "0";
+		return Math.round(n).toLocaleString();
+	}
+
+	function formatPct(n) {
+		if (typeof n !== "number" || !isFinite(n)) return "0%";
+		var sign = n > 0 ? "+" : "";
+		return sign + n.toFixed(1) + "%";
+	}
+
+	function formatShortDate(isoDay) {
+		if (!isoDay) return "";
+		var parts = String(isoDay).split("-");
+		if (parts.length !== 3) return isoDay;
+		var months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+		var m = parseInt(parts[1], 10) - 1;
+		if (m < 0 || m > 11) return isoDay;
+		return months[m] + " " + parseInt(parts[2], 10);
+	}
+
+	function parseSqlDate(s) {
+		if (!s) return null;
+		var iso = String(s).replace(" ", "T") + "Z";
+		var d = new Date(iso);
+		if (isNaN(d.getTime())) {
+			d = new Date(s);
+			if (isNaN(d.getTime())) return null;
+		}
+		return d;
+	}
+
+	function relativeTime(s) {
+		var d = parseSqlDate(s);
+		if (!d) return "";
+		var diff = Date.now() - d.getTime();
+		if (diff < 0) diff = 0;
+		var sec = Math.floor(diff / 1000);
+		if (sec < 60) return sec + "s ago";
+		var min = Math.floor(sec / 60);
+		if (min < 60) return min + "m ago";
+		var hr = Math.floor(min / 60);
+		if (hr < 24) return hr + "h ago";
+		var day = Math.floor(hr / 24);
+		if (day < 30) return day + "d ago";
+		var mo = Math.floor(day / 30);
+		if (mo < 12) return mo + "mo ago";
+		return Math.floor(day / 365) + "y ago";
+	}
+
+	function modelLabel(model) {
+		return String(model || "").replace(/^claude-/, "").replace(/-\d+$/, "") || "unknown";
+	}
+
+	function channelColorIdx(channelId) {
+		var idx = CHANNELS.indexOf(channelId);
+		if (idx < 0) {
+			var h = 0;
+			for (var i = 0; i < channelId.length; i++) h = ((h << 5) - h + channelId.charCodeAt(i)) | 0;
+			idx = Math.abs(h);
+		}
+		return idx % SERIES_PALETTE_LENGTH;
+	}
+
+	// Build a stable model->seriesIdx map. The model with the highest total
+	// cost in the range gets idx 0 (primary color), then idx 1, etc.
+	function buildModelIndex(byModel) {
+		var map = {};
+		for (var i = 0; i < byModel.length; i++) {
+			map[byModel[i].model] = i % SERIES_PALETTE_LENGTH;
+		}
+		return map;
+	}
+
+	// Round up to a "nice" increment so y-axis ticks are human readable.
+	function niceCeil(v) {
+		if (v <= 0) return 1;
+		var pow = Math.pow(10, Math.floor(Math.log10(v)));
+		var n = v / pow;
+		var bucket = n <= 1 ? 1 : n <= 2 ? 2 : n <= 2.5 ? 2.5 : n <= 5 ? 5 : 10;
+		return bucket * pow;
+	}
+
+	// ---- Rendering ----
+
+	function renderHeader() {
+		return (
+			'<div class="dash-header">' +
+			'<p class="dash-header-eyebrow">Cost</p>' +
+			'<h1 class="dash-header-title">Cost</h1>' +
+			'<p class="dash-header-lead">Token spend and model usage over time. Drill down to the most expensive sessions to see what drove the bill.</p>' +
+			'<div class="dash-header-actions">' +
+			'<button class="dash-btn dash-btn-ghost" id="cost-export-btn">Export CSV</button>' +
+			'</div>' +
+			'</div>'
+		);
+	}
+
+	function renderFilterBar() {
+		var rangeOpts = [
+			{ v: "7", l: "Last 7 days" },
+			{ v: "30", l: "Last 30 days" },
+			{ v: "90", l: "Last 90 days" },
+			{ v: "all", l: "All time" },
+		].map(function (o) {
+			return '<option value="' + o.v + '"' + (state.range === o.v ? " selected" : "") + '>' + esc(o.l) + '</option>';
+		}).join("");
+
+		return (
+			'<div class="dash-filter-bar" role="group" aria-label="Cost filters">' +
+			'<div class="dash-filter-group">' +
+			'<label class="dash-filter-label" for="cost-filter-range">Range</label>' +
+			'<select class="dash-filter-select" id="cost-filter-range">' + rangeOpts + '</select>' +
+			'</div>' +
+			'<div class="dash-filter-group">' +
+			'<span class="dash-filter-label">Group by</span>' +
+			'<div class="dash-segmented" role="group" aria-label="Group by">' +
+			'<button type="button" id="cost-group-day" aria-pressed="' + (state.groupBy === "day" ? "true" : "false") + '">Day</button>' +
+			'<button type="button" id="cost-group-week" aria-pressed="' + (state.groupBy === "week" ? "true" : "false") + '">Week</button>' +
+			'</div>' +
+			'</div>' +
+			'</div>'
+		);
+	}
+
+	function metricCard(label, valueHtml, deltaHtml) {
+		return (
+			'<div class="dash-metric-card">' +
+			'<p class="dash-metric-label">' + esc(label) + '</p>' +
+			'<p class="dash-metric-value">' + valueHtml + '</p>' +
+			(deltaHtml ? '<p class="dash-metric-delta">' + deltaHtml + '</p>' : "") +
+			'</div>'
+		);
+	}
+
+	function deltaClass(n) {
+		return n > 0 ? "dash-metric-delta-down" : n < 0 ? "dash-metric-delta-up" : "";
+	}
+
+	function renderMetricStrip() {
+		if (!state.data) {
+			var skel = '<div class="dash-metric-card dash-metric-skeleton" aria-hidden="true"><p class="dash-metric-label">.</p><p class="dash-metric-value">.</p></div>';
+			return '<div class="dash-metric-strip" aria-busy="true">' + skel + skel + skel + skel + skel + '</div>';
+		}
+		var h = state.data.headline;
+		var dayDelta = h.yesterday === 0 && h.today === 0
+			? "No activity"
+			: '<span class="' + deltaClass(h.day_delta_pct) + '">' + esc(formatPct(h.day_delta_pct) + " vs yesterday") + '</span>';
+		var weekDelta = '<span class="' + deltaClass(h.week_delta_pct) + '">' + esc(formatPct(h.week_delta_pct) + " vs prior week") + '</span>';
+		var avgDaily = state.data.daily.length > 0
+			? state.data.daily.reduce(function (a, r) { return a + r.cost_usd; }, 0) / state.data.daily.length
+			: 0;
+		return (
+			'<div class="dash-metric-strip">' +
+			metricCard("Today", esc(formatCost(h.today)), dayDelta) +
+			metricCard("Yesterday", esc(formatCost(h.yesterday))) +
+			metricCard("This week", esc(formatCost(h.this_week)), weekDelta) +
+			metricCard("This month", esc(formatCost(h.this_month)), esc("avg " + formatCost(avgDaily) + "/d")) +
+			metricCard("All time", esc(formatCost(h.all_time))) +
+			'</div>'
+		);
+	}
+
+	// ---- Chart ----
+
+	// Bucket daily rows into Monday-start weeks when groupBy === "week".
+	function bucketByWeek(daily) {
+		if (daily.length === 0) return [];
+		var buckets = [];
+		var current = null;
+		for (var i = 0; i < daily.length; i++) {
+			var d = daily[i];
+			var dt = new Date(d.day + "T00:00:00Z");
+			var monday = new Date(dt.getTime() - ((dt.getUTCDay() + 6) % 7) * 86400000);
+			var key = monday.toISOString().slice(0, 10);
+			if (!current || current.day !== key) {
+				current = { day: key, cost_usd: 0, by_model: {} };
+				buckets.push(current);
+			}
+			current.cost_usd += d.cost_usd;
+			for (var j = 0; j < d.by_model.length; j++) {
+				var m = d.by_model[j];
+				current.by_model[m.model] = (current.by_model[m.model] || 0) + m.cost_usd;
+			}
+		}
+		return buckets.map(function (b) {
+			var arr = Object.keys(b.by_model).map(function (k) { return { model: k, cost_usd: b.by_model[k] }; });
+			arr.sort(function (a, b2) { return b2.cost_usd - a.cost_usd; });
+			return { day: b.day, cost_usd: b.cost_usd, by_model: arr };
+		});
+	}
+
+	// Generic stacked-bar SVG renderer. opts.rows is an array of
+	// { day, segments: [{ value, seriesIdx }] }. Returns SVG markup; the
+	// caller wires up hover on .dash-chart-bar-hit after it lands in DOM.
+	function renderStackedBarChart(opts) {
+		var rows = opts.rows;
+		var width = opts.width;
+		var height = opts.height;
+		var formatY = opts.formatY || function (n) { return String(n); };
+		var padL = 46, padR = 12, padT = 8, padB = 28;
+		var innerW = Math.max(1, width - padL - padR);
+		var innerH = Math.max(1, height - padT - padB);
+
+		if (rows.length === 0) {
+			return '<svg class="dash-chart-svg" viewBox="0 0 ' + width + ' ' + height + '"></svg>';
+		}
+
+		var maxTotal = 0;
+		for (var i = 0; i < rows.length; i++) {
+			var t = 0;
+			for (var k = 0; k < rows[i].segments.length; k++) t += rows[i].segments[k].value;
+			if (t > maxTotal) maxTotal = t;
+		}
+		var yMax = niceCeil(maxTotal || 0.01);
+		var ticks = 4;
+
+		var parts = ['<svg class="dash-chart-svg" viewBox="0 0 ' + width + ' ' + height + '" preserveAspectRatio="none" role="img" aria-label="Stacked bar chart">'];
+
+		for (var tk = 0; tk <= ticks; tk++) {
+			var yv = (yMax * tk) / ticks;
+			var yP = padT + innerH - (yv / yMax) * innerH;
+			parts.push('<line class="dash-chart-gridline" x1="' + padL + '" y1="' + yP + '" x2="' + (padL + innerW) + '" y2="' + yP + '"/>');
+			parts.push('<text class="dash-chart-tick-label" x="' + (padL - 6) + '" y="' + (yP + 3) + '" text-anchor="end">' + esc(formatY(yv)) + '</text>');
+		}
+		parts.push('<line class="dash-chart-axis" x1="' + padL + '" y1="' + (padT + innerH) + '" x2="' + (padL + innerW) + '" y2="' + (padT + innerH) + '"/>');
+
+		var gap = rows.length > 60 ? 1 : rows.length > 30 ? 2 : 3;
+		var barW = Math.max(2, (innerW - gap * (rows.length - 1)) / rows.length);
+		var labelEvery = Math.max(1, Math.ceil(rows.length / 8));
+
+		for (var b = 0; b < rows.length; b++) {
+			var row = rows[b];
+			var x = padL + b * (barW + gap);
+			var cursorY = padT + innerH;
+			var group = '<g class="dash-chart-bar-group" data-bar-index="' + b + '">';
+			for (var s = 0; s < row.segments.length; s++) {
+				var seg = row.segments[s];
+				if (seg.value <= 0) continue;
+				var segH = (seg.value / yMax) * innerH;
+				cursorY -= segH;
+				group += '<rect class="dash-chart-bar" data-series-idx="' + (seg.seriesIdx % SERIES_PALETTE_LENGTH) + '" x="' + x + '" y="' + cursorY + '" width="' + barW + '" height="' + segH + '"></rect>';
+			}
+			group += '<rect class="dash-chart-bar-hit" data-bar-index="' + b + '" x="' + x + '" y="' + padT + '" width="' + barW + '" height="' + innerH + '" fill="transparent" pointer-events="all"></rect></g>';
+			parts.push(group);
+			if (b % labelEvery === 0 || b === rows.length - 1) {
+				parts.push('<text class="dash-chart-tick-label" x="' + (x + barW / 2) + '" y="' + (padT + innerH + 14) + '" text-anchor="middle">' + esc(formatShortDate(row.day)) + '</text>');
+			}
+		}
+		parts.push('</svg>');
+		return parts.join("");
+	}
+
+	function chartFrame(title, id, body) {
+		var idAttr = id ? ' id="' + id + '"' : "";
+		return (
+			'<div class="dash-chart"' + idAttr + '>' +
+			'<div class="dash-chart-header"><p class="dash-chart-title">' + esc(title) + '</p></div>' +
+			body +
+			'</div>'
+		);
+	}
+
+	function renderChart() {
+		var title = state.groupBy === "week" ? "Weekly spend" : "Daily spend";
+		if (state.loading && !state.data) {
+			return chartFrame(title, "", '<div class="dash-chart-skeleton" aria-hidden="true"></div>');
+		}
+		if (!state.data || state.data.daily.length === 0) {
+			return chartFrame(title, "", '<div class="dash-chart-empty">No cost events in this range yet.</div>');
+		}
+		var modelIdx = buildModelIndex(state.data.by_model);
+		var source = state.groupBy === "week" ? bucketByWeek(state.data.daily) : state.data.daily;
+		var chartRows = source.map(function (d) {
+			return {
+				day: d.day,
+				segments: d.by_model.map(function (m) {
+					return { value: m.cost_usd, seriesIdx: modelIdx[m.model] || 0 };
+				}),
+			};
+		});
+		var svg = renderStackedBarChart({
+			rows: chartRows,
+			width: Math.max(640, chartRows.length * 24),
+			height: 260,
+			formatY: formatCostShort,
+		});
+		return chartFrame(title, "cost-chart",
+			'<div class="dash-chart-scroll">' + svg + '</div>' +
+			'<div class="dash-chart-tooltip" id="cost-chart-tooltip" aria-hidden="true"></div>');
+	}
+
+	// Generic table shell: headers declare label + class, rows is raw HTML.
+	// When rows is "" renders an empty-state row spanning all columns.
+	function renderTable(label, headers, rowsHtml, emptyMsg, bodyId) {
+		var headHtml = headers.map(function (h) {
+			var cls = "dash-table-head-cell" + (h.numeric ? " dash-table-head-cell-numeric" : "");
+			return '<th class="' + cls + '" scope="col">' + esc(h.label) + '</th>';
+		}).join("");
+		var body = rowsHtml
+			? rowsHtml
+			: '<tr><td colspan="' + headers.length + '" class="dash-table-empty">' + esc(emptyMsg) + '</td></tr>';
+		var bodyAttr = bodyId ? ' id="' + bodyId + '"' : "";
+		return (
+			'<div class="dash-table-wrap">' +
+			'<table class="dash-table" aria-label="' + esc(label) + '">' +
+			'<thead class="dash-table-head"><tr>' + headHtml + '</tr></thead>' +
+			'<tbody' + bodyAttr + '>' + body + '</tbody>' +
+			'</table>' +
+			'</div>'
+		);
+	}
+
+	function renderByModel() {
+		var headers = [
+			{ label: "Model" },
+			{ label: "Cost", numeric: true },
+			{ label: "Share", numeric: true },
+		];
+		if (!state.data) return renderTable("By model", headers, "", "Loading.");
+		var rows = state.data.by_model;
+		if (rows.length === 0) return renderTable("By model", headers, "", "No models in this range.");
+		var modelIdx = buildModelIndex(rows);
+		var body = rows.map(function (r) {
+			return (
+				'<tr class="dash-table-row">' +
+				'<td class="dash-table-cell">' +
+				'<span class="dash-breakdown-swatch" data-series-idx="' + (modelIdx[r.model] || 0) + '"></span>' +
+				'<span class="dash-table-cell-mono">' + esc(modelLabel(r.model)) + '</span>' +
+				'</td>' +
+				'<td class="dash-table-cell dash-table-cell-numeric">' + esc(formatCost(r.cost_usd)) + '</td>' +
+				'<td class="dash-table-cell dash-table-cell-numeric">' + esc((r.pct * 100).toFixed(1) + "%") + '</td>' +
+				'</tr>'
+			);
+		}).join("");
+		return renderTable("By model", headers, body);
+	}
+
+	function channelCell(channelId) {
+		return '<span class="dash-channel-glyph"><span class="dash-channel-glyph-dot" data-channel-idx="' + channelColorIdx(channelId) + '"></span>' + esc(channelId) + '</span>';
+	}
+
+	function conversationCell(row) {
+		if (row.channel_id === "slack") {
+			var parts = String(row.conversation_id || "").split("/");
+			if (parts.length >= 2) {
+				return '<span class="phantom-muted">' + esc(parts[0]) + ' / </span>' + esc(parts.slice(1).join("/"));
+			}
+		}
+		return esc(row.conversation_id);
+	}
+
+	function renderByChannel() {
+		var headers = [{ label: "Channel" }, { label: "Cost", numeric: true }, { label: "Per session", numeric: true }];
+		if (!state.data) return renderTable("By channel", headers, "", "Loading.");
+		var rows = state.data.by_channel;
+		if (rows.length === 0) return renderTable("By channel", headers, "", "No channels in this range.");
+		var body = rows.map(function (r) {
+			return (
+				'<tr class="dash-table-row">' +
+				'<td class="dash-table-cell">' + channelCell(r.channel_id) + '</td>' +
+				'<td class="dash-table-cell dash-table-cell-numeric">' + esc(formatCost(r.cost_usd)) + '</td>' +
+				'<td class="dash-table-cell dash-table-cell-numeric">' + esc(formatCost(r.avg_per_session)) + '</td>' +
+				'</tr>'
+			);
+		}).join("");
+		return renderTable("By channel", headers, body);
+	}
+
+	function renderTopSessions() {
+		var headers = [
+			{ label: "Channel" },
+			{ label: "Conversation" },
+			{ label: "Cost", numeric: true },
+			{ label: "Turns", numeric: true },
+			{ label: "Last active" },
+		];
+		var rows = state.data ? state.data.top_sessions : null;
+		if (!rows) return renderTable("Top sessions", headers, "", "Loading.", "cost-top-tbody");
+		if (rows.length === 0) return renderTable("Top sessions", headers, "", "No sessions in this range.", "cost-top-tbody");
+		var body = rows.map(function (r) {
+			var keyAttr = encodeURIComponent(r.session_key);
+			return (
+				'<tr class="dash-table-row" data-clickable="true" data-session-key="' + esc(r.session_key) + '" data-session-key-encoded="' + esc(keyAttr) + '" tabindex="0" role="button" aria-label="Open session ' + esc(r.session_key) + '">' +
+				'<td class="dash-table-cell">' + channelCell(r.channel_id) + '</td>' +
+				'<td class="dash-table-cell dash-table-cell-mono">' + conversationCell(r) + '</td>' +
+				'<td class="dash-table-cell dash-table-cell-numeric">' + esc(formatCost(r.total_cost_usd)) + '</td>' +
+				'<td class="dash-table-cell dash-table-cell-numeric">' + formatInt(r.turn_count) + '</td>' +
+				'<td class="dash-table-cell dash-table-cell-muted">' + esc(relativeTime(r.last_active_at)) + '</td>' +
+				'</tr>'
+			);
+		}).join("");
+		return renderTable("Top sessions", headers, body, "", "cost-top-tbody");
+	}
+
+	function renderError() {
+		return (
+			'<div class="dash-empty" style="margin-bottom: var(--space-5);">' +
+			'<h3 class="dash-empty-title">Could not load cost data</h3>' +
+			'<p class="dash-empty-body">' + esc((state.error && state.error.message) || "Unknown error") + '</p>' +
+			'<button class="dash-btn dash-btn-ghost" id="cost-retry-btn">Retry</button>' +
+			'</div>'
+		);
+	}
+
+	function sectionLabel(text) {
+		return '<p class="dash-drawer-section-label" style="margin-bottom: var(--space-2);">' + esc(text) + '</p>';
+	}
+
+	function render() {
+		if (!root) return;
+		if (state.error) {
+			root.innerHTML = renderHeader() + renderFilterBar() + renderError();
+			wireFilterBar();
+			var r = document.getElementById("cost-retry-btn");
+			if (r) r.addEventListener("click", load);
+			return;
+		}
+		root.innerHTML = (
+			renderHeader() + renderFilterBar() + renderMetricStrip() + renderChart() +
+			'<div class="dash-breakdown-grid">' +
+			'<section>' + sectionLabel("By model") + renderByModel() + '</section>' +
+			'<section>' + sectionLabel("By channel") + renderByChannel() + '</section>' +
+			'</div>' +
+			'<section style="margin-bottom: var(--space-5);">' + sectionLabel("Top 10 sessions") + renderTopSessions() + '</section>'
+		);
+		wireFilterBar();
+		wireChart();
+		wireTopSessions();
+		wireExport();
+	}
+
+	// ---- Wiring ----
+
+	function wireFilterBar() {
+		var range = document.getElementById("cost-filter-range");
+		if (range) range.addEventListener("change", function () {
+			state.range = range.value;
+			load();
+		});
+		var d = document.getElementById("cost-group-day");
+		var w = document.getElementById("cost-group-week");
+		if (d) d.addEventListener("click", function () {
+			if (state.groupBy === "day") return;
+			state.groupBy = "day";
+			render();
+		});
+		if (w) w.addEventListener("click", function () {
+			if (state.groupBy === "week") return;
+			state.groupBy = "week";
+			render();
+		});
+	}
+
+	function wireTopSessions() {
+		var tbody = document.getElementById("cost-top-tbody");
+		if (!tbody) return;
+		var rows = tbody.querySelectorAll(".dash-table-row[data-clickable]");
+		for (var i = 0; i < rows.length; i++) {
+			rows[i].addEventListener("click", onRowActivate);
+			rows[i].addEventListener("keydown", onRowKeyDown);
+		}
+	}
+
+	function onRowActivate(e) {
+		var encoded = e.currentTarget.getAttribute("data-session-key-encoded");
+		if (encoded) ctx.navigate("#/sessions/" + encoded);
+	}
+
+	function onRowKeyDown(e) {
+		if (e.key === "Enter" || e.key === " ") { e.preventDefault(); onRowActivate(e); }
+	}
+
+	function wireExport() {
+		var btn = document.getElementById("cost-export-btn");
+		if (btn) btn.addEventListener("click", exportCsv);
+	}
+
+	function wireChart() {
+		var chart = document.getElementById("cost-chart");
+		if (!chart || !state.data) return;
+		hoverTooltipEl = document.getElementById("cost-chart-tooltip");
+		var hits = chart.querySelectorAll(".dash-chart-bar-hit");
+		var source = state.groupBy === "week" ? bucketByWeek(state.data.daily) : state.data.daily;
+		var modelIdx = buildModelIndex(state.data.by_model);
+		for (var i = 0; i < hits.length; i++) {
+			(function (hit) {
+				hit.addEventListener("mouseenter", function (e) { showTooltip(e, hit, source, modelIdx); });
+				hit.addEventListener("mousemove", function (e) { positionTooltip(e, hit); });
+				hit.addEventListener("mouseleave", hideTooltip);
+			})(hits[i]);
+		}
+	}
+
+	function showTooltip(evt, hit, source, modelIdx) {
+		if (!hoverTooltipEl) return;
+		var idx = parseInt(hit.getAttribute("data-bar-index"), 10);
+		if (isNaN(idx) || !source[idx]) return;
+		var row = source[idx];
+		var title = (state.groupBy === "week" ? "Week of " : "") + formatShortDate(row.day);
+		var segRows = row.by_model.map(function (m) {
+			var mi = (modelIdx[m.model] || 0) % SERIES_PALETTE_LENGTH;
+			return (
+				'<div class="dash-chart-tooltip-row">' +
+				'<span class="dash-chart-tooltip-swatch" data-series-idx="' + mi + '"></span>' +
+				'<span>' + esc(modelLabel(m.model)) + '</span>' +
+				'<span style="margin-left:auto;">' + esc(formatCost(m.cost_usd)) + '</span>' +
+				'</div>'
+			);
+		}).join("");
+		hoverTooltipEl.innerHTML = (
+			'<p class="dash-chart-tooltip-title">' + esc(title) + '</p>' +
+			segRows +
+			'<p class="dash-chart-tooltip-total">Total ' + esc(formatCost(row.cost_usd)) + '</p>'
+		);
+		hoverTooltipEl.setAttribute("data-visible", "true");
+		positionTooltip(evt, hit);
+	}
+
+	function positionTooltip(_evt, hit) {
+		if (!hoverTooltipEl) return;
+		var chart = document.getElementById("cost-chart");
+		if (!chart) return;
+		var rect = chart.getBoundingClientRect();
+		var hitRect = hit.getBoundingClientRect();
+		var cx = hitRect.left + hitRect.width / 2 - rect.left;
+		var half = (hoverTooltipEl.offsetWidth || 200) / 2;
+		if (cx - half < 6) cx = half + 6;
+		if (cx + half > rect.width - 6) cx = rect.width - half - 6;
+		hoverTooltipEl.style.left = cx + "px";
+		hoverTooltipEl.style.top = Math.max(0, hitRect.top - rect.top) + "px";
+	}
+
+	function hideTooltip() {
+		if (hoverTooltipEl) hoverTooltipEl.setAttribute("data-visible", "false");
+	}
+
+	// ---- Load ----
+
+	function load() {
+		state.loading = true;
+		state.error = null;
+		render();
+		var url = "/ui/api/cost?days=" + encodeURIComponent(state.range);
+		return ctx.api("GET", url).then(function (res) {
+			state.data = res;
+			state.loading = false;
+			render();
+		}).catch(function (err) {
+			state.loading = false;
+			state.error = err;
+			state.data = null;
+			render();
+			ctx.toast("error", "Failed to load cost data", err.message || String(err));
+		});
+	}
+
+	// ---- CSV export ----
+
+	function exportCsv() {
+		if (!state.data || state.data.daily.length === 0) {
+			ctx.toast("error", "Nothing to export", "No cost data in the current range.");
+			return;
+		}
+		var headers = ["day", "cost_usd", "input_tokens", "output_tokens"];
+		var rows = [headers.join(",")];
+		state.data.daily.forEach(function (d) {
+			rows.push([d.day, d.cost_usd.toFixed(6), d.input_tokens, d.output_tokens].join(","));
+		});
+		var csv = rows.join("\n");
+		var blob = new Blob([csv], { type: "text/csv;charset=utf-8" });
+		var url = URL.createObjectURL(blob);
+		var a = document.createElement("a");
+		a.href = url;
+		a.download = "cost-" + new Date().toISOString().slice(0, 10) + ".csv";
+		document.body.appendChild(a);
+		a.click();
+		setTimeout(function () {
+			URL.revokeObjectURL(url);
+			if (a.parentNode) a.parentNode.removeChild(a);
+		}, 100);
+	}
+
+	// ---- Mount ----
+
+	function mount(container, _arg, dashCtx) {
+		ctx = dashCtx;
+		root = container;
+		ctx.setBreadcrumb("Cost");
+		render();
+		return load();
+	}
+
+	if (window.PhantomDashboard && window.PhantomDashboard.registerRoute) {
+		window.PhantomDashboard.registerRoute("cost", { mount: mount });
+	}
+})();

--- a/public/dashboard/dashboard.css
+++ b/public/dashboard/dashboard.css
@@ -2112,7 +2112,10 @@ body {
 .dash-chart-svg {
 	display: block;
 	width: 100%;
-	min-width: 320px;
+	/* Floor at 540px so narrow viewports trigger the .dash-chart-scroll
+	   horizontal scroll instead of squashing the bars and tick labels via
+	   preserveAspectRatio="none". */
+	min-width: 540px;
 	height: auto;
 	font-family: 'JetBrains Mono', ui-monospace, monospace;
 }

--- a/public/dashboard/dashboard.css
+++ b/public/dashboard/dashboard.css
@@ -2089,17 +2089,156 @@ body {
 	line-height: 1.5;
 }
 
+/* ---- .dash-chart: generic SVG chart primitive. Used by Cost for the
+   stacked bar; Evolution reuses it as a sparkline. Series fills come
+   from [data-series-idx] below so dark/light themes track automatically. */
+.dash-chart {
+	position: relative;
+	padding: var(--space-4);
+	border: 1px solid var(--color-base-300);
+	border-radius: var(--radius-md);
+	background: var(--color-base-200);
+	margin-bottom: var(--space-5);
+}
+.dash-chart-header {
+	display: flex;
+	align-items: baseline;
+	justify-content: space-between;
+	gap: var(--space-3);
+	margin-bottom: var(--space-3);
+}
+.dash-chart-title { font-size: 13px; font-weight: 600; margin: 0; }
+.dash-chart-scroll { overflow-x: auto; overflow-y: hidden; }
+.dash-chart-svg {
+	display: block;
+	width: 100%;
+	min-width: 320px;
+	height: auto;
+	font-family: 'JetBrains Mono', ui-monospace, monospace;
+}
+.dash-chart-axis { stroke: color-mix(in oklab, var(--color-base-content) 22%, transparent); stroke-width: 1; }
+.dash-chart-gridline {
+	stroke: color-mix(in oklab, var(--color-base-content) 10%, transparent);
+	stroke-width: 1;
+	stroke-dasharray: 2 3;
+}
+.dash-chart-tick-label { fill: color-mix(in oklab, var(--color-base-content) 55%, transparent); font-size: 10px; }
+.dash-chart-bar { cursor: pointer; transition: filter var(--motion-fast) var(--ease-out); }
+.dash-chart-bar:hover { filter: brightness(1.15); }
+.dash-chart-tooltip {
+	position: absolute;
+	background: var(--color-base-content);
+	color: var(--color-base-100);
+	font-family: Inter, system-ui, sans-serif;
+	font-size: 11.5px;
+	line-height: 1.45;
+	padding: 8px 10px;
+	border-radius: var(--radius-sm);
+	box-shadow: 0 6px 20px rgba(0, 0, 0, 0.2);
+	pointer-events: none;
+	opacity: 0;
+	transform: translate(-50%, calc(-100% - 8px));
+	transition: opacity var(--motion-fast) var(--ease-out);
+	white-space: nowrap;
+	z-index: 5;
+	max-width: 280px;
+}
+.dash-chart-tooltip[data-visible="true"] { opacity: 1; }
+.dash-chart-tooltip-title { font-weight: 600; margin: 0 0 4px; font-size: 11px; letter-spacing: 0.02em; }
+.dash-chart-tooltip-row { display: flex; align-items: center; gap: 6px; margin: 2px 0; }
+.dash-chart-tooltip-swatch, .dash-breakdown-swatch {
+	width: 10px; height: 10px; border-radius: 2px; flex-shrink: 0;
+}
+.dash-chart-tooltip-swatch { width: 8px; height: 8px; }
+.dash-chart-tooltip-total {
+	margin-top: 4px; padding-top: 4px; font-weight: 600;
+	border-top: 1px solid color-mix(in oklab, var(--color-base-100) 25%, transparent);
+}
+.dash-chart-empty {
+	padding: var(--space-8) var(--space-5);
+	text-align: center;
+	color: color-mix(in oklab, var(--color-base-content) 55%, transparent);
+	font-size: 12.5px;
+}
+.dash-chart-skeleton {
+	height: 240px;
+	border-radius: var(--radius-sm);
+	background: linear-gradient(90deg,
+		var(--color-base-300) 25%,
+		color-mix(in oklab, var(--color-base-300) 50%, transparent) 50%,
+		var(--color-base-300) 75%);
+	background-size: 200% 100%;
+	animation: dash-shimmer 1.5s infinite;
+}
+.dash-breakdown-grid {
+	display: grid;
+	grid-template-columns: 1fr 1fr;
+	gap: var(--space-4);
+	margin-bottom: var(--space-5);
+}
+@media (max-width: 860px) {
+	.dash-breakdown-grid { grid-template-columns: 1fr; }
+}
+.dash-breakdown-swatch {
+	display: inline-block;
+	margin-right: 8px;
+	vertical-align: middle;
+}
+
+/* Segmented control for compact on/off toggles (e.g. Day | Week). */
+.dash-segmented {
+	display: inline-flex;
+	background: var(--color-base-100);
+	border: 1px solid var(--color-base-300);
+	border-radius: var(--radius-sm);
+	padding: 2px;
+	gap: 2px;
+}
+.dash-segmented button {
+	font: 500 12px Inter, system-ui, sans-serif;
+	color: color-mix(in oklab, var(--color-base-content) 65%, transparent);
+	background: transparent;
+	border: 0;
+	padding: 5px 10px;
+	border-radius: 4px;
+	cursor: pointer;
+	transition: background-color var(--motion-fast), color var(--motion-fast);
+}
+.dash-segmented button:hover { color: var(--color-base-content); }
+.dash-segmented button[aria-pressed="true"] {
+	background: var(--color-base-200);
+	color: var(--color-base-content);
+	box-shadow: 0 1px 2px rgba(0, 0, 0, 0.06);
+}
+.dash-segmented button:focus-visible {
+	outline: none;
+	box-shadow: 0 0 0 3px color-mix(in oklab, var(--color-primary) 25%, transparent);
+}
+
+/* Series palette: shared by SVG bars, tooltip dots, breakdown swatches. */
+[data-series-idx="0"].dash-chart-bar { fill: var(--color-primary); }
+[data-series-idx="1"].dash-chart-bar { fill: var(--color-info); }
+[data-series-idx="2"].dash-chart-bar { fill: var(--color-success); }
+[data-series-idx="3"].dash-chart-bar { fill: var(--color-warning); }
+[data-series-idx="4"].dash-chart-bar { fill: #a855f7; }
+[data-series-idx="5"].dash-chart-bar { fill: #ec4899; }
+[data-series-idx="6"].dash-chart-bar { fill: #0891b2; }
+[data-series-idx="7"].dash-chart-bar { fill: #d97706; }
+[data-series-idx="0"].dash-chart-tooltip-swatch, [data-series-idx="0"].dash-breakdown-swatch { background: var(--color-primary); }
+[data-series-idx="1"].dash-chart-tooltip-swatch, [data-series-idx="1"].dash-breakdown-swatch { background: var(--color-info); }
+[data-series-idx="2"].dash-chart-tooltip-swatch, [data-series-idx="2"].dash-breakdown-swatch { background: var(--color-success); }
+[data-series-idx="3"].dash-chart-tooltip-swatch, [data-series-idx="3"].dash-breakdown-swatch { background: var(--color-warning); }
+[data-series-idx="4"].dash-chart-tooltip-swatch, [data-series-idx="4"].dash-breakdown-swatch { background: #a855f7; }
+[data-series-idx="5"].dash-chart-tooltip-swatch, [data-series-idx="5"].dash-breakdown-swatch { background: #ec4899; }
+[data-series-idx="6"].dash-chart-tooltip-swatch, [data-series-idx="6"].dash-breakdown-swatch { background: #0891b2; }
+[data-series-idx="7"].dash-chart-tooltip-swatch, [data-series-idx="7"].dash-breakdown-swatch { background: #d97706; }
+
 /* Respect reduced motion: snap drawer in, skip shimmer. */
 @media (prefers-reduced-motion: reduce) {
-	.dash-drawer {
-		animation: none;
-	}
-	.dash-drawer-backdrop {
-		animation: none;
-	}
+	.dash-drawer, .dash-drawer-backdrop { animation: none; }
 	.dash-metric-card.dash-metric-skeleton .dash-metric-label,
 	.dash-metric-card.dash-metric-skeleton .dash-metric-value,
-	.dash-table-skeleton-pill {
-		animation: none;
-	}
+	.dash-table-skeleton-pill,
+	.dash-chart-skeleton { animation: none; }
+	.dash-chart-bar, .dash-chart-tooltip { transition: none; }
 }

--- a/public/dashboard/dashboard.js
+++ b/public/dashboard/dashboard.js
@@ -265,8 +265,8 @@
 		var name = parsed.route;
 		deactivateAllRoutes();
 
-		var liveRoutes = ["skills", "memory-files", "plugins", "subagents", "hooks", "settings", "sessions"];
-		var comingSoon = ["cost", "scheduler", "evolution", "memory"];
+		var liveRoutes = ["skills", "memory-files", "plugins", "subagents", "hooks", "settings", "sessions", "cost"];
+		var comingSoon = ["scheduler", "evolution", "memory"];
 
 		if (liveRoutes.indexOf(name) >= 0 && routes[name]) {
 			var containerId = "route-" + name;

--- a/public/dashboard/index.html
+++ b/public/dashboard/index.html
@@ -64,15 +64,14 @@
         <svg class="dash-sidebar-icon" fill="none" viewBox="0 0 24 24" stroke-width="1.6" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M20.25 14.15v4.098a2.25 2.25 0 0 1-2.25 2.25h-12a2.25 2.25 0 0 1-2.25-2.25V5.625a2.25 2.25 0 0 1 2.25-2.25h8.25M15.75 9l3.75-3.75m0 0L23.25 9m-3.75-3.75v9"/></svg>
         <span>Sessions</span>
       </a>
+      <a href="#/cost" class="dash-sidebar-item" data-route="cost">
+        <svg class="dash-sidebar-icon" fill="none" viewBox="0 0 24 24" stroke-width="1.6" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M2.25 18 9 11.25l4.306 4.306a11.95 11.95 0 0 1 5.814-5.518l2.74-1.22m0 0-5.94-2.281m5.94 2.28-2.28 5.941"/></svg>
+        <span>Cost</span>
+      </a>
     </nav>
 
     <div class="dash-sidebar-eyebrow" style="margin-top:var(--space-5);">Coming soon</div>
     <nav class="dash-sidebar-nav">
-      <a href="#/cost" class="dash-sidebar-item dash-sidebar-item-soon" data-route="cost">
-        <svg class="dash-sidebar-icon" fill="none" viewBox="0 0 24 24" stroke-width="1.6" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M2.25 18 9 11.25l4.306 4.306a11.95 11.95 0 0 1 5.814-5.518l2.74-1.22m0 0-5.94-2.281m5.94 2.28-2.28 5.941"/></svg>
-        <span>Cost</span>
-        <span class="dash-sidebar-soon-pill">soon</span>
-      </a>
       <a href="#/scheduler" class="dash-sidebar-item dash-sidebar-item-soon" data-route="scheduler">
         <svg class="dash-sidebar-icon" fill="none" viewBox="0 0 24 24" stroke-width="1.6" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6h4.5m4.5 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"/></svg>
         <span>Scheduler</span>
@@ -104,6 +103,7 @@
     <div id="route-hooks" class="dash-route" hidden></div>
     <div id="route-settings" class="dash-route" hidden></div>
     <div id="route-sessions" class="dash-route" hidden></div>
+    <div id="route-cost" class="dash-route" hidden></div>
     <div id="route-soon" class="dash-route" hidden></div>
   </main>
 
@@ -119,6 +119,7 @@
 <script src="/ui/dashboard/hooks.js"></script>
 <script src="/ui/dashboard/settings.js"></script>
 <script src="/ui/dashboard/sessions.js"></script>
+<script src="/ui/dashboard/cost.js"></script>
 <script>window.PhantomDashboard.init();</script>
 </body>
 </html>

--- a/src/agent/cost-queries.ts
+++ b/src/agent/cost-queries.ts
@@ -1,0 +1,254 @@
+// Cost aggregation queries shared between the MCP cost resource, the
+// universal_metrics_read tool, and the dashboard cost API. All SQL uses
+// COALESCE(SUM(...), 0) so empty result sets return 0 rather than NULL.
+
+import type { Database } from "bun:sqlite";
+
+export type CostForPeriod = {
+	total: number;
+	events: number;
+};
+
+export type CostHeadline = {
+	today: number;
+	yesterday: number;
+	this_week: number;
+	this_month: number;
+	all_time: number;
+	day_delta_pct: number;
+	week_delta_pct: number;
+};
+
+export type DailyCostRow = {
+	day: string;
+	cost_usd: number;
+	input_tokens: number;
+	output_tokens: number;
+	by_model: Array<{ model: string; cost_usd: number }>;
+};
+
+export type ByModelRow = {
+	model: string;
+	cost_usd: number;
+	pct: number;
+	input_tokens: number;
+	output_tokens: number;
+	events: number;
+};
+
+export type ByChannelRow = {
+	channel_id: string;
+	cost_usd: number;
+	sessions: number;
+	avg_per_session: number;
+	input_tokens: number;
+	output_tokens: number;
+};
+
+export type TopSessionRow = {
+	session_key: string;
+	channel_id: string;
+	conversation_id: string;
+	total_cost_usd: number;
+	turn_count: number;
+	last_active_at: string;
+};
+
+// Percent change from `prior` to `now`, or 0 when prior is 0 (avoids NaN).
+function deltaPct(now: number, prior: number): number {
+	if (prior === 0) return 0;
+	return ((now - prior) / prior) * 100;
+}
+
+// Shared by MCP cost resource and universal metrics tool. `dateFilter` is
+// an inlined SQLite date expression (e.g. "date('now', '-7 days')"). It is
+// NEVER interpolated from user input; callers pass one of a small set of
+// trusted constants.
+export function getCostForPeriod(db: Database, dateFilter: string): CostForPeriod {
+	const row = db
+		.query(
+			`SELECT COALESCE(SUM(cost_usd), 0) AS total, COUNT(*) AS events
+			 FROM cost_events WHERE created_at >= ${dateFilter}`,
+		)
+		.get() as { total: number; events: number };
+	return { total: row.total, events: row.events };
+}
+
+export function getCostHeadline(db: Database): CostHeadline {
+	const today = (
+		db
+			.query(
+				"SELECT COALESCE(SUM(cost_usd), 0) AS total FROM cost_events WHERE date(created_at) = date('now')",
+			)
+			.get() as { total: number }
+	).total;
+	const yesterday = (
+		db
+			.query(
+				"SELECT COALESCE(SUM(cost_usd), 0) AS total FROM cost_events WHERE date(created_at) = date('now', '-1 day')",
+			)
+			.get() as { total: number }
+	).total;
+	const thisWeek = (
+		db
+			.query(
+				"SELECT COALESCE(SUM(cost_usd), 0) AS total FROM cost_events WHERE created_at >= datetime('now', '-7 days')",
+			)
+			.get() as { total: number }
+	).total;
+	const priorWeek = (
+		db
+			.query(
+				"SELECT COALESCE(SUM(cost_usd), 0) AS total FROM cost_events WHERE created_at >= datetime('now', '-14 days') AND created_at < datetime('now', '-7 days')",
+			)
+			.get() as { total: number }
+	).total;
+	const thisMonth = (
+		db
+			.query(
+				"SELECT COALESCE(SUM(cost_usd), 0) AS total FROM cost_events WHERE created_at >= datetime('now', '-30 days')",
+			)
+			.get() as { total: number }
+	).total;
+	const allTime = (
+		db.query("SELECT COALESCE(SUM(cost_usd), 0) AS total FROM cost_events").get() as { total: number }
+	).total;
+
+	return {
+		today,
+		yesterday,
+		this_week: thisWeek,
+		this_month: thisMonth,
+		all_time: allTime,
+		day_delta_pct: deltaPct(today, yesterday),
+		week_delta_pct: deltaPct(thisWeek, priorWeek),
+	};
+}
+
+// `days` is `null` for all-time, otherwise clamped by the caller. Returns
+// only days that have events; the chart skips missing days on its x-axis.
+export function getDailyCost(db: Database, days: number | null): DailyCostRow[] {
+	const whereSql = days === null ? "" : "WHERE created_at >= datetime('now', ?)";
+	const params: string[] = days === null ? [] : [`-${days} days`];
+
+	const dayRows = db
+		.query(
+			`SELECT date(created_at) AS day,
+			        COALESCE(SUM(cost_usd), 0) AS cost_usd,
+			        COALESCE(SUM(input_tokens), 0) AS input_tokens,
+			        COALESCE(SUM(output_tokens), 0) AS output_tokens
+			 FROM cost_events ${whereSql}
+			 GROUP BY day
+			 ORDER BY day ASC`,
+		)
+		.all(...params) as Array<{ day: string; cost_usd: number; input_tokens: number; output_tokens: number }>;
+
+	const modelRows = db
+		.query(
+			`SELECT date(created_at) AS day, model, COALESCE(SUM(cost_usd), 0) AS cost_usd
+			 FROM cost_events ${whereSql}
+			 GROUP BY day, model
+			 ORDER BY day ASC, cost_usd DESC`,
+		)
+		.all(...params) as Array<{ day: string; model: string; cost_usd: number }>;
+
+	const byDay: Map<string, Array<{ model: string; cost_usd: number }>> = new Map();
+	for (const mr of modelRows) {
+		const list = byDay.get(mr.day) ?? [];
+		list.push({ model: mr.model, cost_usd: mr.cost_usd });
+		byDay.set(mr.day, list);
+	}
+
+	return dayRows.map((r) => ({
+		day: r.day,
+		cost_usd: r.cost_usd,
+		input_tokens: r.input_tokens,
+		output_tokens: r.output_tokens,
+		by_model: byDay.get(r.day) ?? [],
+	}));
+}
+
+export function getByModel(db: Database, days: number | null): ByModelRow[] {
+	const whereSql = days === null ? "" : "WHERE created_at >= datetime('now', ?)";
+	const params: string[] = days === null ? [] : [`-${days} days`];
+
+	const rows = db
+		.query(
+			`SELECT model,
+			        COALESCE(SUM(cost_usd), 0) AS cost_usd,
+			        COALESCE(SUM(input_tokens), 0) AS input_tokens,
+			        COALESCE(SUM(output_tokens), 0) AS output_tokens,
+			        COUNT(*) AS events
+			 FROM cost_events ${whereSql}
+			 GROUP BY model
+			 ORDER BY cost_usd DESC`,
+		)
+		.all(...params) as Array<{
+		model: string;
+		cost_usd: number;
+		input_tokens: number;
+		output_tokens: number;
+		events: number;
+	}>;
+
+	const total = rows.reduce((acc, r) => acc + r.cost_usd, 0);
+	return rows.map((r) => ({
+		model: r.model,
+		cost_usd: r.cost_usd,
+		pct: total > 0 ? r.cost_usd / total : 0,
+		input_tokens: r.input_tokens,
+		output_tokens: r.output_tokens,
+		events: r.events,
+	}));
+}
+
+export function getByChannel(db: Database, days: number | null): ByChannelRow[] {
+	const whereSql = days === null ? "" : "WHERE ce.created_at >= datetime('now', ?)";
+	const params: string[] = days === null ? [] : [`-${days} days`];
+
+	const rows = db
+		.query(
+			`SELECT s.channel_id AS channel_id,
+			        COALESCE(SUM(ce.cost_usd), 0) AS cost_usd,
+			        COUNT(DISTINCT ce.session_key) AS sessions,
+			        COALESCE(SUM(ce.input_tokens), 0) AS input_tokens,
+			        COALESCE(SUM(ce.output_tokens), 0) AS output_tokens
+			 FROM cost_events ce
+			 JOIN sessions s ON ce.session_key = s.session_key
+			 ${whereSql}
+			 GROUP BY s.channel_id
+			 ORDER BY cost_usd DESC`,
+		)
+		.all(...params) as Array<{
+		channel_id: string;
+		cost_usd: number;
+		sessions: number;
+		input_tokens: number;
+		output_tokens: number;
+	}>;
+
+	return rows.map((r) => ({
+		channel_id: r.channel_id,
+		cost_usd: r.cost_usd,
+		sessions: r.sessions,
+		avg_per_session: r.sessions > 0 ? r.cost_usd / r.sessions : 0,
+		input_tokens: r.input_tokens,
+		output_tokens: r.output_tokens,
+	}));
+}
+
+export function getTopSessions(db: Database, limit: number, days: number | null): TopSessionRow[] {
+	const whereSql = days === null ? "" : "WHERE s.last_active_at >= datetime('now', ?)";
+	const params: Array<string | number> = days === null ? [] : [`-${days} days`];
+
+	return db
+		.query(
+			`SELECT s.session_key, s.channel_id, s.conversation_id,
+			        s.total_cost_usd, s.turn_count, s.last_active_at
+			 FROM sessions s
+			 ${whereSql}
+			 ORDER BY s.total_cost_usd DESC, s.last_active_at DESC
+			 LIMIT ?`,
+		)
+		.all(...params, limit) as TopSessionRow[];
+}

--- a/src/agent/cost-queries.ts
+++ b/src/agent/cost-queries.ts
@@ -4,10 +4,7 @@
 
 import type { Database } from "bun:sqlite";
 
-export type CostForPeriod = {
-	total: number;
-	events: number;
-};
+export type CostForPeriod = { total: number; events: number };
 
 export type CostHeadline = {
 	today: number;
@@ -56,14 +53,21 @@ export type TopSessionRow = {
 
 // Percent change from `prior` to `now`, or 0 when prior is 0 (avoids NaN).
 function deltaPct(now: number, prior: number): number {
-	if (prior === 0) return 0;
-	return ((now - prior) / prior) * 100;
+	return prior === 0 ? 0 : ((now - prior) / prior) * 100;
+}
+
+// Helper: run a single-row `SELECT COALESCE(SUM(cost_usd), 0) AS total`
+// scoped by an inlined date expression. `dateExpr` is a trusted constant,
+// never interpolated from user input.
+function sumCost(db: Database, dateExpr: string): number {
+	const row = db.query(`SELECT COALESCE(SUM(cost_usd), 0) AS total FROM cost_events WHERE ${dateExpr}`).get() as {
+		total: number;
+	};
+	return row.total;
 }
 
 // Shared by MCP cost resource and universal metrics tool. `dateFilter` is
-// an inlined SQLite date expression (e.g. "date('now', '-7 days')"). It is
-// NEVER interpolated from user input; callers pass one of a small set of
-// trusted constants.
+// an inlined SQLite date expression (e.g. "date('now', '-7 days')").
 export function getCostForPeriod(db: Database, dateFilter: string): CostForPeriod {
 	const row = db
 		.query(
@@ -71,48 +75,20 @@ export function getCostForPeriod(db: Database, dateFilter: string): CostForPerio
 			 FROM cost_events WHERE created_at >= ${dateFilter}`,
 		)
 		.get() as { total: number; events: number };
-	return { total: row.total, events: row.events };
+	return row;
 }
 
 export function getCostHeadline(db: Database): CostHeadline {
-	const today = (
-		db
-			.query(
-				"SELECT COALESCE(SUM(cost_usd), 0) AS total FROM cost_events WHERE date(created_at) = date('now')",
-			)
-			.get() as { total: number }
-	).total;
-	const yesterday = (
-		db
-			.query(
-				"SELECT COALESCE(SUM(cost_usd), 0) AS total FROM cost_events WHERE date(created_at) = date('now', '-1 day')",
-			)
-			.get() as { total: number }
-	).total;
-	const thisWeek = (
-		db
-			.query(
-				"SELECT COALESCE(SUM(cost_usd), 0) AS total FROM cost_events WHERE created_at >= datetime('now', '-7 days')",
-			)
-			.get() as { total: number }
-	).total;
-	const priorWeek = (
-		db
-			.query(
-				"SELECT COALESCE(SUM(cost_usd), 0) AS total FROM cost_events WHERE created_at >= datetime('now', '-14 days') AND created_at < datetime('now', '-7 days')",
-			)
-			.get() as { total: number }
-	).total;
-	const thisMonth = (
-		db
-			.query(
-				"SELECT COALESCE(SUM(cost_usd), 0) AS total FROM cost_events WHERE created_at >= datetime('now', '-30 days')",
-			)
-			.get() as { total: number }
-	).total;
-	const allTime = (
-		db.query("SELECT COALESCE(SUM(cost_usd), 0) AS total FROM cost_events").get() as { total: number }
-	).total;
+	const today = sumCost(db, "date(created_at) = date('now')");
+	const yesterday = sumCost(db, "date(created_at) = date('now', '-1 day')");
+	const thisWeek = sumCost(db, "created_at >= datetime('now', '-7 days')");
+	const priorWeek = sumCost(
+		db,
+		"created_at >= datetime('now', '-14 days') AND created_at < datetime('now', '-7 days')",
+	);
+	const thisMonth = sumCost(db, "created_at >= datetime('now', '-30 days')");
+	const allTime = (db.query("SELECT COALESCE(SUM(cost_usd), 0) AS total FROM cost_events").get() as { total: number })
+		.total;
 
 	return {
 		today,
@@ -125,10 +101,10 @@ export function getCostHeadline(db: Database): CostHeadline {
 	};
 }
 
-// `days` is `null` for all-time, otherwise clamped by the caller. Returns
+// `days` is null for all-time, otherwise clamped by the caller. Returns
 // only days that have events; the chart skips missing days on its x-axis.
 export function getDailyCost(db: Database, days: number | null): DailyCostRow[] {
-	const whereSql = days === null ? "" : "WHERE created_at >= datetime('now', ?)";
+	const where = days === null ? "" : "WHERE created_at >= datetime('now', ?)";
 	const params: string[] = days === null ? [] : [`-${days} days`];
 
 	const dayRows = db
@@ -137,118 +113,72 @@ export function getDailyCost(db: Database, days: number | null): DailyCostRow[] 
 			        COALESCE(SUM(cost_usd), 0) AS cost_usd,
 			        COALESCE(SUM(input_tokens), 0) AS input_tokens,
 			        COALESCE(SUM(output_tokens), 0) AS output_tokens
-			 FROM cost_events ${whereSql}
-			 GROUP BY day
-			 ORDER BY day ASC`,
+			 FROM cost_events ${where} GROUP BY day ORDER BY day ASC`,
 		)
 		.all(...params) as Array<{ day: string; cost_usd: number; input_tokens: number; output_tokens: number }>;
 
 	const modelRows = db
 		.query(
 			`SELECT date(created_at) AS day, model, COALESCE(SUM(cost_usd), 0) AS cost_usd
-			 FROM cost_events ${whereSql}
-			 GROUP BY day, model
-			 ORDER BY day ASC, cost_usd DESC`,
+			 FROM cost_events ${where} GROUP BY day, model ORDER BY day ASC, cost_usd DESC`,
 		)
 		.all(...params) as Array<{ day: string; model: string; cost_usd: number }>;
 
-	const byDay: Map<string, Array<{ model: string; cost_usd: number }>> = new Map();
+	const byDay = new Map<string, Array<{ model: string; cost_usd: number }>>();
 	for (const mr of modelRows) {
 		const list = byDay.get(mr.day) ?? [];
 		list.push({ model: mr.model, cost_usd: mr.cost_usd });
 		byDay.set(mr.day, list);
 	}
 
-	return dayRows.map((r) => ({
-		day: r.day,
-		cost_usd: r.cost_usd,
-		input_tokens: r.input_tokens,
-		output_tokens: r.output_tokens,
-		by_model: byDay.get(r.day) ?? [],
-	}));
+	return dayRows.map((r) => ({ ...r, by_model: byDay.get(r.day) ?? [] }));
 }
 
 export function getByModel(db: Database, days: number | null): ByModelRow[] {
-	const whereSql = days === null ? "" : "WHERE created_at >= datetime('now', ?)";
+	const where = days === null ? "" : "WHERE created_at >= datetime('now', ?)";
 	const params: string[] = days === null ? [] : [`-${days} days`];
 
 	const rows = db
 		.query(
-			`SELECT model,
-			        COALESCE(SUM(cost_usd), 0) AS cost_usd,
+			`SELECT model, COALESCE(SUM(cost_usd), 0) AS cost_usd,
 			        COALESCE(SUM(input_tokens), 0) AS input_tokens,
-			        COALESCE(SUM(output_tokens), 0) AS output_tokens,
-			        COUNT(*) AS events
-			 FROM cost_events ${whereSql}
-			 GROUP BY model
-			 ORDER BY cost_usd DESC`,
+			        COALESCE(SUM(output_tokens), 0) AS output_tokens, COUNT(*) AS events
+			 FROM cost_events ${where} GROUP BY model ORDER BY cost_usd DESC`,
 		)
-		.all(...params) as Array<{
-		model: string;
-		cost_usd: number;
-		input_tokens: number;
-		output_tokens: number;
-		events: number;
-	}>;
+		.all(...params) as Array<Omit<ByModelRow, "pct">>;
 
 	const total = rows.reduce((acc, r) => acc + r.cost_usd, 0);
-	return rows.map((r) => ({
-		model: r.model,
-		cost_usd: r.cost_usd,
-		pct: total > 0 ? r.cost_usd / total : 0,
-		input_tokens: r.input_tokens,
-		output_tokens: r.output_tokens,
-		events: r.events,
-	}));
+	return rows.map((r) => ({ ...r, pct: total > 0 ? r.cost_usd / total : 0 }));
 }
 
 export function getByChannel(db: Database, days: number | null): ByChannelRow[] {
-	const whereSql = days === null ? "" : "WHERE ce.created_at >= datetime('now', ?)";
+	const where = days === null ? "" : "WHERE ce.created_at >= datetime('now', ?)";
 	const params: string[] = days === null ? [] : [`-${days} days`];
 
 	const rows = db
 		.query(
-			`SELECT s.channel_id AS channel_id,
-			        COALESCE(SUM(ce.cost_usd), 0) AS cost_usd,
+			`SELECT s.channel_id AS channel_id, COALESCE(SUM(ce.cost_usd), 0) AS cost_usd,
 			        COUNT(DISTINCT ce.session_key) AS sessions,
 			        COALESCE(SUM(ce.input_tokens), 0) AS input_tokens,
 			        COALESCE(SUM(ce.output_tokens), 0) AS output_tokens
-			 FROM cost_events ce
-			 JOIN sessions s ON ce.session_key = s.session_key
-			 ${whereSql}
-			 GROUP BY s.channel_id
-			 ORDER BY cost_usd DESC`,
+			 FROM cost_events ce JOIN sessions s ON ce.session_key = s.session_key
+			 ${where} GROUP BY s.channel_id ORDER BY cost_usd DESC`,
 		)
-		.all(...params) as Array<{
-		channel_id: string;
-		cost_usd: number;
-		sessions: number;
-		input_tokens: number;
-		output_tokens: number;
-	}>;
+		.all(...params) as Array<Omit<ByChannelRow, "avg_per_session">>;
 
-	return rows.map((r) => ({
-		channel_id: r.channel_id,
-		cost_usd: r.cost_usd,
-		sessions: r.sessions,
-		avg_per_session: r.sessions > 0 ? r.cost_usd / r.sessions : 0,
-		input_tokens: r.input_tokens,
-		output_tokens: r.output_tokens,
-	}));
+	return rows.map((r) => ({ ...r, avg_per_session: r.sessions > 0 ? r.cost_usd / r.sessions : 0 }));
 }
 
 export function getTopSessions(db: Database, limit: number, days: number | null): TopSessionRow[] {
-	const whereSql = days === null ? "" : "WHERE s.last_active_at >= datetime('now', ?)";
+	const where = days === null ? "" : "WHERE s.last_active_at >= datetime('now', ?)";
 	const params: Array<string | number> = days === null ? [] : [`-${days} days`];
 
 	return db
 		.query(
 			`SELECT s.session_key, s.channel_id, s.conversation_id,
 			        s.total_cost_usd, s.turn_count, s.last_active_at
-			 FROM sessions s
-			 ${whereSql}
-			 ORDER BY s.total_cost_usd DESC, s.last_active_at DESC
-			 LIMIT ?`,
+			 FROM sessions s ${where}
+			 ORDER BY s.total_cost_usd DESC, s.last_active_at DESC LIMIT ?`,
 		)
 		.all(...params, limit) as TopSessionRow[];
 }

--- a/src/agent/cost-queries.ts
+++ b/src/agent/cost-queries.ts
@@ -170,15 +170,23 @@ export function getByChannel(db: Database, days: number | null): ByChannelRow[] 
 }
 
 export function getTopSessions(db: Database, limit: number, days: number | null): TopSessionRow[] {
-	const where = days === null ? "" : "WHERE s.last_active_at >= datetime('now', ?)";
+	// Sum cost_events within the chosen window so the table reflects spend in
+	// the active range, not lifetime totals. Sessions with large historical
+	// cost but no recent activity correctly drop out of short-window views.
+	const where = days === null ? "" : "WHERE ce.created_at >= datetime('now', ?)";
 	const params: Array<string | number> = days === null ? [] : [`-${days} days`];
 
 	return db
 		.query(
 			`SELECT s.session_key, s.channel_id, s.conversation_id,
-			        s.total_cost_usd, s.turn_count, s.last_active_at
-			 FROM sessions s ${where}
-			 ORDER BY s.total_cost_usd DESC, s.last_active_at DESC LIMIT ?`,
+			        COALESCE(SUM(ce.cost_usd), 0) AS total_cost_usd,
+			        s.turn_count, s.last_active_at
+			 FROM cost_events ce
+			 JOIN sessions s ON ce.session_key = s.session_key
+			 ${where}
+			 GROUP BY s.session_key, s.channel_id, s.conversation_id, s.turn_count, s.last_active_at
+			 ORDER BY total_cost_usd DESC, s.last_active_at DESC
+			 LIMIT ?`,
 		)
 		.all(...params, limit) as TopSessionRow[];
 }

--- a/src/mcp/resources.ts
+++ b/src/mcp/resources.ts
@@ -1,6 +1,7 @@
 import type { Database } from "bun:sqlite";
 import { type McpServer, ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { ReadResourceResult } from "@modelcontextprotocol/sdk/types.js";
+import { getCostForPeriod } from "../agent/cost-queries.ts";
 import type { PhantomConfig } from "../config/types.ts";
 import type { EvolutionEngine } from "../evolution/engine.ts";
 import type { MemorySystem } from "../memory/system.ts";
@@ -254,17 +255,13 @@ function registerMetricsCostResource(server: McpServer, deps: ResourceDependenci
 			const dateFilter =
 				period === "today" ? "date('now')" : period === "week" ? "date('now', '-7 days')" : "date('now', '-30 days')";
 
-			const row = deps.db
-				.query(
-					`SELECT COALESCE(SUM(cost_usd), 0) as total, COUNT(*) as events FROM cost_events WHERE created_at >= ${dateFilter}`,
-				)
-				.get() as { total: number; events: number };
+			const { total, events } = getCostForPeriod(deps.db, dateFilter);
 
 			return {
 				contents: [
 					{
 						uri: uri.href,
-						text: JSON.stringify({ period, totalCost: row.total, events: row.events }, null, 2),
+						text: JSON.stringify({ period, totalCost: total, events }, null, 2),
 					},
 				],
 			};

--- a/src/mcp/tools-universal.ts
+++ b/src/mcp/tools-universal.ts
@@ -2,6 +2,7 @@ import type { Database } from "bun:sqlite";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
+import { getCostForPeriod } from "../agent/cost-queries.ts";
 import type { AgentRuntime } from "../agent/runtime.ts";
 import type { PhantomConfig } from "../config/types.ts";
 import type { EvolutionEngine } from "../evolution/engine.ts";
@@ -149,17 +150,13 @@ function registerPhantomMetrics(server: McpServer, deps: ToolDependencies): void
 							? "date('now', '-30 days')"
 							: "date('1970-01-01')";
 
-			const costRow = deps.db
-				.query(
-					`SELECT COALESCE(SUM(cost_usd), 0) as total, COUNT(*) as count FROM cost_events WHERE created_at >= ${dateFilter}`,
-				)
-				.get() as { total: number; count: number } | null;
+			const costRow = getCostForPeriod(deps.db, dateFilter);
 
 			const result = {
 				totalTasks: metrics?.session_count ?? 0,
 				successRate: metrics ? +(metrics.success_rate_7d * 100).toFixed(1) : 0,
-				avgCost: costRow && costRow.count > 0 ? +(costRow.total / costRow.count).toFixed(4) : 0,
-				totalCost: +(costRow?.total ?? 0).toFixed(4),
+				avgCost: costRow.events > 0 ? +(costRow.total / costRow.events).toFixed(4) : 0,
+				totalCost: +costRow.total.toFixed(4),
 				evolutionGeneration: deps.evolution?.getCurrentVersion() ?? 0,
 				evolutionCount: metrics?.evolution_count ?? 0,
 				rollbackCount: 0,

--- a/src/ui/api/__tests__/cost.test.ts
+++ b/src/ui/api/__tests__/cost.test.ts
@@ -1,0 +1,367 @@
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { resolve } from "node:path";
+import { MIGRATIONS } from "../../../db/schema.ts";
+import { handleUiRequest, setDashboardDb, setPublicDir } from "../../serve.ts";
+import { createSession, revokeAllSessions } from "../../session.ts";
+
+setPublicDir(resolve(import.meta.dir, "../../../../public"));
+
+let db: Database;
+let sessionToken: string;
+
+type CostResponse = {
+	range: { from: string | null; to: string; days: number | "all" };
+	headline: {
+		today: number;
+		yesterday: number;
+		this_week: number;
+		this_month: number;
+		all_time: number;
+		day_delta_pct: number;
+		week_delta_pct: number;
+	};
+	daily: Array<{
+		day: string;
+		cost_usd: number;
+		input_tokens: number;
+		output_tokens: number;
+		by_model: Array<{ model: string; cost_usd: number }>;
+	}>;
+	by_model: Array<{
+		model: string;
+		cost_usd: number;
+		pct: number;
+		input_tokens: number;
+		output_tokens: number;
+		events: number;
+	}>;
+	by_channel: Array<{
+		channel_id: string;
+		cost_usd: number;
+		sessions: number;
+		avg_per_session: number;
+		input_tokens: number;
+		output_tokens: number;
+	}>;
+	top_sessions: Array<{
+		session_key: string;
+		channel_id: string;
+		conversation_id: string;
+		total_cost_usd: number;
+		turn_count: number;
+		last_active_at: string;
+	}>;
+	limits: { top_sessions: number };
+};
+
+function runMigrations(target: Database): void {
+	for (const migration of MIGRATIONS) {
+		try {
+			target.run(migration);
+		} catch {
+			// ignore duplicate ALTER errors on repeated migrations
+		}
+	}
+}
+
+function seedSession(
+	target: Database,
+	row: {
+		session_key: string;
+		channel_id: string;
+		conversation_id: string;
+		total_cost_usd?: number;
+		turn_count?: number;
+		last_active_at?: string;
+	},
+): void {
+	target
+		.query(
+			`INSERT INTO sessions (session_key, channel_id, conversation_id, total_cost_usd, turn_count, last_active_at)
+				VALUES (?, ?, ?, ?, ?, ?)`,
+		)
+		.run(
+			row.session_key,
+			row.channel_id,
+			row.conversation_id,
+			row.total_cost_usd ?? 0,
+			row.turn_count ?? 0,
+			row.last_active_at ?? new Date().toISOString().replace("T", " ").slice(0, 19),
+		);
+}
+
+function seedCostEvent(
+	target: Database,
+	row: {
+		session_key: string;
+		cost_usd: number;
+		input_tokens?: number;
+		output_tokens?: number;
+		model?: string;
+		created_at?: string;
+	},
+): void {
+	target
+		.query(
+			`INSERT INTO cost_events (session_key, cost_usd, input_tokens, output_tokens, model, created_at)
+				VALUES (?, ?, ?, ?, ?, ?)`,
+		)
+		.run(
+			row.session_key,
+			row.cost_usd,
+			row.input_tokens ?? 100,
+			row.output_tokens ?? 50,
+			row.model ?? "claude-opus-4-7",
+			row.created_at ?? new Date().toISOString().replace("T", " ").slice(0, 19),
+		);
+}
+
+function hoursAgo(h: number): string {
+	const d = new Date(Date.now() - h * 3600 * 1000);
+	return d.toISOString().replace("T", " ").slice(0, 19);
+}
+
+function daysAgo(d: number): string {
+	return hoursAgo(d * 24);
+}
+
+beforeEach(() => {
+	db = new Database(":memory:");
+	runMigrations(db);
+	setDashboardDb(db);
+	sessionToken = createSession().sessionToken;
+});
+
+afterEach(() => {
+	db.close();
+	revokeAllSessions();
+});
+
+function req(path: string, init?: RequestInit): Request {
+	return new Request(`http://localhost${path}`, {
+		...init,
+		headers: {
+			Cookie: `phantom_session=${encodeURIComponent(sessionToken)}`,
+			Accept: "application/json",
+			...((init?.headers as Record<string, string>) ?? {}),
+		},
+	});
+}
+
+describe("cost API", () => {
+	test("401 without session cookie", async () => {
+		const res = await handleUiRequest(
+			new Request("http://localhost/ui/api/cost", { headers: { Accept: "application/json" } }),
+		);
+		expect(res.status).toBe(401);
+	});
+
+	test("POST returns 405", async () => {
+		const res = await handleUiRequest(req("/ui/api/cost", { method: "POST", body: "{}" }));
+		expect(res.status).toBe(405);
+	});
+
+	test("invalid days returns 422", async () => {
+		const r1 = await handleUiRequest(req("/ui/api/cost?days=abc"));
+		expect(r1.status).toBe(422);
+		const r2 = await handleUiRequest(req("/ui/api/cost?days=999"));
+		expect(r2.status).toBe(422);
+		const r3 = await handleUiRequest(req("/ui/api/cost?days=0"));
+		expect(r3.status).toBe(422);
+	});
+
+	test("empty DB returns all zeros without NaN or null", async () => {
+		const res = await handleUiRequest(req("/ui/api/cost?days=30"));
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as CostResponse;
+		expect(body.headline.today).toBe(0);
+		expect(body.headline.yesterday).toBe(0);
+		expect(body.headline.this_week).toBe(0);
+		expect(body.headline.this_month).toBe(0);
+		expect(body.headline.all_time).toBe(0);
+		expect(body.headline.day_delta_pct).toBe(0);
+		expect(body.headline.week_delta_pct).toBe(0);
+		expect(body.daily).toEqual([]);
+		expect(body.by_model).toEqual([]);
+		expect(body.by_channel).toEqual([]);
+		expect(body.top_sessions).toEqual([]);
+		const raw = JSON.stringify(body);
+		expect(raw.includes("null")).toBe(false);
+		expect(raw.includes("NaN")).toBe(false);
+	});
+
+	test("headline math: today, yesterday, week, month, all_time", async () => {
+		seedSession(db, { session_key: "s1", channel_id: "slack", conversation_id: "c1" });
+		seedCostEvent(db, { session_key: "s1", cost_usd: 1.0, created_at: hoursAgo(1) });
+		seedCostEvent(db, { session_key: "s1", cost_usd: 2.0, created_at: hoursAgo(3) });
+		seedCostEvent(db, { session_key: "s1", cost_usd: 0.5, created_at: daysAgo(1) });
+		seedCostEvent(db, { session_key: "s1", cost_usd: 4.0, created_at: daysAgo(5) });
+		seedCostEvent(db, { session_key: "s1", cost_usd: 10.0, created_at: daysAgo(25) });
+		seedCostEvent(db, { session_key: "s1", cost_usd: 100.0, created_at: daysAgo(120) });
+
+		const res = await handleUiRequest(req("/ui/api/cost?days=all"));
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as CostResponse;
+		expect(body.headline.today).toBeCloseTo(3.0, 6);
+		expect(body.headline.yesterday).toBeCloseTo(0.5, 6);
+		expect(body.headline.this_week).toBeCloseTo(7.5, 6);
+		expect(body.headline.this_month).toBeCloseTo(17.5, 6);
+		expect(body.headline.all_time).toBeCloseTo(117.5, 6);
+	});
+
+	test("day_delta_pct is correct and 0 (not NaN) when yesterday is 0", async () => {
+		seedSession(db, { session_key: "s1", channel_id: "slack", conversation_id: "c1" });
+		seedCostEvent(db, { session_key: "s1", cost_usd: 5.0, created_at: hoursAgo(1) });
+
+		const res = await handleUiRequest(req("/ui/api/cost?days=all"));
+		const body = (await res.json()) as CostResponse;
+		expect(body.headline.day_delta_pct).toBe(0);
+		expect(Number.isNaN(body.headline.day_delta_pct)).toBe(false);
+
+		db.run("DELETE FROM cost_events");
+		seedCostEvent(db, { session_key: "s1", cost_usd: 10.0, created_at: hoursAgo(1) });
+		seedCostEvent(db, { session_key: "s1", cost_usd: 5.0, created_at: daysAgo(1) });
+		const res2 = await handleUiRequest(req("/ui/api/cost?days=all"));
+		const body2 = (await res2.json()) as CostResponse;
+		expect(body2.headline.day_delta_pct).toBeCloseTo(100, 1);
+	});
+
+	test("week_delta_pct is correct when prior week was populated", async () => {
+		seedSession(db, { session_key: "s1", channel_id: "slack", conversation_id: "c1" });
+		seedCostEvent(db, { session_key: "s1", cost_usd: 20.0, created_at: daysAgo(2) });
+		seedCostEvent(db, { session_key: "s1", cost_usd: 10.0, created_at: daysAgo(10) });
+
+		const res = await handleUiRequest(req("/ui/api/cost?days=all"));
+		const body = (await res.json()) as CostResponse;
+		expect(body.headline.week_delta_pct).toBeCloseTo(100, 1);
+	});
+
+	test("daily timeseries groups by date with by_model breakdown", async () => {
+		seedSession(db, { session_key: "s1", channel_id: "slack", conversation_id: "c1" });
+		seedCostEvent(db, { session_key: "s1", cost_usd: 1.0, model: "claude-opus-4-7", created_at: daysAgo(1) });
+		seedCostEvent(db, {
+			session_key: "s1",
+			cost_usd: 0.5,
+			model: "claude-sonnet-4-6",
+			created_at: daysAgo(1),
+		});
+		seedCostEvent(db, { session_key: "s1", cost_usd: 2.0, model: "claude-opus-4-7", created_at: daysAgo(2) });
+
+		const res = await handleUiRequest(req("/ui/api/cost?days=30"));
+		const body = (await res.json()) as CostResponse;
+		expect(body.daily.length).toBe(2);
+		const day2 = body.daily.find((d) => d.day === daysAgo(2).slice(0, 10));
+		expect(day2).toBeDefined();
+		expect(day2?.cost_usd).toBeCloseTo(2.0, 6);
+		expect(day2?.by_model.length).toBe(1);
+		expect(day2?.by_model[0].model).toBe("claude-opus-4-7");
+		const day1 = body.daily.find((d) => d.day === daysAgo(1).slice(0, 10));
+		expect(day1).toBeDefined();
+		expect(day1?.cost_usd).toBeCloseTo(1.5, 6);
+		expect(day1?.by_model.length).toBe(2);
+	});
+
+	test("by_model pct sums to ~1 and orders by cost DESC", async () => {
+		seedSession(db, { session_key: "s1", channel_id: "slack", conversation_id: "c1" });
+		seedCostEvent(db, { session_key: "s1", cost_usd: 8.0, model: "claude-opus-4-7" });
+		seedCostEvent(db, { session_key: "s1", cost_usd: 2.0, model: "claude-sonnet-4-6" });
+
+		const res = await handleUiRequest(req("/ui/api/cost?days=all"));
+		const body = (await res.json()) as CostResponse;
+		expect(body.by_model.length).toBe(2);
+		expect(body.by_model[0].model).toBe("claude-opus-4-7");
+		expect(body.by_model[0].pct).toBeCloseTo(0.8, 3);
+		expect(body.by_model[1].pct).toBeCloseTo(0.2, 3);
+		const sum = body.by_model.reduce((a, r) => a + r.pct, 0);
+		expect(sum).toBeCloseTo(1, 6);
+	});
+
+	test("by_channel includes avg_per_session from distinct session count", async () => {
+		seedSession(db, { session_key: "s1", channel_id: "slack", conversation_id: "c1" });
+		seedSession(db, { session_key: "s2", channel_id: "slack", conversation_id: "c2" });
+		seedSession(db, { session_key: "s3", channel_id: "chat", conversation_id: "c3" });
+		seedCostEvent(db, { session_key: "s1", cost_usd: 3.0 });
+		seedCostEvent(db, { session_key: "s1", cost_usd: 1.0 });
+		seedCostEvent(db, { session_key: "s2", cost_usd: 2.0 });
+		seedCostEvent(db, { session_key: "s3", cost_usd: 5.0 });
+
+		const res = await handleUiRequest(req("/ui/api/cost?days=all"));
+		const body = (await res.json()) as CostResponse;
+		const slack = body.by_channel.find((c) => c.channel_id === "slack");
+		expect(slack?.cost_usd).toBeCloseTo(6.0, 6);
+		expect(slack?.sessions).toBe(2);
+		expect(slack?.avg_per_session).toBeCloseTo(3.0, 6);
+		const chat = body.by_channel.find((c) => c.channel_id === "chat");
+		expect(chat?.avg_per_session).toBeCloseTo(5.0, 6);
+	});
+
+	test("top_sessions limits to 10 and orders by total_cost_usd DESC", async () => {
+		for (let i = 0; i < 15; i++) {
+			seedSession(db, {
+				session_key: `k${i}`,
+				channel_id: "slack",
+				conversation_id: `cv${i}`,
+				total_cost_usd: (15 - i) * 0.5,
+			});
+		}
+
+		const res = await handleUiRequest(req("/ui/api/cost?days=all"));
+		const body = (await res.json()) as CostResponse;
+		expect(body.top_sessions.length).toBe(10);
+		expect(body.top_sessions[0].session_key).toBe("k0");
+		expect(body.top_sessions[0].total_cost_usd).toBeCloseTo(7.5, 6);
+		for (let i = 1; i < body.top_sessions.length; i++) {
+			expect(body.top_sessions[i].total_cost_usd).toBeLessThanOrEqual(
+				body.top_sessions[i - 1].total_cost_usd,
+			);
+		}
+	});
+
+	test("range param filters daily, by_model, by_channel to window", async () => {
+		seedSession(db, { session_key: "s1", channel_id: "slack", conversation_id: "c1" });
+		seedCostEvent(db, { session_key: "s1", cost_usd: 1.0, created_at: daysAgo(3) });
+		seedCostEvent(db, { session_key: "s1", cost_usd: 2.0, created_at: daysAgo(10) });
+		seedCostEvent(db, { session_key: "s1", cost_usd: 3.0, created_at: daysAgo(40) });
+
+		const res7 = await handleUiRequest(req("/ui/api/cost?days=7"));
+		const body7 = (await res7.json()) as CostResponse;
+		expect(body7.daily.length).toBe(1);
+		expect(body7.by_model[0]?.cost_usd).toBeCloseTo(1.0, 6);
+
+		const res30 = await handleUiRequest(req("/ui/api/cost?days=30"));
+		const body30 = (await res30.json()) as CostResponse;
+		expect(body30.daily.length).toBe(2);
+		expect(body30.by_model[0]?.cost_usd).toBeCloseTo(3.0, 6);
+
+		const resAll = await handleUiRequest(req("/ui/api/cost?days=all"));
+		const bodyAll = (await resAll.json()) as CostResponse;
+		expect(bodyAll.daily.length).toBe(3);
+		expect(bodyAll.by_model[0]?.cost_usd).toBeCloseTo(6.0, 6);
+	});
+
+	test("default days is 30 when param omitted", async () => {
+		seedSession(db, { session_key: "s1", channel_id: "slack", conversation_id: "c1" });
+		seedCostEvent(db, { session_key: "s1", cost_usd: 1.0, created_at: daysAgo(3) });
+		seedCostEvent(db, { session_key: "s1", cost_usd: 5.0, created_at: daysAgo(60) });
+
+		const res = await handleUiRequest(req("/ui/api/cost"));
+		const body = (await res.json()) as CostResponse;
+		expect(body.range.days).toBe(30);
+		expect(body.daily.length).toBe(1);
+	});
+
+	test("SQL injection attempt on days is rejected at parse time", async () => {
+		seedSession(db, { session_key: "s1", channel_id: "slack", conversation_id: "c1" });
+		seedCostEvent(db, { session_key: "s1", cost_usd: 1.0 });
+		const before = (db.query("SELECT COUNT(*) as n FROM cost_events").get() as { n: number }).n;
+		expect(before).toBe(1);
+
+		const payload = "1; DROP TABLE cost_events; --";
+		const res = await handleUiRequest(req(`/ui/api/cost?days=${encodeURIComponent(payload)}`));
+		expect(res.status).toBe(422);
+
+		const after = (db.query("SELECT COUNT(*) as n FROM cost_events").get() as { n: number }).n;
+		expect(after).toBe(1);
+	});
+});

--- a/src/ui/api/__tests__/cost.test.ts
+++ b/src/ui/api/__tests__/cost.test.ts
@@ -12,47 +12,14 @@ let sessionToken: string;
 
 type CostResponse = {
 	range: { from: string | null; to: string; days: number | "all" };
-	headline: {
-		today: number;
-		yesterday: number;
-		this_week: number;
-		this_month: number;
-		all_time: number;
-		day_delta_pct: number;
-		week_delta_pct: number;
-	};
-	daily: Array<{
-		day: string;
-		cost_usd: number;
-		input_tokens: number;
-		output_tokens: number;
-		by_model: Array<{ model: string; cost_usd: number }>;
-	}>;
-	by_model: Array<{
-		model: string;
-		cost_usd: number;
-		pct: number;
-		input_tokens: number;
-		output_tokens: number;
-		events: number;
-	}>;
-	by_channel: Array<{
-		channel_id: string;
-		cost_usd: number;
-		sessions: number;
-		avg_per_session: number;
-		input_tokens: number;
-		output_tokens: number;
-	}>;
-	top_sessions: Array<{
-		session_key: string;
-		channel_id: string;
-		conversation_id: string;
-		total_cost_usd: number;
-		turn_count: number;
-		last_active_at: string;
-	}>;
-	limits: { top_sessions: number };
+	headline: Record<
+		"today" | "yesterday" | "this_week" | "this_month" | "all_time" | "day_delta_pct" | "week_delta_pct",
+		number
+	>;
+	daily: Array<{ day: string; cost_usd: number; by_model: Array<{ model: string; cost_usd: number }> }>;
+	by_model: Array<{ model: string; cost_usd: number; pct: number }>;
+	by_channel: Array<{ channel_id: string; cost_usd: number; sessions: number; avg_per_session: number }>;
+	top_sessions: Array<{ session_key: string; total_cost_usd: number }>;
 };
 
 function runMigrations(target: Database): void {
@@ -312,9 +279,7 @@ describe("cost API", () => {
 		expect(body.top_sessions[0].session_key).toBe("k0");
 		expect(body.top_sessions[0].total_cost_usd).toBeCloseTo(7.5, 6);
 		for (let i = 1; i < body.top_sessions.length; i++) {
-			expect(body.top_sessions[i].total_cost_usd).toBeLessThanOrEqual(
-				body.top_sessions[i - 1].total_cost_usd,
-			);
+			expect(body.top_sessions[i].total_cost_usd).toBeLessThanOrEqual(body.top_sessions[i - 1].total_cost_usd);
 		}
 	});
 

--- a/src/ui/api/__tests__/cost.test.ts
+++ b/src/ui/api/__tests__/cost.test.ts
@@ -263,14 +263,14 @@ describe("cost API", () => {
 		expect(chat?.avg_per_session).toBeCloseTo(5.0, 6);
 	});
 
-	test("top_sessions limits to 10 and orders by total_cost_usd DESC", async () => {
+	test("top_sessions limits to 10 and orders by summed cost_events DESC", async () => {
 		for (let i = 0; i < 15; i++) {
 			seedSession(db, {
 				session_key: `k${i}`,
 				channel_id: "slack",
 				conversation_id: `cv${i}`,
-				total_cost_usd: (15 - i) * 0.5,
 			});
+			seedCostEvent(db, { session_key: `k${i}`, cost_usd: (15 - i) * 0.5 });
 		}
 
 		const res = await handleUiRequest(req("/ui/api/cost?days=all"));
@@ -281,6 +281,24 @@ describe("cost API", () => {
 		for (let i = 1; i < body.top_sessions.length; i++) {
 			expect(body.top_sessions[i].total_cost_usd).toBeLessThanOrEqual(body.top_sessions[i - 1].total_cost_usd);
 		}
+	});
+
+	test("top_sessions ranks by in-window spend, not lifetime", async () => {
+		// Session A: $50 lifetime, but only $5 in last 7 days.
+		seedSession(db, { session_key: "old-whale", channel_id: "slack", conversation_id: "cw" });
+		seedCostEvent(db, { session_key: "old-whale", cost_usd: 45.0, created_at: daysAgo(40) });
+		seedCostEvent(db, { session_key: "old-whale", cost_usd: 5.0, created_at: daysAgo(2) });
+
+		// Session B: $10 all from this week.
+		seedSession(db, { session_key: "fresh", channel_id: "slack", conversation_id: "cf" });
+		seedCostEvent(db, { session_key: "fresh", cost_usd: 10.0, created_at: daysAgo(1) });
+
+		const res = await handleUiRequest(req("/ui/api/cost?days=7"));
+		const body = (await res.json()) as CostResponse;
+		expect(body.top_sessions[0].session_key).toBe("fresh");
+		expect(body.top_sessions[0].total_cost_usd).toBeCloseTo(10.0, 6);
+		expect(body.top_sessions[1].session_key).toBe("old-whale");
+		expect(body.top_sessions[1].total_cost_usd).toBeCloseTo(5.0, 6);
 	});
 
 	test("range param filters daily, by_model, by_channel to window", async () => {

--- a/src/ui/api/cost.ts
+++ b/src/ui/api/cost.ts
@@ -1,0 +1,96 @@
+// UI API route for the Cost dashboard tab. One combined endpoint so the
+// client does a single fetch.
+//
+//   GET /ui/api/cost?days=<n|all>
+//
+// Returns headline totals, a daily stacked-by-model timeseries, by-model
+// and by-channel breakdowns, and the 10 most expensive sessions. Read-only
+// over cost_events + sessions, cookie-auth gated by the dispatcher.
+
+import type { Database } from "bun:sqlite";
+import { z } from "zod";
+import {
+	getByChannel,
+	getByModel,
+	getCostHeadline,
+	getDailyCost,
+	getTopSessions,
+} from "../../agent/cost-queries.ts";
+
+type CostApiDeps = {
+	db: Database;
+};
+
+const TOP_SESSIONS_LIMIT = 10;
+
+const DaysSchema = z.union([z.literal("all"), z.coerce.number().int().min(1).max(365)]);
+
+const QuerySchema = z.object({
+	days: DaysSchema.optional(),
+});
+
+type CostQuery = z.infer<typeof QuerySchema>;
+
+function json(body: unknown, init?: ResponseInit): Response {
+	return new Response(JSON.stringify(body), {
+		...init,
+		headers: {
+			"Content-Type": "application/json",
+			"Cache-Control": "no-store",
+			...((init?.headers as Record<string, string>) ?? {}),
+		},
+	});
+}
+
+function parseQuery(url: URL): { ok: true; value: CostQuery } | { ok: false; error: string } {
+	const raw: Record<string, string> = {};
+	const days = url.searchParams.get("days");
+	if (days !== null && days.length > 0) raw.days = days;
+	const parsed = QuerySchema.safeParse(raw);
+	if (!parsed.success) {
+		const issue = parsed.error.issues[0];
+		const path = issue.path.length > 0 ? issue.path.join(".") : "query";
+		return { ok: false, error: `${path}: ${issue.message}` };
+	}
+	return { ok: true, value: parsed.data };
+}
+
+function handleGet(db: Database, filter: CostQuery): Response {
+	const daysVal = filter.days ?? 30;
+	const days: number | null = daysVal === "all" ? null : daysVal;
+
+	const headline = getCostHeadline(db);
+	const daily = getDailyCost(db, days);
+	const by_model = getByModel(db, days);
+	const by_channel = getByChannel(db, days);
+	const top_sessions = getTopSessions(db, TOP_SESSIONS_LIMIT, days);
+
+	const now = new Date();
+	const from =
+		days === null
+			? null
+			: new Date(now.getTime() - days * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+	const to = now.toISOString().slice(0, 10);
+
+	return json({
+		range: { from, to, days: days === null ? "all" : days },
+		headline,
+		daily,
+		by_model,
+		by_channel,
+		top_sessions,
+		limits: { top_sessions: TOP_SESSIONS_LIMIT },
+	});
+}
+
+export async function handleCostApi(req: Request, url: URL, deps: CostApiDeps): Promise<Response | null> {
+	if (url.pathname !== "/ui/api/cost") return null;
+
+	if (req.method === "GET") {
+		const parsed = parseQuery(url);
+		if (!parsed.ok) return json({ error: parsed.error }, { status: 422 });
+		return handleGet(deps.db, parsed.value);
+	}
+
+	return json({ error: "Method not allowed" }, { status: 405 });
+}

--- a/src/ui/api/cost.ts
+++ b/src/ui/api/cost.ts
@@ -9,13 +9,7 @@
 
 import type { Database } from "bun:sqlite";
 import { z } from "zod";
-import {
-	getByChannel,
-	getByModel,
-	getCostHeadline,
-	getDailyCost,
-	getTopSessions,
-} from "../../agent/cost-queries.ts";
+import { getByChannel, getByModel, getCostHeadline, getDailyCost, getTopSessions } from "../../agent/cost-queries.ts";
 
 type CostApiDeps = {
 	db: Database;
@@ -66,10 +60,7 @@ function handleGet(db: Database, filter: CostQuery): Response {
 	const top_sessions = getTopSessions(db, TOP_SESSIONS_LIMIT, days);
 
 	const now = new Date();
-	const from =
-		days === null
-			? null
-			: new Date(now.getTime() - days * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+	const from = days === null ? null : new Date(now.getTime() - days * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
 	const to = now.toISOString().slice(0, 10);
 
 	return json({

--- a/src/ui/serve.ts
+++ b/src/ui/serve.ts
@@ -7,6 +7,7 @@ import { consumeMagicLink, createSession, isValidSession } from "./session.ts";
 
 import { secretsExpiredHtml, secretsFormHtml } from "../secrets/form-page.ts";
 import { getSecretRequest, saveSecrets, validateMagicToken } from "../secrets/store.ts";
+import { handleCostApi } from "./api/cost.ts";
 import { handleHooksApi } from "./api/hooks.ts";
 import { handleMemoryFilesApi } from "./api/memory-files.ts";
 import { type PluginsApiDeps, handlePluginsApi } from "./api/plugins.ts";
@@ -219,6 +220,13 @@ export async function handleUiRequest(req: Request): Promise<Response> {
 			return Response.json({ error: "Dashboard API not initialized" }, { status: 503 });
 		}
 		const apiResponse = await handleSessionsApi(req, url, { db: dashboardDb });
+		if (apiResponse) return apiResponse;
+	}
+	if (url.pathname.startsWith("/ui/api/cost")) {
+		if (!dashboardDb) {
+			return Response.json({ error: "Dashboard API not initialized" }, { status: 503 });
+		}
+		const apiResponse = await handleCostApi(req, url, { db: dashboardDb });
 		if (apiResponse) return apiResponse;
 	}
 


### PR DESCRIPTION
## Summary

Ships the Cost tab: a single combined `GET /ui/api/cost` endpoint plus a new `cost.js` module with a headline metric strip, a shared SVG stacked bar chart, by-model and by-channel breakdowns, and a top-10 sessions table that navigates across tabs into the Sessions drawer.

- Backend: one read-only endpoint with Zod-validated `days` param (1..365 or `all`). Four SQLite queries via a new `src/agent/cost-queries.ts` helper so the MCP cost resource, the `metrics_read` tool, and the dashboard all share the same aggregation SQL. Every `SUM(cost_usd)` is wrapped in `COALESCE(..., 0)` so empty result sets return `0` rather than NULL. Day/week deltas return `0` (not `NaN`) when the prior period was empty.
- Chart primitive: `renderStackedBarChart` in `cost.js` is generic over `{ day, segments: [{ value, seriesIdx }] }` rows and returns SVG markup. Evolution (and possibly Memory) will reuse it as a sparkline in a later PR. Color palette is driven by `[data-series-idx]` CSS so dark/light themes track automatically; no hardcoded hex inside the SVG.
- Cross-tab nav: clicking a top-session row hashes to `#/sessions/<url-encoded key>`. The Sessions tab's existing `mount(container, arg, ctx)` handler then opens its drawer. Verified end to end.
- Interactions: Range picker (7/30/90/All) refetches; Day | Week toggle buckets client-side (single fetch); hover on a chart bar shows a tooltip with day + per-model breakdown + total; CSV export covers the daily timeseries.
- States: skeleton metric strip + skeleton chart on first load, empty state messaging per section if no rows, error state with retry.

## cost-queries refactor

Done. `src/agent/cost-queries.ts` exports `getCostForPeriod(db, dateFilter)` which both `src/mcp/resources.ts` (per-period resource) and `src/mcp/tools-universal.ts` (`metrics_read` tool) now delegate to. Richer helpers (`getCostHeadline`, `getDailyCost`, `getByModel`, `getByChannel`, `getTopSessions`) are used by the new cost API.

## LOC discipline

PR 2 shipped 2.6x its budget. This PR targeted a ~850 LOC total with a 1,200 LOC ceiling; we landed at ~1,420 across all changed files (overshoot ~18%). `cost.js` finished at 642 LOC against a 600 ceiling (7% overshoot), after extracting a `renderTable` helper to DRY the three tables and a `chartFrame` helper for the chart skeleton/empty/populated paths. Further compression would start to hurt clarity.

## Test plan

Backend coverage (`src/ui/api/__tests__/cost.test.ts`, 14 cases, all pass):
- [x] Headline math: today / yesterday / this_week / this_month / all_time match hand-calculated totals
- [x] `day_delta_pct` is 0 (not NaN) when yesterday is 0; correct when populated
- [x] `week_delta_pct` correct against prior week
- [x] Empty DB: every numeric is 0, no `null` or `NaN` anywhere in response
- [x] Daily timeseries groups by date with per-model breakdown
- [x] By-model `pct` sums to 1.0 and orders by cost DESC
- [x] By-channel `avg_per_session` uses `COUNT(DISTINCT session_key)`
- [x] Top sessions limits to 10, ordered by `total_cost_usd` DESC
- [x] Range param filters daily/by_model/by_channel
- [x] Default `days` is 30 when param omitted
- [x] Invalid `days` returns 422; SQL injection on `days` rejected at parse
- [x] POST returns 405; 401 without cookie

Full suite: 1,644 pass / 0 fail. Biome lint + tsc --noEmit both clean.

Visual verification in browser (light, dark, and 380px mobile):
- [x] `http://.../ui/dashboard/#/cost` renders header, filter bar, 5-card strip, chart, breakdowns, top sessions
- [x] Range picker re-fetches
- [x] Day/Week toggle re-buckets client-side (chart title becomes "Weekly spend")
- [x] Hover over a bar shows `day + per-model breakdown + total` tooltip, clamped to chart edges
- [x] Click a top-session row navigates to `#/sessions/<key>` and the Sessions drawer opens with overview + cost events
- [x] Dark theme picks up palette via CSS vars
- [x] Mobile: breakdown grid collapses to one column, metric cards wrap, top-sessions table stays legible
- [x] No cost.js-originated console errors

## Cardinal Rule

Read-only aggregation over existing data. Cardinal Rule exception applies.