### PR TITLE
v0.20 PR 4: Scheduler dashboard tab with create-job and Sonnet describe-assist

### DIFF
--- a/public/dashboard/dashboard.css
+++ b/public/dashboard/dashboard.css
@@ -2245,3 +2245,291 @@ body {
 	.dash-chart-skeleton { animation: none; }
 	.dash-chart-bar, .dash-chart-tooltip { transition: none; }
 }
+
+/* ==== Scheduler-specific additions (PR4) ==== */
+
+.dash-status-chip-completed {
+	background: color-mix(in oklab, var(--color-base-content) 9%, transparent);
+	color: color-mix(in oklab, var(--color-base-content) 72%, transparent);
+}
+.dash-status-chip-failed {
+	background: color-mix(in oklab, var(--color-error) 14%, transparent);
+	color: var(--color-error);
+}
+
+.dash-sched-wide-drawer {
+	width: min(640px, 58vw);
+}
+@media (max-width: 720px) {
+	.dash-sched-wide-drawer { width: 100%; max-width: 100%; }
+}
+
+.dash-sched-drawer-actions {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	flex-wrap: wrap;
+}
+
+.dash-sched-template-row {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 6px;
+	align-items: center;
+}
+.dash-sched-template-pill {
+	font: 500 12px Inter, system-ui, sans-serif;
+	color: var(--color-base-content);
+	background: var(--color-base-200);
+	border: 1px solid var(--color-base-300);
+	padding: 6px 12px;
+	border-radius: var(--radius-pill);
+	cursor: pointer;
+	transition: border-color var(--motion-fast), background-color var(--motion-fast);
+}
+.dash-sched-template-pill:hover {
+	border-color: color-mix(in oklab, var(--color-primary) 40%, var(--color-base-300));
+	background: color-mix(in oklab, var(--color-primary) 4%, var(--color-base-200));
+}
+.dash-sched-template-pill[aria-pressed="true"] {
+	border-color: var(--color-primary);
+	background: color-mix(in oklab, var(--color-primary) 10%, var(--color-base-200));
+	color: var(--color-primary);
+}
+.dash-sched-template-pill:focus-visible {
+	outline: none;
+	box-shadow: 0 0 0 3px color-mix(in oklab, var(--color-primary) 25%, transparent);
+}
+.dash-sched-template-clear {
+	font: 500 12px Inter, system-ui, sans-serif;
+	background: transparent;
+	border: 0;
+	color: color-mix(in oklab, var(--color-base-content) 55%, transparent);
+	cursor: pointer;
+	text-decoration: underline;
+	text-underline-offset: 3px;
+	padding: 4px 6px;
+}
+.dash-sched-template-clear:hover { color: var(--color-base-content); }
+
+.dash-sched-preview {
+	padding: var(--space-3) var(--space-4);
+	border-radius: var(--radius-sm);
+	background: color-mix(in oklab, var(--color-primary) 6%, var(--color-base-200));
+	border: 1px solid color-mix(in oklab, var(--color-primary) 20%, var(--color-base-300));
+	font-size: 12.5px;
+	color: var(--color-base-content);
+	display: flex;
+	align-items: center;
+	gap: 8px;
+}
+.dash-sched-preview-label {
+	font-weight: 600;
+	color: color-mix(in oklab, var(--color-primary) 90%, var(--color-base-content));
+}
+.dash-sched-preview-error {
+	background: color-mix(in oklab, var(--color-error) 6%, var(--color-base-200));
+	border-color: color-mix(in oklab, var(--color-error) 30%, var(--color-base-300));
+	color: var(--color-error);
+}
+
+.dash-sched-field-row {
+	display: flex;
+	gap: var(--space-3);
+	align-items: flex-start;
+}
+.dash-sched-field-row > * { flex: 1; min-width: 0; }
+@media (max-width: 520px) {
+	.dash-sched-field-row { flex-direction: column; }
+}
+
+.dash-sched-radio-group {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+	margin-top: 2px;
+}
+.dash-sched-radio {
+	display: flex;
+	align-items: center;
+	gap: var(--space-2);
+	font-size: 13px;
+	color: var(--color-base-content);
+	cursor: pointer;
+	padding: 6px 8px;
+	border-radius: var(--radius-sm);
+	transition: background-color var(--motion-fast);
+}
+.dash-sched-radio:hover { background: color-mix(in oklab, var(--color-base-content) 4%, transparent); }
+.dash-sched-radio input[type="radio"] {
+	accent-color: var(--color-primary);
+	margin: 0;
+}
+
+.dash-sched-describe {
+	padding: var(--space-4);
+	background: color-mix(in oklab, var(--color-primary) 3%, var(--color-base-200));
+	border: 1px solid color-mix(in oklab, var(--color-primary) 18%, var(--color-base-300));
+	border-radius: var(--radius-md);
+	display: flex;
+	flex-direction: column;
+	gap: var(--space-3);
+}
+.dash-sched-describe-header {
+	display: flex;
+	justify-content: space-between;
+	align-items: baseline;
+	gap: var(--space-2);
+}
+.dash-sched-describe-title {
+	font-size: 13px;
+	font-weight: 600;
+	margin: 0;
+	color: var(--color-base-content);
+}
+.dash-sched-describe-eyebrow {
+	font-size: 10px;
+	font-weight: 600;
+	letter-spacing: 0.09em;
+	text-transform: uppercase;
+	color: color-mix(in oklab, var(--color-primary) 80%, var(--color-base-content));
+	margin: 0;
+}
+.dash-sched-describe-actions {
+	display: flex;
+	gap: var(--space-2);
+	align-items: center;
+}
+.dash-sched-describe-filled-banner {
+	padding: 8px 12px;
+	border-radius: var(--radius-sm);
+	background: color-mix(in oklab, var(--color-success) 10%, var(--color-base-200));
+	border: 1px solid color-mix(in oklab, var(--color-success) 32%, var(--color-base-300));
+	color: color-mix(in oklab, var(--color-success) 90%, var(--color-base-content));
+	font-size: 12.5px;
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	gap: var(--space-2);
+}
+.dash-sched-describe-error {
+	padding: 8px 12px;
+	border-radius: var(--radius-sm);
+	background: color-mix(in oklab, var(--color-error) 8%, var(--color-base-200));
+	border: 1px solid color-mix(in oklab, var(--color-error) 32%, var(--color-base-300));
+	color: color-mix(in oklab, var(--color-error) 88%, var(--color-base-content));
+	font-size: 12.5px;
+}
+
+.dash-sched-char-count {
+	font-size: 11px;
+	color: color-mix(in oklab, var(--color-base-content) 45%, transparent);
+	text-align: right;
+	font-variant-numeric: tabular-nums;
+}
+.dash-sched-char-count-over {
+	color: var(--color-error);
+}
+
+.dash-sched-code-block {
+	font-family: 'JetBrains Mono', ui-monospace, monospace;
+	font-size: 12px;
+	line-height: 1.55;
+	background: var(--color-base-200);
+	border: 1px solid var(--color-base-300);
+	border-radius: var(--radius-sm);
+	padding: var(--space-3);
+	white-space: pre-wrap;
+	word-break: break-word;
+	color: var(--color-base-content);
+	max-height: 320px;
+	overflow: auto;
+}
+
+.dash-sched-examples {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 6px;
+	margin-top: 6px;
+}
+.dash-sched-example-chip {
+	font: 500 11px 'JetBrains Mono', ui-monospace, monospace;
+	color: color-mix(in oklab, var(--color-base-content) 75%, transparent);
+	background: var(--color-base-200);
+	border: 1px solid var(--color-base-300);
+	padding: 3px 8px;
+	border-radius: var(--radius-sm);
+	cursor: pointer;
+	transition: border-color var(--motion-fast), background-color var(--motion-fast);
+}
+.dash-sched-example-chip:hover {
+	border-color: color-mix(in oklab, var(--color-primary) 30%, var(--color-base-300));
+	background: color-mix(in oklab, var(--color-primary) 4%, var(--color-base-200));
+}
+
+.dash-sched-run-result {
+	margin-top: var(--space-3);
+	font-family: 'JetBrains Mono', ui-monospace, monospace;
+	font-size: 12px;
+	background: var(--color-base-200);
+	border: 1px solid var(--color-base-300);
+	border-radius: var(--radius-sm);
+	padding: var(--space-3);
+	white-space: pre-wrap;
+	max-height: 220px;
+	overflow: auto;
+}
+
+.dash-sched-audit-list {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+	font-size: 12px;
+}
+.dash-sched-audit-row {
+	display: grid;
+	grid-template-columns: auto auto 1fr auto;
+	gap: var(--space-3);
+	align-items: baseline;
+	padding: 4px 0;
+	border-bottom: 1px dashed color-mix(in oklab, var(--color-base-content) 8%, transparent);
+}
+.dash-sched-audit-row:last-child { border-bottom: 0; }
+.dash-sched-audit-action {
+	font-weight: 600;
+	font-family: 'JetBrains Mono', ui-monospace, monospace;
+	color: var(--color-base-content);
+}
+.dash-sched-audit-actor {
+	font-size: 11px;
+	color: color-mix(in oklab, var(--color-base-content) 55%, transparent);
+}
+.dash-sched-audit-detail {
+	color: color-mix(in oklab, var(--color-base-content) 65%, transparent);
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+.dash-sched-audit-time {
+	font-size: 11px;
+	font-family: 'JetBrains Mono', ui-monospace, monospace;
+	color: color-mix(in oklab, var(--color-base-content) 45%, transparent);
+}
+
+.dash-sched-inline-spinner {
+	width: 12px;
+	height: 12px;
+	border-radius: 50%;
+	border: 2px solid color-mix(in oklab, var(--color-base-content) 20%, transparent);
+	border-top-color: var(--color-primary);
+	display: inline-block;
+	animation: dash-sched-spin 700ms linear infinite;
+	vertical-align: -2px;
+	margin-right: 6px;
+}
+@keyframes dash-sched-spin {
+	to { transform: rotate(360deg); }
+}
+@media (prefers-reduced-motion: reduce) {
+	.dash-sched-inline-spinner { animation: none; }
+}

--- a/public/dashboard/dashboard.js
+++ b/public/dashboard/dashboard.js
@@ -214,11 +214,6 @@
 				title: "Cost",
 				body: "Daily and weekly cost breakdowns with model-level detail. Charts across time so you can see where the agent's budget actually goes, and alerts when anything drifts out of its baseline.",
 			},
-			scheduler: {
-				eyebrow: "soon",
-				title: "Scheduler",
-				body: "Every cron and one-shot job the agent has created, with next-run times, recent outcomes, and the ability to edit or pause a schedule without asking the agent to do it for you.",
-			},
 			evolution: {
 				eyebrow: "soon",
 				title: "Evolution timeline",
@@ -265,8 +260,8 @@
 		var name = parsed.route;
 		deactivateAllRoutes();
 
-		var liveRoutes = ["skills", "memory-files", "plugins", "subagents", "hooks", "settings", "sessions", "cost"];
-		var comingSoon = ["scheduler", "evolution", "memory"];
+		var liveRoutes = ["skills", "memory-files", "plugins", "subagents", "hooks", "settings", "sessions", "cost", "scheduler"];
+		var comingSoon = ["evolution", "memory"];
 
 		if (liveRoutes.indexOf(name) >= 0 && routes[name]) {
 			var containerId = "route-" + name;

--- a/public/dashboard/index.html
+++ b/public/dashboard/index.html
@@ -36,6 +36,10 @@
   <aside class="dash-sidebar" aria-label="Dashboard sections">
     <div class="dash-sidebar-eyebrow">Workspace</div>
     <nav class="dash-sidebar-nav" id="sidebar-nav">
+      <a href="#/scheduler" class="dash-sidebar-item" data-route="scheduler">
+        <svg class="dash-sidebar-icon" fill="none" viewBox="0 0 24 24" stroke-width="1.6" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6h4.5m4.5 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"/></svg>
+        <span>Scheduler</span>
+      </a>
       <a href="#/skills" class="dash-sidebar-item" data-route="skills">
         <svg class="dash-sidebar-icon" fill="none" viewBox="0 0 24 24" stroke-width="1.6" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M12 6.042A8.967 8.967 0 0 0 6 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 0 1 6 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 0 1 6-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0 0 18 18a8.967 8.967 0 0 0-6 2.292m0-14.25v14.25"/></svg>
         <span>Skills</span>
@@ -72,11 +76,6 @@
 
     <div class="dash-sidebar-eyebrow" style="margin-top:var(--space-5);">Coming soon</div>
     <nav class="dash-sidebar-nav">
-      <a href="#/scheduler" class="dash-sidebar-item dash-sidebar-item-soon" data-route="scheduler">
-        <svg class="dash-sidebar-icon" fill="none" viewBox="0 0 24 24" stroke-width="1.6" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6h4.5m4.5 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"/></svg>
-        <span>Scheduler</span>
-        <span class="dash-sidebar-soon-pill">soon</span>
-      </a>
       <a href="#/evolution" class="dash-sidebar-item dash-sidebar-item-soon" data-route="evolution">
         <svg class="dash-sidebar-icon" fill="none" viewBox="0 0 24 24" stroke-width="1.6" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0 3.181 3.183a8.25 8.25 0 0 0 13.803-3.7M4.031 9.865a8.25 8.25 0 0 1 13.803-3.7l3.181 3.182m0-4.991v4.99"/></svg>
         <span>Evolution</span>
@@ -104,6 +103,7 @@
     <div id="route-settings" class="dash-route" hidden></div>
     <div id="route-sessions" class="dash-route" hidden></div>
     <div id="route-cost" class="dash-route" hidden></div>
+    <div id="route-scheduler" class="dash-route" hidden></div>
     <div id="route-soon" class="dash-route" hidden></div>
   </main>
 
@@ -120,6 +120,7 @@
 <script src="/ui/dashboard/settings.js"></script>
 <script src="/ui/dashboard/sessions.js"></script>
 <script src="/ui/dashboard/cost.js"></script>
+<script src="/ui/dashboard/scheduler.js"></script>
 <script>window.PhantomDashboard.init();</script>
 </body>
 </html>

--- a/public/dashboard/scheduler.js
+++ b/public/dashboard/scheduler.js
@@ -62,7 +62,7 @@
 			open: false, appliedTemplate: null, form: defaultForm(), dirtyByUser: false,
 			preview: null, previewError: null, previewPending: false,
 			submitting: false, submitError: null,
-			describeText: "", describeFilled: false, describePending: false, describeError: null, describeDisabled: false,
+			describeText: "", describeFilled: false, describePending: false, describeError: null,
 			errors: {},
 		};
 	}
@@ -667,7 +667,6 @@
 	}
 
 	function renderDescribe() {
-		if (state.create.describeDisabled) return "";
 		var c = state.create;
 		var count = c.describeText.length, over = count > DESCRIBE_MAX;
 		var banner = c.describeFilled
@@ -1019,13 +1018,7 @@
 			schedulePreview();
 		}).catch(function (err) {
 			state.create.describePending = false;
-			if (err.status === 503) {
-				state.create.describeDisabled = true;
-				state.create.describeError = null;
-				ctx.toast("error", "Describe assist unavailable", "Set ANTHROPIC_API_KEY to enable this.");
-			} else {
-				state.create.describeError = err.message || "Could not parse description, please fill the form manually.";
-			}
+			state.create.describeError = err.message || "Could not parse description, please fill the form manually.";
 			renderCreateDrawer();
 		});
 	}

--- a/public/dashboard/scheduler.js
+++ b/public/dashboard/scheduler.js
@@ -235,7 +235,7 @@
 		var errors = job.consecutiveErrors || 0;
 		var lastCell = job.lastRunAt ? (job.lastRunStatus === "ok" ? "ok " : "err ") + relativeTime(job.lastRunAt) : "never";
 		var errorBadge = errors > 0 ? '<span class="dash-status-chip dash-status-chip-failed">' + esc(String(errors)) + '</span>' : '<span class="phantom-muted">0</span>';
-		var nextLabel = job.nextRunAt ? relativeTime(job.nextRunAt) : (job.status === "paused" ? "paused" : "\u2014");
+		var nextLabel = job.nextRunAt ? relativeTime(job.nextRunAt) : (job.status === "paused" ? "paused" : "-");
 		return '<tr class="dash-table-row" data-clickable="true" data-job-id="' + esc(job.id) + '" tabindex="0" role="button" aria-label="Open job ' + esc(job.name) + '">' +
 			'<td class="dash-table-cell dash-table-cell-mono">' + esc(job.name) + '</td>' +
 			'<td class="dash-table-cell dash-table-cell-mono phantom-muted">' + esc(humanSchedule(job.schedule)) + '</td>' +
@@ -986,8 +986,10 @@
 		var v = t.values, f = defaultForm();
 		f.name = v.name; f.description = v.description || ""; f.task = v.task || "";
 		f.enabled = v.enabled !== false;
+		// Templates ship "every", "cron", or "at" only. UI-only "daily" never
+		// appears in template values; it's exposed in the manual editor and
+		// translated to cron at submit.
 		if (v.schedule.kind === "every") { f.schedule.kind = "every"; f.schedule.unit = v.schedule.unit || "hours"; f.schedule.value = v.schedule.value || 1; }
-		else if (v.schedule.kind === "daily") { f.schedule.kind = "daily"; f.schedule.expr = v.schedule.expr || ""; f.schedule.at = v.schedule.time || "09:00"; f.schedule.tz = v.schedule.tz || defaultTz(); }
 		else if (v.schedule.kind === "cron") { f.schedule.kind = "cron"; f.schedule.expr = v.schedule.expr; f.schedule.tz = v.schedule.tz || defaultTz(); }
 		else if (v.schedule.kind === "at") { f.schedule.kind = "once"; f.schedule.at = v.schedule.at || ""; f.schedule.tz = v.schedule.tz || defaultTz(); }
 		if (v.delivery) { f.delivery.channel = v.delivery.channel || "slack"; f.delivery.targetKind = v.delivery.targetKind || "owner"; f.delivery.target = v.delivery.target || ""; }
@@ -1198,6 +1200,7 @@
 			name: f.name.trim(),
 			task: f.task,
 			schedule: buildServerSchedule(f.schedule),
+			enabled: f.enabled !== false,
 			createdBy: "user",
 		};
 		if (f.description.trim()) payload.description = f.description.trim();

--- a/public/dashboard/scheduler.js
+++ b/public/dashboard/scheduler.js
@@ -1,0 +1,1274 @@
+// Scheduler dashboard tab: list, detail drawer, create drawer with templates
+// and Sonnet describe-assist. Values from the API flow through ctx.esc() or
+// textContent. The task field renders as pre-wrapped text via textContent.
+// Cardinal Rule: the describe endpoint fills a form. The operator reviews
+// and edits the proposal before saving. See src/scheduler/parse-with-sonnet.ts.
+
+(function () {
+	var TASK_MAX = 32 * 1024;
+	var DESCRIPTION_MAX = 1000;
+	var DESCRIBE_MAX = 2000;
+	var NAME_MAX = 200;
+	var PREVIEW_DEBOUNCE_MS = 300;
+	var SEARCH_DEBOUNCE_MS = 200;
+
+	var TZ_OPTIONS = ["UTC", "America/Los_Angeles", "America/New_York", "America/Chicago", "Europe/London", "Europe/Berlin", "Asia/Tokyo", "Asia/Singapore", "Australia/Sydney"];
+	var CRON_EXAMPLES = ["*/15 * * * *", "0 9 * * *", "0 9 * * 1-5", "0 0 1 * *", "0 17 * * 5"];
+
+	// Templates. UI kind ("daily") maps to backend cron at submit.
+	var TEMPLATES = [
+		{ id: "hn-digest", label: "Hacker News digest", description: "Top HN stories every 6 hours, posted to your owner DM",
+			values: {
+				name: "hn-digest", description: "Top Hacker News stories every 6 hours",
+				task: "Fetch the top 10 Hacker News stories from\nhttps://hacker-news.firebaseio.com/v0/topstories.json, resolve each\nto its title and URL, and post a brief summary (one sentence per\nstory) to Slack.",
+				schedule: { kind: "every", unit: "hours", value: 6 },
+				delivery: { channel: "slack", targetKind: "owner" }, enabled: true } },
+		{ id: "daily-standup", label: "Daily standup", description: "9am weekdays, summary of yesterday and today's priorities",
+			values: {
+				name: "daily-standup", description: "Weekday 9am summary and priorities",
+				task: "Summarize yesterday's activity across Slack, pull requests, and scheduled job outputs. Then list three priorities for today. Post to Slack.",
+				schedule: { kind: "cron", expr: "0 9 * * 1-5", tz: "America/Los_Angeles" },
+				delivery: { channel: "slack", targetKind: "owner" }, enabled: true } },
+		{ id: "pr-review-reminder", label: "PR review reminder", description: "Every 2 hours, check for stale open PRs",
+			values: {
+				name: "pr-review-reminder", description: "Check for stale open PRs needing review",
+				task: "List any open pull requests on ghostwright/phantom older than 24 hours that have not received a review. Post to Slack.",
+				schedule: { kind: "every", unit: "hours", value: 2 },
+				delivery: { channel: "slack", targetKind: "owner" }, enabled: true } },
+		{ id: "weekly-metrics", label: "Weekly metrics", description: "Friday 5pm, summary of agent activity this week",
+			values: {
+				name: "weekly-metrics", description: "Weekly agent activity summary",
+				task: "Summarize this week's agent activity: session count, total cost, top channels, notable memories consolidated, evolution changes. Post to Slack.",
+				schedule: { kind: "cron", expr: "0 17 * * 5", tz: "America/Los_Angeles" },
+				delivery: { channel: "slack", targetKind: "owner" }, enabled: true } },
+	];
+
+	var state = makeInitialState();
+	var ctx = null, root = null;
+	var searchTimer = null, previewTimer = null;
+	var drawerRoot = null, drawerKeyHandler = null, drawerFocusRestore = null, prevBodyOverflow = null;
+	var documentKeyHandler = null, dirtyRegistered = false;
+
+	function makeInitialState() {
+		return {
+			loading: false, listError: null, list: null, summary: null,
+			filter: { status: "all", q: "" },
+			detail: { open: false, id: null, loading: false, error: null, job: null, audit: [], runResult: null, runPending: false },
+			create: makeCreateState(),
+		};
+	}
+	function makeCreateState() {
+		return {
+			open: false, appliedTemplate: null, form: defaultForm(), dirtyByUser: false,
+			preview: null, previewError: null, previewPending: false,
+			submitting: false, submitError: null,
+			describeText: "", describeFilled: false, describePending: false, describeError: null, describeDisabled: false,
+			errors: {},
+		};
+	}
+	function defaultForm() {
+		return {
+			name: "", description: "", task: "",
+			schedule: { kind: "every", unit: "hours", value: 1, expr: "", tz: defaultTz(), at: "" },
+			delivery: { channel: "slack", targetKind: "owner", target: "" },
+			enabled: true, deleteAfterRun: false,
+		};
+	}
+	function defaultTz() {
+		try { return Intl.DateTimeFormat().resolvedOptions().timeZone || "America/Los_Angeles"; } catch (_) { return "America/Los_Angeles"; }
+	}
+
+	function esc(s) { return ctx ? ctx.esc(s) : ""; }
+
+	function parseSqlDate(s) {
+		if (!s) return null;
+		var iso = String(s).indexOf("T") >= 0 ? s : String(s).replace(" ", "T") + "Z";
+		var d = new Date(iso);
+		if (isNaN(d.getTime())) { d = new Date(s); if (isNaN(d.getTime())) return null; }
+		return d;
+	}
+	function relativeTime(s) {
+		var d = parseSqlDate(s);
+		if (!d) return "";
+		var diff = d.getTime() - Date.now();
+		var future = diff > 0;
+		var sec = Math.round(Math.abs(diff) / 1000);
+		var label = sec < 60 ? sec + "s" : sec < 3600 ? Math.round(sec / 60) + "m" : sec < 86400 ? Math.round(sec / 3600) + "h" : Math.round(sec / 86400) + "d";
+		return future ? "in " + label : label + " ago";
+	}
+	function absoluteTime(s) {
+		var d = parseSqlDate(s);
+		return d ? d.toISOString().replace("T", " ").slice(0, 19) + " UTC" : "";
+	}
+
+	function humanSchedule(schedule) {
+		if (!schedule) return "";
+		if (schedule.kind === "every") {
+			var ms = schedule.intervalMs;
+			if (!ms) return "every ?";
+			if (ms < 60000) return "every " + Math.round(ms / 1000) + "s";
+			if (ms < 3_600_000) return "every " + Math.round(ms / 60000) + "m";
+			var hrs = ms / 3_600_000;
+			if (hrs === Math.floor(hrs) && hrs < 48) return "every " + hrs + "h";
+			var days = ms / 86_400_000;
+			return days === Math.floor(days) ? "every " + days + "d" : "every " + Math.round(hrs) + "h";
+		}
+		if (schedule.kind === "at") return "once " + schedule.at;
+		if (schedule.kind === "cron") return schedule.expr + (schedule.tz ? " " + schedule.tz : "");
+		return "";
+	}
+
+	function statusChip(status) {
+		if (!status) return "";
+		var cls = status === "active" ? "dash-status-chip-active" : status === "paused" ? "dash-status-chip-paused" : status === "completed" ? "dash-status-chip-completed" : status === "failed" ? "dash-status-chip-failed" : "";
+		return '<span class="dash-status-chip ' + cls + '">' + esc(status) + '</span>';
+	}
+
+	function deliverySummary(d) {
+		if (!d) return "";
+		return d.channel === "none" ? "silent" : "slack " + (d.target || "owner");
+	}
+
+	function cronToHhMm(expr) {
+		var parts = (expr || "").trim().split(/\s+/);
+		if (parts.length !== 5) return "09:00";
+		var m = Number(parts[0]), h = Number(parts[1]);
+		if (!Number.isFinite(m) || !Number.isFinite(h)) return "09:00";
+		return String(h).padStart(2, "0") + ":" + String(m).padStart(2, "0");
+	}
+
+	function formatBytes(n) {
+		if (n < 1024) return n + " B";
+		if (n < 1024 * 1024) return (n / 1024).toFixed(1) + " KB";
+		return (n / (1024 * 1024)).toFixed(2) + " MB";
+	}
+
+	// ---- list chrome ----
+
+	function render() {
+		if (!root) return;
+		root.innerHTML = renderHeader() + renderFilterBar() + renderMetricStrip() + renderTable();
+		wireFilterBar(); wireTableInteractions(); wireHeaderButtons();
+	}
+
+	function renderHeader() {
+		return '<div class="dash-header">' +
+			'<p class="dash-header-eyebrow">Scheduler</p>' +
+			'<h1 class="dash-header-title">Scheduler</h1>' +
+			'<p class="dash-header-lead">Every cron and one-shot job the agent knows about, plus the ones you author. Inspect, pause, run now, or delete any schedule in one click.</p>' +
+			'<div class="dash-header-actions"><button class="dash-btn dash-btn-primary" id="scheduler-new-btn">+ New job</button></div>' +
+			'</div>';
+	}
+
+	function renderFilterBar() {
+		var statuses = ["all", "active", "paused", "completed", "failed"];
+		var opts = statuses.map(function (s) {
+			var label = s === "all" ? "All statuses" : s.charAt(0).toUpperCase() + s.slice(1);
+			return '<option value="' + esc(s) + '"' + (state.filter.status === s ? " selected" : "") + '>' + esc(label) + '</option>';
+		}).join("");
+		return '<div class="dash-filter-bar" role="group" aria-label="Scheduler filters">' +
+			'<div class="dash-filter-group"><label class="dash-filter-label" for="scheduler-filter-status">Status</label>' +
+			'<select class="dash-filter-select" id="scheduler-filter-status">' + opts + '</select></div>' +
+			'<div class="dash-filter-search"><svg fill="none" viewBox="0 0 24 24" stroke-width="1.8" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z"/></svg>' +
+			'<input type="search" id="scheduler-filter-q" placeholder="Search by name or task" value="' + esc(state.filter.q) + '" aria-label="Search scheduler jobs"></div>' +
+			'</div>';
+	}
+
+	function renderMetricStrip() {
+		var s = state.summary;
+		if (!s) {
+			var sk = '<div class="dash-metric-card dash-metric-skeleton" aria-hidden="true"><p class="dash-metric-label">.</p><p class="dash-metric-value">.</p></div>';
+			return '<div class="dash-metric-strip" aria-busy="true">' + sk + sk + sk + sk + sk + sk + '</div>';
+		}
+		var nextLabel = s.nextFireAt ? relativeTime(s.nextFireAt) : "none";
+		return '<div class="dash-metric-strip">' +
+			metricCard("Total", String(s.total || 0)) +
+			metricCard("Active", String(s.active || 0)) +
+			metricCard("Paused", String(s.paused || 0)) +
+			metricCard("Failed", String(s.failed || 0)) +
+			metricCard("Next run", nextLabel) +
+			metricCard("Recent errors", String(s.recentFailures || 0)) +
+			'</div>';
+	}
+
+	function metricCard(label, value) {
+		return '<div class="dash-metric-card"><p class="dash-metric-label">' + esc(label) + '</p><p class="dash-metric-value">' + esc(value) + '</p></div>';
+	}
+
+	function filterJobs(jobs) {
+		var q = (state.filter.q || "").toLowerCase().trim();
+		var out = [];
+		for (var i = 0; i < jobs.length; i++) {
+			var j = jobs[i];
+			if (state.filter.status !== "all" && j.status !== state.filter.status) continue;
+			if (q) {
+				var hay = (j.name + " " + (j.description || "") + " " + (j.task || "")).toLowerCase();
+				if (hay.indexOf(q) < 0) continue;
+			}
+			out.push(j);
+		}
+		return out;
+	}
+
+	function renderTable() {
+		var body;
+		if (state.loading && !state.list) body = skeletonRows(5);
+		else if (state.listError) body = '<tr><td colspan="7"><div class="dash-table-empty"><p>Could not load scheduler.</p><p style="margin-top:var(--space-2);"><button class="dash-btn dash-btn-ghost dash-btn-sm" id="scheduler-retry-btn">Retry</button></p></div></td></tr>';
+		else {
+			var jobs = filterJobs((state.list && state.list.jobs) || []);
+			body = jobs.length === 0 ? '<tr><td colspan="7">' + renderEmptyState() + '</td></tr>' : jobs.map(renderRow).join("");
+		}
+		return '<div class="dash-table-wrap">' +
+			'<table class="dash-table" aria-label="Scheduled jobs" aria-busy="' + (state.loading ? "true" : "false") + '">' +
+			'<thead class="dash-table-head"><tr>' +
+			'<th class="dash-table-head-cell" scope="col">Name</th>' +
+			'<th class="dash-table-head-cell" scope="col">Schedule</th>' +
+			'<th class="dash-table-head-cell" scope="col">Status</th>' +
+			'<th class="dash-table-head-cell" scope="col">Next run</th>' +
+			'<th class="dash-table-head-cell dash-table-hide-sm" scope="col">Last run</th>' +
+			'<th class="dash-table-head-cell dash-table-head-cell-numeric" scope="col">Runs</th>' +
+			'<th class="dash-table-head-cell dash-table-hide-sm" scope="col">Errors</th>' +
+			'</tr></thead><tbody id="scheduler-tbody">' + body + '</tbody></table></div>';
+	}
+
+	function renderRow(job) {
+		var errors = job.consecutiveErrors || 0;
+		var lastCell = job.lastRunAt ? (job.lastRunStatus === "ok" ? "ok " : "err ") + relativeTime(job.lastRunAt) : "never";
+		var errorBadge = errors > 0 ? '<span class="dash-status-chip dash-status-chip-failed">' + esc(String(errors)) + '</span>' : '<span class="phantom-muted">0</span>';
+		var nextLabel = job.nextRunAt ? relativeTime(job.nextRunAt) : (job.status === "paused" ? "paused" : "\u2014");
+		return '<tr class="dash-table-row" data-clickable="true" data-job-id="' + esc(job.id) + '" tabindex="0" role="button" aria-label="Open job ' + esc(job.name) + '">' +
+			'<td class="dash-table-cell dash-table-cell-mono">' + esc(job.name) + '</td>' +
+			'<td class="dash-table-cell dash-table-cell-mono phantom-muted">' + esc(humanSchedule(job.schedule)) + '</td>' +
+			'<td class="dash-table-cell">' + statusChip(job.status) + '</td>' +
+			'<td class="dash-table-cell dash-table-cell-muted" title="' + esc(job.nextRunAt ? absoluteTime(job.nextRunAt) : "") + '">' + esc(nextLabel) + '</td>' +
+			'<td class="dash-table-cell dash-table-cell-muted dash-table-hide-sm" title="' + esc(job.lastRunAt ? absoluteTime(job.lastRunAt) : "") + '">' + esc(lastCell) + '</td>' +
+			'<td class="dash-table-cell dash-table-cell-numeric">' + esc(String(job.runCount || 0)) + '</td>' +
+			'<td class="dash-table-cell dash-table-hide-sm">' + errorBadge + '</td>' +
+			'</tr>';
+	}
+
+	function skeletonRows(n) {
+		var out = [];
+		for (var i = 0; i < n; i++) {
+			out.push('<tr class="dash-table-skeleton-row" aria-hidden="true">' +
+				'<td><div class="dash-table-skeleton-pill" style="width:50%;"></div></td>' +
+				'<td><div class="dash-table-skeleton-pill" style="width:65%;"></div></td>' +
+				'<td><div class="dash-table-skeleton-pill" style="width:45%;"></div></td>' +
+				'<td><div class="dash-table-skeleton-pill" style="width:35%;"></div></td>' +
+				'<td class="dash-table-hide-sm"><div class="dash-table-skeleton-pill" style="width:55%;"></div></td>' +
+				'<td><div class="dash-table-skeleton-pill" style="width:25%; margin-left:auto;"></div></td>' +
+				'<td class="dash-table-hide-sm"><div class="dash-table-skeleton-pill" style="width:30%;"></div></td></tr>');
+		}
+		return out.join("");
+	}
+
+	function renderEmptyState() {
+		return '<div class="dash-empty" style="border:none; padding:var(--space-10) var(--space-5);">' +
+			'<svg class="dash-empty-icon" fill="none" viewBox="0 0 24 24" stroke-width="1.2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6h4.5m4.5 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"/></svg>' +
+			'<h3 class="dash-empty-title">No scheduled jobs yet</h3>' +
+			'<p class="dash-empty-body">Click +&nbsp;New&nbsp;job, or ask your agent in Slack to "schedule the top HN digest every 6 hours". Every schedule shows up here with its next run, last outcome, and actions to pause or delete.</p>' +
+			'<p style="margin-top:var(--space-4);"><button class="dash-btn dash-btn-primary" id="scheduler-empty-new-btn">Create your first job</button></p>' +
+			'</div>';
+	}
+
+	function renderTableOnly() {
+		var wrap = root.querySelector(".dash-table-wrap");
+		if (!wrap) { render(); return; }
+		var temp = document.createElement("div");
+		temp.innerHTML = renderTable();
+		if (temp.firstChild) wrap.parentNode.replaceChild(temp.firstChild, wrap);
+		wireTableInteractions();
+	}
+
+	function wireFilterBar() {
+		var statusEl = document.getElementById("scheduler-filter-status");
+		if (statusEl) statusEl.addEventListener("change", function () { state.filter.status = statusEl.value; renderTableOnly(); });
+		var qEl = document.getElementById("scheduler-filter-q");
+		if (qEl) qEl.addEventListener("input", function () {
+			if (searchTimer) clearTimeout(searchTimer);
+			var val = qEl.value;
+			searchTimer = setTimeout(function () { state.filter.q = val; renderTableOnly(); }, SEARCH_DEBOUNCE_MS);
+		});
+	}
+
+	function wireHeaderButtons() {
+		var a = document.getElementById("scheduler-new-btn");
+		if (a) a.addEventListener("click", function () { ctx.navigate("#/scheduler/new"); });
+		var b = document.getElementById("scheduler-empty-new-btn");
+		if (b) b.addEventListener("click", function () { ctx.navigate("#/scheduler/new"); });
+	}
+
+	function wireTableInteractions() {
+		var tbody = document.getElementById("scheduler-tbody");
+		if (tbody) {
+			var rows = tbody.querySelectorAll(".dash-table-row[data-clickable]");
+			for (var i = 0; i < rows.length; i++) {
+				rows[i].addEventListener("click", onRowActivate);
+				rows[i].addEventListener("keydown", onRowKey);
+			}
+		}
+		var retry = document.getElementById("scheduler-retry-btn");
+		if (retry) retry.addEventListener("click", loadList);
+	}
+
+	function onRowActivate(e) {
+		var id = e.currentTarget.getAttribute("data-job-id");
+		if (id) ctx.navigate("#/scheduler/" + encodeURIComponent(id));
+	}
+	function onRowKey(e) { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); onRowActivate(e); } }
+
+	function loadList() {
+		state.loading = true; state.listError = null;
+		renderTableOnly();
+		return ctx.api("GET", "/ui/api/scheduler").then(function (res) {
+			state.loading = false;
+			state.list = { jobs: res.jobs || [] };
+			state.summary = res.summary || null;
+			render();
+		}).catch(function (err) {
+			state.loading = false; state.listError = err;
+			render();
+			ctx.toast("error", "Failed to load scheduler", err.message || String(err));
+		});
+	}
+
+	// ---- drawer lifecycle ----
+
+	function openDrawer(mode) {
+		if (!drawerRoot) {
+			drawerFocusRestore = document.activeElement;
+			drawerRoot = document.createElement("div");
+			drawerRoot.setAttribute("data-scheduler-drawer", "true");
+			document.body.appendChild(drawerRoot);
+			prevBodyOverflow = document.body.style.overflow;
+			document.body.style.overflow = "hidden";
+		}
+		if (mode === "create") renderCreateDrawer(); else renderDetailDrawer();
+	}
+
+	function closeDrawer(skipHash) {
+		if (state.create.open && state.create.dirtyByUser) {
+			if (!window.confirm("Discard this job draft?")) return;
+		}
+		state.create = makeCreateState();
+		state.detail = { open: false, id: null, loading: false, error: null, job: null, audit: [], runResult: null, runPending: false };
+		removeDrawerDom();
+		if (!skipHash && (window.location.hash || "").indexOf("#/scheduler/") === 0) ctx.navigate("#/scheduler");
+	}
+
+	function removeDrawerDom() {
+		if (!drawerRoot) return;
+		if (drawerRoot.parentNode) drawerRoot.parentNode.removeChild(drawerRoot);
+		drawerRoot = null;
+		if (drawerKeyHandler) document.removeEventListener("keydown", drawerKeyHandler, true);
+		drawerKeyHandler = null;
+		document.body.style.overflow = prevBodyOverflow || "";
+		prevBodyOverflow = null;
+		if (drawerFocusRestore && typeof drawerFocusRestore.focus === "function") {
+			try { drawerFocusRestore.focus(); } catch (_) { /* ignore */ }
+		}
+		drawerFocusRestore = null;
+	}
+
+	function wireDrawerKeys() {
+		if (drawerKeyHandler) document.removeEventListener("keydown", drawerKeyHandler, true);
+		drawerKeyHandler = function (e) {
+			if (e.key === "Escape") { e.preventDefault(); e.stopPropagation(); closeDrawer(false); return; }
+			if (e.key === "Tab") handleTab(e);
+		};
+		document.addEventListener("keydown", drawerKeyHandler, true);
+	}
+
+	function getFocusable() {
+		if (!drawerRoot) return [];
+		var panel = drawerRoot.querySelector(".dash-drawer");
+		if (!panel) return [];
+		var nodes = panel.querySelectorAll('a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]):not([type="hidden"]), select:not([disabled]), [tabindex]:not([tabindex="-1"])');
+		var out = [];
+		for (var i = 0; i < nodes.length; i++) {
+			if (nodes[i].offsetParent !== null || nodes[i] === document.activeElement) out.push(nodes[i]);
+		}
+		return out;
+	}
+	function handleTab(e) {
+		var f = getFocusable();
+		if (f.length === 0) {
+			e.preventDefault();
+			var p = drawerRoot && drawerRoot.querySelector(".dash-drawer");
+			if (p) p.focus();
+			return;
+		}
+		var first = f[0], last = f[f.length - 1];
+		if (e.shiftKey && document.activeElement === first) { e.preventDefault(); last.focus(); }
+		else if (!e.shiftKey && document.activeElement === last) { e.preventDefault(); first.focus(); }
+	}
+	function focusInDrawer(selector) {
+		setTimeout(function () {
+			if (!drawerRoot) return;
+			var el = (selector && drawerRoot.querySelector(selector)) || drawerRoot.querySelector(".dash-drawer-close");
+			if (el && typeof el.focus === "function") el.focus();
+		}, 40);
+	}
+
+	// ---- detail drawer ----
+
+	function renderDetailDrawer() {
+		if (!drawerRoot) return;
+		state.detail.open = true; state.create.open = false;
+		var d = state.detail, job = d.job;
+		var body = d.error
+			? '<div class="dash-drawer-body"><div class="dash-drawer-error" role="alert">' +
+				'<p style="margin:0 0 var(--space-2); font-weight:600;">Could not load job.</p>' +
+				'<p style="margin:0 0 var(--space-3);">' + esc(d.error.message || String(d.error)) + '</p>' +
+				'<button class="dash-btn dash-btn-ghost dash-btn-sm" id="scheduler-detail-retry">Retry</button></div></div>'
+			: (!job || d.loading) ? renderDetailSkeleton() : renderDetailContent(job);
+
+		var actions = "";
+		if (job) {
+			var isPaused = job.status === "paused";
+			actions = '<div class="dash-sched-drawer-actions">' +
+				(isPaused
+					? '<button class="dash-btn dash-btn-ghost dash-btn-sm" id="scheduler-resume-btn">Resume</button>'
+					: '<button class="dash-btn dash-btn-ghost dash-btn-sm" id="scheduler-pause-btn"' + (job.status !== "active" ? " disabled" : "") + '>Pause</button>') +
+				'<button class="dash-btn dash-btn-ghost dash-btn-sm" id="scheduler-run-btn"' + (job.status !== "active" || d.runPending ? " disabled" : "") + '>' +
+				(d.runPending ? '<span class="dash-sched-inline-spinner" aria-hidden="true"></span>Running' : "Run now") +
+				'</button>' +
+				'<button class="dash-btn dash-btn-danger dash-btn-sm" id="scheduler-delete-btn">Delete</button>' +
+				'</div>';
+		}
+
+		drawerRoot.innerHTML = '<div class="dash-drawer-backdrop" data-drawer-backdrop="true" aria-hidden="true"></div>' +
+			'<aside class="dash-drawer dash-sched-wide-drawer" role="dialog" aria-modal="true" aria-labelledby="scheduler-detail-title" tabindex="-1">' +
+			'<header class="dash-drawer-header"><div class="dash-drawer-title-wrap">' +
+			'<p class="dash-drawer-eyebrow">Scheduled job</p>' +
+			'<h2 class="dash-drawer-title" id="scheduler-detail-title">' + esc(job ? job.name : (state.detail.id || "")) + '</h2>' +
+			'<div class="dash-drawer-subtitle">' + (job ? '<span class="phantom-muted">' + esc(humanSchedule(job.schedule)) + '</span>' + statusChip(job.status) : "") + '</div>' +
+			actions + '</div>' +
+			'<button class="dash-drawer-close" type="button" aria-label="Close" id="scheduler-detail-close">' +
+			'<svg fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12"/></svg>' +
+			'</button></header>' + body + '</aside>';
+
+		wireDetailDrawer();
+		wireDrawerKeys();
+		if (!d.loading && job) focusInDrawer("#scheduler-detail-close");
+	}
+
+	function renderDetailSkeleton() {
+		var pill = '<div class="dash-table-skeleton-pill"></div>';
+		return '<div class="dash-drawer-body" aria-busy="true">' +
+			'<section class="dash-drawer-section"><p class="dash-drawer-section-label">Overview</p>' +
+			'<div class="dash-drawer-kv">' +
+			'<span class="dash-drawer-kv-key">Schedule</span><span class="dash-drawer-kv-value" style="min-width:120px; height:14px;">' + pill + '</span>' +
+			'<span class="dash-drawer-kv-key">Next run</span><span class="dash-drawer-kv-value" style="min-width:100px; height:14px;">' + pill + '</span>' +
+			'<span class="dash-drawer-kv-key">Last run</span><span class="dash-drawer-kv-value" style="min-width:160px; height:14px;">' + pill + '</span>' +
+			'<span class="dash-drawer-kv-key">Delivery</span><span class="dash-drawer-kv-value" style="min-width:120px; height:14px;">' + pill + '</span>' +
+			'</div></section></div>';
+	}
+
+	function renderDetailContent(job) {
+		var kv = [
+			kvRow("Schedule", humanSchedule(job.schedule), "plain"),
+			kvRow("Status", job.status, "plain"),
+			kvRow("Enabled", job.enabled ? "yes" : "no", "plain"),
+			kvRow("Created by", job.createdBy || "agent", "plain"),
+			kvRow("Created", absoluteTime(job.createdAt), "plain"),
+			kvRow("Next run", job.nextRunAt ? absoluteTime(job.nextRunAt) + " (" + relativeTime(job.nextRunAt) + ")" : "none", "plain"),
+		];
+		if (job.lastRunAt) {
+			kv.push(kvRow("Last run", [absoluteTime(job.lastRunAt), job.lastRunStatus || "", job.lastRunDurationMs != null ? job.lastRunDurationMs + " ms" : "", job.lastDeliveryStatus || ""].filter(Boolean).join(" "), "plain"));
+		} else {
+			kv.push(kvRow("Last run", "never", "plain"));
+		}
+		kv.push(kvRow("Run count", String(job.runCount || 0), "plain"));
+		kv.push(kvRow("Consecutive errors", String(job.consecutiveErrors || 0), "plain"));
+		kv.push(kvRow("Delivery", deliverySummary(job.delivery), "plain"));
+		if (job.deleteAfterRun) kv.push(kvRow("Delete after run", "yes", "plain"));
+
+		var audit = state.detail.audit || [];
+		var auditHtml;
+		if (audit.length === 0) {
+			auditHtml = '<section class="dash-drawer-section"><p class="dash-drawer-section-label">Recent actions</p><p class="phantom-muted" style="font-size:12px; margin:0;">No UI actions recorded for this job yet.</p></section>';
+		} else {
+			var rows = audit.map(function (a) {
+				return '<div class="dash-sched-audit-row">' +
+					'<span class="dash-sched-audit-action">' + esc(a.action) + '</span>' +
+					'<span class="dash-sched-audit-actor">' + esc(a.actor || "") + '</span>' +
+					'<span class="dash-sched-audit-detail" title="' + esc(a.detail || "") + '">' + esc(a.detail || "") + '</span>' +
+					'<span class="dash-sched-audit-time" title="' + esc(absoluteTime(a.created_at)) + '">' + esc(relativeTime(a.created_at)) + '</span>' +
+					'</div>';
+			}).join("");
+			auditHtml = '<section class="dash-drawer-section"><p class="dash-drawer-section-label">Recent actions (' + audit.length + ')</p><div class="dash-sched-audit-list">' + rows + '</div></section>';
+		}
+
+		var errorSection = job.lastRunError ? '<section class="dash-drawer-section"><p class="dash-drawer-section-label">Last error</p><div id="scheduler-last-error-mount"></div></section>' : "";
+		var runSection = state.detail.runResult != null ? '<section class="dash-drawer-section"><p class="dash-drawer-section-label">Run-now result</p><div id="scheduler-run-result-mount"></div></section>' : "";
+
+		setTimeout(function () {
+			mountTextBlock("scheduler-task-mount", job.task || "", "dash-sched-code-block");
+			if (job.lastRunError) mountTextBlock("scheduler-last-error-mount", job.lastRunError, "dash-sched-code-block");
+			if (state.detail.runResult != null) mountTextBlock("scheduler-run-result-mount", state.detail.runResult, "dash-sched-run-result");
+		}, 0);
+
+		return '<div class="dash-drawer-body">' +
+			'<section class="dash-drawer-section"><p class="dash-drawer-section-label">Overview</p><div class="dash-drawer-kv">' + kv.join("") + '</div></section>' +
+			'<section class="dash-drawer-section"><p class="dash-drawer-section-label">Task prompt</p><div id="scheduler-task-mount"></div></section>' +
+			errorSection + runSection + auditHtml +
+			'</div>';
+	}
+
+	function mountTextBlock(id, text, cls) {
+		var mount = document.getElementById(id);
+		if (!mount) return;
+		var pre = document.createElement("pre");
+		pre.className = cls;
+		pre.textContent = text;
+		mount.innerHTML = "";
+		mount.appendChild(pre);
+	}
+
+	function kvRow(key, value, variant) {
+		var valClass = variant === "plain" ? " dash-drawer-kv-value-plain" : "";
+		return '<span class="dash-drawer-kv-key">' + esc(key) + '</span><span class="dash-drawer-kv-value' + valClass + '">' + esc(value) + '</span>';
+	}
+
+	function wireDetailDrawer() {
+		if (!drawerRoot) return;
+		var close = drawerRoot.querySelector("#scheduler-detail-close");
+		var bd = drawerRoot.querySelector("[data-drawer-backdrop]");
+		if (close) close.addEventListener("click", function () { closeDrawer(false); });
+		if (bd) bd.addEventListener("click", function () { closeDrawer(false); });
+		var retry = drawerRoot.querySelector("#scheduler-detail-retry");
+		if (retry) retry.addEventListener("click", function () { if (state.detail.id) loadDetail(state.detail.id); });
+		bindAction("#scheduler-pause-btn", actPause);
+		bindAction("#scheduler-resume-btn", actResume);
+		bindAction("#scheduler-run-btn", actRun);
+		bindAction("#scheduler-delete-btn", actDelete);
+	}
+	function bindAction(sel, fn) {
+		var el = drawerRoot.querySelector(sel);
+		if (el) el.addEventListener("click", fn);
+	}
+
+	function loadDetail(id) {
+		state.detail.open = true; state.detail.id = id; state.detail.loading = true;
+		state.detail.error = null; state.detail.job = null; state.detail.audit = []; state.detail.runResult = null;
+		renderDetailDrawer();
+		return Promise.all([
+			ctx.api("GET", "/ui/api/scheduler/" + encodeURIComponent(id)),
+			ctx.api("GET", "/ui/api/scheduler/" + encodeURIComponent(id) + "/audit?limit=20").catch(function () { return { entries: [] }; }),
+		]).then(function (vals) {
+			if (state.detail.id !== id) return;
+			state.detail.loading = false;
+			state.detail.job = vals[0].job;
+			state.detail.audit = vals[1].entries || [];
+			renderDetailDrawer();
+		}).catch(function (err) {
+			if (state.detail.id !== id) return;
+			state.detail.loading = false; state.detail.error = err;
+			renderDetailDrawer();
+			ctx.toast("error", err.status === 404 ? "Job not found" : "Failed to load job", err.message || String(err));
+		});
+	}
+
+	function simpleAction(path, successTitle, errorTitle) {
+		var id = state.detail.id;
+		if (!id) return;
+		ctx.api("POST", "/ui/api/scheduler/" + encodeURIComponent(id) + "/" + path).then(function (res) {
+			state.detail.job = res.job;
+			patchListJob(res.job);
+			renderDetailDrawer();
+			ctx.toast("success", successTitle, res.job.name);
+		}).catch(function (err) { ctx.toast("error", errorTitle, err.message || String(err)); });
+	}
+	function actPause() { simpleAction("pause", "Job paused", "Could not pause job"); }
+	function actResume() { simpleAction("resume", "Job resumed", "Could not resume job"); }
+
+	function actRun() {
+		var id = state.detail.id; if (!id) return;
+		state.detail.runPending = true; state.detail.runResult = null;
+		renderDetailDrawer();
+		ctx.api("POST", "/ui/api/scheduler/" + encodeURIComponent(id) + "/run").then(function (res) {
+			state.detail.runPending = false;
+			state.detail.runResult = res.result || "";
+			if (res.job) { state.detail.job = res.job; patchListJob(res.job); }
+			renderDetailDrawer();
+			ctx.toast("success", "Job ran", "Result captured in drawer.");
+		}).catch(function (err) {
+			state.detail.runPending = false;
+			renderDetailDrawer();
+			ctx.toast("error", "Run failed", err.message || String(err));
+		});
+	}
+
+	function actDelete() {
+		var id = state.detail.id, job = state.detail.job;
+		if (!id) return;
+		ctx.openModal({
+			title: "Delete scheduled job?",
+			body: 'This removes "' + (job ? job.name : id) + '" immediately. The job will not fire again.',
+			actions: [
+				{ label: "Cancel", className: "dash-btn-ghost" },
+				{ label: "Delete", className: "dash-btn-danger",
+					onClick: function () {
+						return ctx.api("DELETE", "/ui/api/scheduler/" + encodeURIComponent(id)).then(function () {
+							ctx.toast("success", "Job deleted", job ? job.name : id);
+							removeListJob(id);
+							closeDrawer(false);
+						}).catch(function (err) {
+							ctx.toast("error", "Could not delete", err.message || String(err));
+							return false;
+						});
+					} },
+			],
+		});
+	}
+
+	function patchListJob(job) {
+		if (!state.list || !Array.isArray(state.list.jobs)) return;
+		for (var i = 0; i < state.list.jobs.length; i++) {
+			if (state.list.jobs[i].id === job.id) { state.list.jobs[i] = job; render(); return; }
+		}
+	}
+	function removeListJob(id) {
+		if (!state.list || !Array.isArray(state.list.jobs)) return;
+		state.list.jobs = state.list.jobs.filter(function (j) { return j.id !== id; });
+		render();
+	}
+
+	// ---- create drawer ----
+
+	function renderCreateDrawer() {
+		state.create.open = true; state.detail.open = false;
+		drawerRoot.innerHTML = '<div class="dash-drawer-backdrop" data-drawer-backdrop="true" aria-hidden="true"></div>' +
+			'<aside class="dash-drawer dash-sched-wide-drawer" role="dialog" aria-modal="true" aria-labelledby="scheduler-create-title" tabindex="-1">' +
+			'<header class="dash-drawer-header"><div class="dash-drawer-title-wrap">' +
+			'<p class="dash-drawer-eyebrow">New scheduled job</p>' +
+			'<h2 class="dash-drawer-title" id="scheduler-create-title">Schedule a job</h2>' +
+			'<div class="dash-drawer-subtitle"><span class="phantom-muted">Fill the form or describe it in plain English below.</span></div>' +
+			'</div>' +
+			'<button class="dash-drawer-close" type="button" aria-label="Close" id="scheduler-create-close">' +
+			'<svg fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12"/></svg>' +
+			'</button></header>' +
+			'<div class="dash-drawer-body">' +
+			renderDescribe() + renderTemplates() +
+			(state.create.submitError ? '<div class="dash-alert dash-alert-error" role="alert">' + esc(state.create.submitError) + '</div>' : "") +
+			renderCreateForm() +
+			'</div>' +
+			'<footer class="dash-drawer-footer">' +
+			'<button class="dash-btn dash-btn-ghost" id="scheduler-cancel-btn">Cancel</button>' +
+			'<div style="flex:1;"></div>' +
+			'<button class="dash-btn dash-btn-primary" id="scheduler-save-btn"' + (isCreateValid() && !state.create.submitting ? "" : " disabled") + '>' +
+			(state.create.submitting ? '<span class="dash-sched-inline-spinner" aria-hidden="true"></span>Saving' : "Save job") +
+			'</button></footer></aside>';
+		wireCreateDrawer();
+		wireDrawerKeys();
+		focusInDrawer("#scheduler-describe-text");
+		schedulePreview();
+	}
+
+	function renderDescribe() {
+		if (state.create.describeDisabled) return "";
+		var c = state.create;
+		var count = c.describeText.length, over = count > DESCRIBE_MAX;
+		var banner = c.describeFilled
+			? '<div class="dash-sched-describe-filled-banner" role="status"><span>Filled from your description. Review and edit before saving.</span><button type="button" class="dash-sched-template-clear" id="scheduler-describe-dismiss">Dismiss</button></div>'
+			: "";
+		var err = c.describeError ? '<div class="dash-sched-describe-error" role="alert">' + esc(c.describeError) + '</div>' : "";
+		var disableFill = !c.describeText.trim() || c.describePending || over;
+		return '<section class="dash-sched-describe">' +
+			'<div class="dash-sched-describe-header">' +
+			'<p class="dash-sched-describe-eyebrow">Describe assist</p>' +
+			'<span class="dash-sched-char-count' + (over ? ' dash-sched-char-count-over' : '') + '">' + esc(count + " / " + DESCRIBE_MAX) + '</span>' +
+			'</div>' +
+			'<p class="dash-sched-describe-title">Describe your job in plain English (optional)</p>' +
+			'<textarea class="dash-textarea" id="scheduler-describe-text" rows="3" placeholder="pull the top HN stories every 6 hours and post a summary to my Slack DM" aria-label="Describe your job in plain English">' + esc(c.describeText) + '</textarea>' +
+			'<div class="dash-sched-describe-actions">' +
+			'<button type="button" class="dash-btn dash-btn-ghost dash-btn-sm" id="scheduler-describe-fill"' + (disableFill ? " disabled" : "") + '>' +
+			(c.describePending ? '<span class="dash-sched-inline-spinner" aria-hidden="true"></span>Filling' : "Fill form from description") +
+			'</button>' +
+			'<span class="phantom-muted" style="font-size:11px;">Sonnet proposes fields. You review and edit before saving.</span>' +
+			'</div>' + err + banner + '</section>';
+	}
+
+	function renderTemplates() {
+		var pills = TEMPLATES.map(function (t) {
+			var pressed = state.create.appliedTemplate === t.id ? 'aria-pressed="true" ' : 'aria-pressed="false" ';
+			return '<button type="button" class="dash-sched-template-pill" ' + pressed + 'data-template-id="' + esc(t.id) + '" title="' + esc(t.description) + '">' + esc(t.label) + '</button>';
+		}).join("");
+		var clearBtn = state.create.appliedTemplate ? '<button type="button" class="dash-sched-template-clear" id="scheduler-template-clear">Clear template</button>' : "";
+		return '<section class="dash-drawer-section"><p class="dash-drawer-section-label">Templates</p>' +
+			'<div class="dash-sched-template-row" role="group" aria-label="Job templates">' + pills + clearBtn + '</div></section>';
+	}
+
+	function renderCreateForm() {
+		var f = state.create.form, e = state.create.errors;
+		var taskBytes = new Blob([f.task]).size, taskOver = taskBytes > TASK_MAX;
+		return '<section class="dash-drawer-section">' +
+			'<p class="dash-drawer-section-label">Basics</p>' +
+			'<div class="dash-form">' +
+			field("scheduler-name", "Name",
+				'<input type="text" class="dash-input" id="scheduler-name" maxlength="' + NAME_MAX + '" value="' + esc(f.name) + '" placeholder="hn-digest" aria-invalid="' + (e.name ? "true" : "false") + '">' +
+				(e.name ? fieldError(e.name) : '<p class="dash-field-hint">Lowercase, kebab-case. Must be unique.</p>')) +
+			field("scheduler-description", "Description",
+				'<input type="text" class="dash-input" id="scheduler-description" maxlength="' + DESCRIPTION_MAX + '" value="' + esc(f.description) + '" placeholder="Top Hacker News stories every 6 hours">' +
+				'<p class="dash-field-hint">One-sentence summary, optional.</p>') +
+			field("scheduler-task", "Task prompt",
+				'<textarea class="dash-textarea" id="scheduler-task" rows="6" aria-invalid="' + (e.task || taskOver ? "true" : "false") + '" placeholder="Fetch the top 10 Hacker News stories and post a summary to Slack.">' + esc(f.task) + '</textarea>' +
+				'<div class="dash-sched-char-count' + (taskOver ? ' dash-sched-char-count-over' : '') + '">' + formatBytes(taskBytes) + ' / 32 KB</div>' +
+				(e.task ? fieldError(e.task) : '<p class="dash-field-hint">The prompt the agent runs when the job fires. Include every bit of context it needs.</p>')) +
+			'</div></section>' +
+
+			'<section class="dash-drawer-section"><p class="dash-drawer-section-label">Schedule</p>' +
+			renderKindTabs(f.schedule.kind) + renderKindControls(f.schedule) + renderPreview() + '</section>' +
+
+			'<section class="dash-drawer-section"><p class="dash-drawer-section-label">Delivery</p>' + renderDelivery(f.delivery) + '</section>' +
+
+			'<section class="dash-drawer-section"><p class="dash-drawer-section-label">Options</p>' +
+			'<label class="dash-toggle"><input type="checkbox" id="scheduler-enabled"' + (f.enabled ? " checked" : "") + '><span class="dash-toggle-track" aria-hidden="true"></span><span>Enabled</span></label>' +
+			(f.schedule.kind === "once" ? '<label class="dash-toggle"><input type="checkbox" id="scheduler-delete-after"' + (f.deleteAfterRun ? " checked" : "") + '><span class="dash-toggle-track" aria-hidden="true"></span><span>Delete after single run</span></label>' : "") +
+			'</section>';
+	}
+
+	function field(id, label, contents) {
+		return '<div class="dash-field"><label class="dash-field-label" for="' + esc(id) + '">' + esc(label) + '</label>' + contents + '</div>';
+	}
+	function fieldError(msg) {
+		return '<p class="dash-field-hint" role="alert" style="color:var(--color-error);">' + esc(msg) + '</p>';
+	}
+
+	function renderKindTabs(kind) {
+		var kinds = [{ id: "every", label: "Every interval" }, { id: "daily", label: "Daily time" }, { id: "cron", label: "Cron expression" }, { id: "once", label: "Once" }];
+		return '<div class="dash-segmented" role="tablist" aria-label="Schedule kind">' +
+			kinds.map(function (k) {
+				return '<button type="button" data-schedule-kind="' + esc(k.id) + '" aria-pressed="' + (kind === k.id ? "true" : "false") + '">' + esc(k.label) + '</button>';
+			}).join("") + '</div>';
+	}
+
+	function renderKindControls(s) {
+		var err = state.create.errors.schedule;
+		var errNode = err ? fieldError(err) : "";
+		if (s.kind === "every") {
+			return '<div class="dash-sched-field-row">' +
+				field("scheduler-every-value", "Interval",
+					'<input type="number" min="1" max="1440" class="dash-input" id="scheduler-every-value" value="' + esc(String(s.value || 1)) + '">') +
+				field("scheduler-every-unit", "Unit",
+					'<select class="dash-select" id="scheduler-every-unit">' +
+					["minutes", "hours", "days"].map(function (u) { return '<option value="' + u + '"' + (s.unit === u ? " selected" : "") + '>' + u + '</option>'; }).join("") +
+					'</select>') + '</div>' + errNode;
+		}
+		if (s.kind === "daily") {
+			var hhmm = s.expr && /^\d+ \d+/.test(s.expr) ? cronToHhMm(s.expr) : (s.at || "09:00");
+			return '<div class="dash-sched-field-row">' +
+				field("scheduler-daily-time", "Time", '<input type="time" class="dash-input" id="scheduler-daily-time" value="' + esc(hhmm) + '">') +
+				field("scheduler-daily-tz", "Timezone", tzSelect("scheduler-daily-tz", s.tz)) +
+				'</div>' + errNode;
+		}
+		if (s.kind === "cron") {
+			var exChips = CRON_EXAMPLES.map(function (ex) { return '<button type="button" class="dash-sched-example-chip" data-cron-example="' + esc(ex) + '">' + esc(ex) + '</button>'; }).join("");
+			return '<div class="dash-sched-field-row">' +
+				field("scheduler-cron-expr", "Expression", '<input type="text" class="dash-input" id="scheduler-cron-expr" value="' + esc(s.expr || "") + '" placeholder="0 9 * * 1-5" spellcheck="false">') +
+				field("scheduler-cron-tz", "Timezone", tzSelect("scheduler-cron-tz", s.tz)) +
+				'</div>' +
+				'<p class="dash-field-hint">5-field cron: minute hour day-of-month month day-of-week. No @nicknames.</p>' +
+				'<div class="dash-sched-examples">' + exChips + '</div>' + errNode;
+		}
+		return '<div class="dash-sched-field-row">' +
+			field("scheduler-once-at", "Date and time", '<input type="datetime-local" class="dash-input" id="scheduler-once-at" value="' + esc(s.at || "") + '">') +
+			field("scheduler-once-tz", "Timezone", tzSelect("scheduler-once-tz", s.tz)) +
+			'</div>' + errNode;
+	}
+
+	function tzSelect(id, current) {
+		var tz = current || defaultTz();
+		var opts = TZ_OPTIONS.slice();
+		if (opts.indexOf(tz) < 0) opts.unshift(tz);
+		return '<select class="dash-select" id="' + esc(id) + '">' +
+			opts.map(function (o) { return '<option value="' + esc(o) + '"' + (o === tz ? " selected" : "") + '>' + esc(o) + '</option>'; }).join("") +
+			'</select>';
+	}
+
+	function renderPreview() {
+		var c = state.create, body;
+		if (c.previewPending) body = '<span class="dash-sched-inline-spinner" aria-hidden="true"></span><span>Computing next run...</span>';
+		else if (c.previewError) return '<div class="dash-sched-preview dash-sched-preview-error" role="status"><span class="dash-sched-preview-label">Preview error:</span><span>' + esc(c.previewError) + '</span></div>';
+		else if (c.preview && c.preview.nextRunAt) {
+			var human = c.preview.humanReadable ? " (" + c.preview.humanReadable + ")" : "";
+			body = '<span class="dash-sched-preview-label">Next run:</span><span>' + esc(absoluteTime(c.preview.nextRunAt)) + '</span><span class="phantom-muted">' + esc(relativeTime(c.preview.nextRunAt) + human) + '</span>';
+		} else if (c.preview && c.preview.humanReadable) {
+			body = '<span class="dash-sched-preview-label">Next run:</span><span>' + esc(c.preview.humanReadable) + '</span>';
+		} else {
+			body = '<span class="phantom-muted">Fill the schedule to preview the next run.</span>';
+		}
+		return '<div class="dash-sched-preview" role="status">' + body + '</div>';
+	}
+
+	function renderDelivery(d) {
+		var radios = [
+			{ value: "owner", label: "Owner (you, via DM)" },
+			{ value: "channel", label: "Slack channel id (starts with C...)" },
+			{ value: "user", label: "Slack user id (starts with U...)" },
+		];
+		var kind = d.targetKind || "owner", err = state.create.errors.delivery;
+		var targetInput = kind !== "owner"
+			? '<input type="text" class="dash-input" id="scheduler-delivery-target" value="' + esc(d.target || "") + '" placeholder="' + esc(kind === "channel" ? "C04ABC123" : "U04ABC123") + '">'
+			: "";
+		return field("scheduler-delivery-channel", "Channel",
+			'<select class="dash-select" id="scheduler-delivery-channel"><option value="slack"' + (d.channel === "slack" ? " selected" : "") + '>Slack</option><option value="none"' + (d.channel === "none" ? " selected" : "") + '>None (silent)</option></select>') +
+			(d.channel === "slack"
+				? '<div class="dash-sched-radio-group" role="radiogroup" aria-label="Target">' +
+					radios.map(function (r) {
+						return '<label class="dash-sched-radio"><input type="radio" name="scheduler-delivery-target-kind" value="' + esc(r.value) + '"' + (kind === r.value ? " checked" : "") + '><span>' + esc(r.label) + '</span></label>';
+					}).join("") + '</div>' +
+					(targetInput ? '<div class="dash-field">' + targetInput + (err ? fieldError(err) : "") + '</div>' : "")
+				: '<p class="dash-field-hint">No Slack message. Useful for quiet maintenance tasks.</p>');
+	}
+
+	// ---- wiring ----
+
+	function wireCreateDrawer() {
+		if (!drawerRoot) return;
+		bindClick("#scheduler-create-close", function () { closeDrawer(false); });
+		bindClick("[data-drawer-backdrop]", function () { closeDrawer(false); });
+		bindClick("#scheduler-cancel-btn", function () { closeDrawer(false); });
+		bindClick("#scheduler-save-btn", submitCreate);
+		wireDescribeInputs();
+		wireTemplateInputs();
+		wireFormInputs();
+	}
+	function bindClick(sel, fn) {
+		var el = drawerRoot.querySelector(sel);
+		if (el) el.addEventListener("click", fn);
+	}
+
+	function wireDescribeInputs() {
+		var text = drawerRoot.querySelector("#scheduler-describe-text");
+		if (text) text.addEventListener("input", function () {
+			state.create.describeText = text.value;
+			var over = text.value.length > DESCRIBE_MAX;
+			var fillBtn = drawerRoot.querySelector("#scheduler-describe-fill");
+			if (fillBtn) fillBtn.disabled = text.value.trim().length === 0 || state.create.describePending || over;
+			var countEl = drawerRoot.querySelector(".dash-sched-describe .dash-sched-char-count");
+			if (countEl) {
+				countEl.textContent = text.value.length + " / " + DESCRIBE_MAX;
+				countEl.classList.toggle("dash-sched-char-count-over", over);
+			}
+		});
+		bindClick("#scheduler-describe-fill", fillFromDescription);
+		bindClick("#scheduler-describe-dismiss", function () { state.create.describeFilled = false; renderCreateDrawer(); });
+	}
+
+	function wireTemplateInputs() {
+		var pills = drawerRoot.querySelectorAll(".dash-sched-template-pill");
+		for (var i = 0; i < pills.length; i++) {
+			pills[i].addEventListener("click", function (e) { applyTemplate(e.currentTarget.getAttribute("data-template-id")); });
+		}
+		bindClick("#scheduler-template-clear", function () {
+			state.create.appliedTemplate = null;
+			state.create.form = defaultForm();
+			state.create.dirtyByUser = false;
+			renderCreateDrawer();
+			schedulePreview();
+		});
+	}
+
+	function wireFormInputs() {
+		bindInput("#scheduler-name", function (v) { state.create.form.name = v; markDirty(); validateField("name"); });
+		bindInput("#scheduler-description", function (v) { state.create.form.description = v; markDirty(); });
+		bindInput("#scheduler-task", function (v) {
+			state.create.form.task = v; markDirty(); validateField("task"); updateTaskCount(); updateSaveButton();
+		});
+
+		var kindTabs = drawerRoot.querySelectorAll("[data-schedule-kind]");
+		for (var i = 0; i < kindTabs.length; i++) {
+			kindTabs[i].addEventListener("click", function (e) { setScheduleKind(e.currentTarget.getAttribute("data-schedule-kind")); });
+		}
+		wireScheduleInputs();
+		wireDeliveryInputs();
+
+		bindChange("#scheduler-enabled", function (el) { state.create.form.enabled = el.checked; markDirty(); });
+		bindChange("#scheduler-delete-after", function (el) { state.create.form.deleteAfterRun = el.checked; markDirty(); });
+	}
+
+	function bindInput(sel, fn) {
+		var el = drawerRoot.querySelector(sel);
+		if (el) el.addEventListener("input", function () { fn(el.value); });
+	}
+	function bindChange(sel, fn) {
+		var el = drawerRoot.querySelector(sel);
+		if (el) el.addEventListener("change", function () { fn(el); });
+	}
+
+	function wireScheduleInputs() {
+		bindInput("#scheduler-every-value", function (v) {
+			var n = Number(v);
+			state.create.form.schedule.value = isFinite(n) && n > 0 ? n : 1;
+			markDirty(); schedulePreview();
+		});
+		bindChange("#scheduler-every-unit", function (el) { state.create.form.schedule.unit = el.value; markDirty(); schedulePreview(); });
+		bindInput("#scheduler-daily-time", function (v) {
+			var parts = v.split(":");
+			if (parts.length === 2) {
+				state.create.form.schedule.expr = Number(parts[1]) + " " + Number(parts[0]) + " * * *";
+				state.create.form.schedule.at = v;
+			}
+			markDirty(); schedulePreview();
+		});
+		bindChange("#scheduler-daily-tz", function (el) { state.create.form.schedule.tz = el.value; markDirty(); schedulePreview(); });
+		bindInput("#scheduler-cron-expr", function (v) { state.create.form.schedule.expr = v; markDirty(); schedulePreview(); });
+		bindChange("#scheduler-cron-tz", function (el) { state.create.form.schedule.tz = el.value; markDirty(); schedulePreview(); });
+		var chips = drawerRoot.querySelectorAll(".dash-sched-example-chip");
+		for (var i = 0; i < chips.length; i++) {
+			chips[i].addEventListener("click", function (e) {
+				var ex = e.currentTarget.getAttribute("data-cron-example");
+				state.create.form.schedule.expr = ex;
+				var eEl = drawerRoot.querySelector("#scheduler-cron-expr");
+				if (eEl) eEl.value = ex;
+				markDirty(); schedulePreview();
+			});
+		}
+		bindInput("#scheduler-once-at", function (v) { state.create.form.schedule.at = v; markDirty(); schedulePreview(); });
+		bindChange("#scheduler-once-tz", function (el) { state.create.form.schedule.tz = el.value; markDirty(); schedulePreview(); });
+	}
+
+	function wireDeliveryInputs() {
+		bindChange("#scheduler-delivery-channel", function (el) {
+			state.create.form.delivery.channel = el.value;
+			if (el.value === "none") state.create.form.delivery.targetKind = "owner";
+			markDirty();
+			renderCreateDrawer();
+		});
+		var radios = drawerRoot.querySelectorAll('input[name="scheduler-delivery-target-kind"]');
+		for (var i = 0; i < radios.length; i++) {
+			radios[i].addEventListener("change", function (e) {
+				state.create.form.delivery.targetKind = e.currentTarget.value;
+				if (e.currentTarget.value === "owner") state.create.form.delivery.target = "";
+				markDirty();
+				renderCreateDrawer();
+			});
+		}
+		bindInput("#scheduler-delivery-target", function (v) { state.create.form.delivery.target = v; markDirty(); validateField("delivery"); });
+	}
+
+	function setScheduleKind(kind) {
+		if (state.create.form.schedule.kind === kind) return;
+		state.create.form.schedule.kind = kind;
+		if (kind === "once") state.create.form.deleteAfterRun = true;
+		markDirty();
+		renderCreateDrawer();
+		schedulePreview();
+	}
+
+	function markDirty() { state.create.dirtyByUser = true; updateSaveButton(); }
+
+	function updateSaveButton() {
+		if (!drawerRoot) return;
+		var btn = drawerRoot.querySelector("#scheduler-save-btn");
+		if (btn) btn.disabled = state.create.submitting || !isCreateValid();
+	}
+
+	function updateTaskCount() {
+		if (!drawerRoot) return;
+		var el = drawerRoot.querySelector("#scheduler-task");
+		if (!el) return;
+		var bytes = new Blob([el.value]).size;
+		var countEl = el.parentNode.querySelector(".dash-sched-char-count");
+		if (countEl) {
+			countEl.textContent = formatBytes(bytes) + " / 32 KB";
+			countEl.classList.toggle("dash-sched-char-count-over", bytes > TASK_MAX);
+		}
+	}
+
+	// ---- templates ----
+
+	function applyTemplate(tid) {
+		var t = null;
+		for (var i = 0; i < TEMPLATES.length; i++) if (TEMPLATES[i].id === tid) { t = TEMPLATES[i]; break; }
+		if (!t) return;
+		var v = t.values, f = defaultForm();
+		f.name = v.name; f.description = v.description || ""; f.task = v.task || "";
+		f.enabled = v.enabled !== false;
+		if (v.schedule.kind === "every") { f.schedule.kind = "every"; f.schedule.unit = v.schedule.unit || "hours"; f.schedule.value = v.schedule.value || 1; }
+		else if (v.schedule.kind === "daily") { f.schedule.kind = "daily"; f.schedule.expr = v.schedule.expr || ""; f.schedule.at = v.schedule.time || "09:00"; f.schedule.tz = v.schedule.tz || defaultTz(); }
+		else if (v.schedule.kind === "cron") { f.schedule.kind = "cron"; f.schedule.expr = v.schedule.expr; f.schedule.tz = v.schedule.tz || defaultTz(); }
+		else if (v.schedule.kind === "at") { f.schedule.kind = "once"; f.schedule.at = v.schedule.at || ""; f.schedule.tz = v.schedule.tz || defaultTz(); }
+		if (v.delivery) { f.delivery.channel = v.delivery.channel || "slack"; f.delivery.targetKind = v.delivery.targetKind || "owner"; f.delivery.target = v.delivery.target || ""; }
+
+		state.create.appliedTemplate = tid;
+		state.create.form = f;
+		state.create.dirtyByUser = false;
+		state.create.errors = {};
+		state.create.submitError = null;
+		renderCreateDrawer();
+		schedulePreview();
+	}
+
+	// ---- describe assist ----
+
+	function fillFromDescription() {
+		var desc = state.create.describeText.trim();
+		if (!desc || desc.length > DESCRIBE_MAX) return;
+		state.create.describePending = true;
+		state.create.describeError = null;
+		renderCreateDrawer();
+		ctx.api("POST", "/ui/api/scheduler/parse", { description: desc }).then(function (res) {
+			state.create.describePending = false;
+			applyProposal(res.proposal);
+			state.create.describeFilled = true;
+			renderCreateDrawer();
+			focusInDrawer("#scheduler-name");
+			schedulePreview();
+		}).catch(function (err) {
+			state.create.describePending = false;
+			if (err.status === 503) {
+				state.create.describeDisabled = true;
+				state.create.describeError = null;
+				ctx.toast("error", "Describe assist unavailable", "Set ANTHROPIC_API_KEY to enable this.");
+			} else {
+				state.create.describeError = err.message || "Could not parse description, please fill the form manually.";
+			}
+			renderCreateDrawer();
+		});
+	}
+
+	function applyProposal(p) {
+		if (!p || typeof p !== "object") return;
+		var f = defaultForm();
+		if (typeof p.name === "string") f.name = p.name;
+		if (typeof p.description === "string") f.description = p.description;
+		if (typeof p.task === "string") f.task = p.task;
+		if (p.schedule && typeof p.schedule === "object") {
+			if (p.schedule.kind === "every") {
+				f.schedule.kind = "every";
+				var ms = Number(p.schedule.intervalMs) || 3_600_000;
+				if (ms % 86_400_000 === 0) { f.schedule.unit = "days"; f.schedule.value = ms / 86_400_000; }
+				else if (ms % 3_600_000 === 0) { f.schedule.unit = "hours"; f.schedule.value = ms / 3_600_000; }
+				else { f.schedule.unit = "minutes"; f.schedule.value = Math.max(1, Math.round(ms / 60_000)); }
+			} else if (p.schedule.kind === "cron") {
+				var expr = String(p.schedule.expr || "");
+				var parts = expr.trim().split(/\s+/);
+				var isDaily = parts.length === 5 && parts[2] === "*" && parts[3] === "*" && parts[4] === "*";
+				f.schedule.kind = isDaily ? "daily" : "cron";
+				f.schedule.expr = expr;
+				if (isDaily) f.schedule.at = cronToHhMm(expr);
+				if (p.schedule.tz) f.schedule.tz = String(p.schedule.tz);
+			} else if (p.schedule.kind === "at") {
+				f.schedule.kind = "once";
+				var iso = String(p.schedule.at || "");
+				f.schedule.at = iso ? iso.slice(0, 16) : "";
+			}
+		}
+		if (p.delivery && typeof p.delivery === "object") {
+			f.delivery.channel = p.delivery.channel === "none" ? "none" : "slack";
+			var t = String(p.delivery.target || "owner");
+			if (t === "owner") f.delivery.targetKind = "owner";
+			else if (/^C[A-Z0-9]+$/.test(t)) { f.delivery.targetKind = "channel"; f.delivery.target = t; }
+			else if (/^U[A-Z0-9]+$/.test(t)) { f.delivery.targetKind = "user"; f.delivery.target = t; }
+		}
+		state.create.form = f;
+		state.create.dirtyByUser = false;
+		state.create.errors = {};
+		state.create.submitError = null;
+	}
+
+	// ---- validation + submit ----
+
+	function validateField(fld) {
+		var errors = state.create.errors, f = state.create.form;
+		if (fld === "name") {
+			delete errors.name;
+			if (!f.name.trim()) errors.name = "Name is required.";
+			else if (f.name.length > NAME_MAX) errors.name = "Name exceeds " + NAME_MAX + " characters.";
+			else {
+				var jobs = (state.list && state.list.jobs) || [];
+				for (var i = 0; i < jobs.length; i++) {
+					if (jobs[i].name.toLowerCase() === f.name.toLowerCase()) { errors.name = 'A job named "' + f.name + '" already exists.'; break; }
+				}
+			}
+		}
+		if (fld === "task") {
+			delete errors.task;
+			if (!f.task.trim()) errors.task = "Task prompt is required.";
+			else if (new Blob([f.task]).size > TASK_MAX) errors.task = "Task prompt exceeds 32 KB.";
+		}
+		if (fld === "delivery") {
+			delete errors.delivery;
+			if (f.delivery.channel === "slack") {
+				if (f.delivery.targetKind === "channel" && !/^C[A-Z0-9]+$/.test(f.delivery.target)) errors.delivery = "Channel id must start with C and use capital letters and digits.";
+				if (f.delivery.targetKind === "user" && !/^U[A-Z0-9]+$/.test(f.delivery.target)) errors.delivery = "User id must start with U and use capital letters and digits.";
+			}
+		}
+		updateSaveButton();
+	}
+
+	function validateAll() {
+		validateField("name"); validateField("task"); validateField("delivery");
+		if (state.create.previewError) state.create.errors.schedule = state.create.previewError;
+		else delete state.create.errors.schedule;
+	}
+
+	function isCreateValid() {
+		var f = state.create.form;
+		if (!f.name.trim() || !f.task.trim()) return false;
+		if (new Blob([f.task]).size > TASK_MAX) return false;
+		if (state.create.previewError) return false;
+		var e = state.create.errors;
+		if (e.name || e.task || e.delivery) return false;
+		if (f.delivery.channel === "slack" && f.delivery.targetKind !== "owner" && !f.delivery.target.trim()) return false;
+		if (f.schedule.kind === "cron" && !f.schedule.expr.trim()) return false;
+		if (f.schedule.kind === "once" && !f.schedule.at.trim()) return false;
+		if (f.schedule.kind === "daily" && !(f.schedule.expr || f.schedule.at)) return false;
+		return true;
+	}
+
+	function schedulePreview() {
+		if (previewTimer) clearTimeout(previewTimer);
+		var payload = buildServerSchedule(state.create.form.schedule);
+		if (!payload) {
+			state.create.preview = null; state.create.previewError = null;
+			updatePreviewNode();
+			return;
+		}
+		state.create.previewPending = true;
+		updatePreviewNode();
+		previewTimer = setTimeout(function () {
+			ctx.api("POST", "/ui/api/scheduler/preview", { schedule: payload }).then(function (res) {
+				state.create.previewPending = false;
+				state.create.preview = { nextRunAt: res.nextRunAt, humanReadable: res.humanReadable };
+				state.create.previewError = res.error || null;
+				updatePreviewNode();
+				updateSaveButton();
+			}).catch(function (err) {
+				state.create.previewPending = false;
+				state.create.preview = null;
+				state.create.previewError = err.message || "Could not preview schedule.";
+				updatePreviewNode();
+				updateSaveButton();
+			});
+		}, PREVIEW_DEBOUNCE_MS);
+	}
+
+	function updatePreviewNode() {
+		if (!drawerRoot) return;
+		var node = drawerRoot.querySelector(".dash-sched-preview");
+		if (!node) return;
+		var temp = document.createElement("div");
+		temp.innerHTML = renderPreview();
+		if (temp.firstChild) node.parentNode.replaceChild(temp.firstChild, node);
+	}
+
+	function buildServerSchedule(s) {
+		if (s.kind === "every") {
+			var v = Number(s.value) || 0;
+			if (v <= 0) return null;
+			var mult = s.unit === "minutes" ? 60_000 : s.unit === "days" ? 86_400_000 : 3_600_000;
+			return { kind: "every", intervalMs: v * mult };
+		}
+		if (s.kind === "daily") {
+			var hhmm = s.at || (/^\d+ \d+/.test(s.expr || "") ? cronToHhMm(s.expr) : "");
+			if (!/^\d{1,2}:\d{2}$/.test(hhmm || "")) return null;
+			var parts = hhmm.split(":");
+			return { kind: "cron", expr: Number(parts[1]) + " " + Number(parts[0]) + " * * *", tz: s.tz || defaultTz() };
+		}
+		if (s.kind === "cron") {
+			if (!s.expr || !s.expr.trim()) return null;
+			var out = { kind: "cron", expr: s.expr.trim() };
+			if (s.tz) out.tz = s.tz;
+			return out;
+		}
+		if (s.kind === "once") {
+			if (!s.at) return null;
+			var iso = toIsoWithOffset(s.at);
+			return iso ? { kind: "at", at: iso } : null;
+		}
+		return null;
+	}
+
+	// datetime-local yields "YYYY-MM-DDTHH:mm". Backend rejects bare-local;
+	// we emit the viewer's current offset for the chosen instant. If the
+	// operator picked a tz different from the viewer's system tz the
+	// timestamp still parses, but the interpretation uses the viewer's
+	// offset. Tradeoff noted in the spec.
+	function toIsoWithOffset(localDt) {
+		var d = new Date(localDt);
+		if (isNaN(d.getTime())) return null;
+		var offsetMin = -d.getTimezoneOffset();
+		var sign = offsetMin >= 0 ? "+" : "-";
+		var abs = Math.abs(offsetMin);
+		return localDt + ":00" + sign + String(Math.floor(abs / 60)).padStart(2, "0") + ":" + String(abs % 60).padStart(2, "0");
+	}
+
+	function submitCreate() {
+		validateAll();
+		if (!isCreateValid()) { updateSaveButton(); return; }
+		var f = state.create.form;
+		var payload = {
+			name: f.name.trim(),
+			task: f.task,
+			schedule: buildServerSchedule(f.schedule),
+			createdBy: "user",
+		};
+		if (f.description.trim()) payload.description = f.description.trim();
+		if (f.delivery.channel === "none") payload.delivery = { channel: "none", target: "none" };
+		else if (f.delivery.targetKind === "owner") payload.delivery = { channel: "slack", target: "owner" };
+		else payload.delivery = { channel: "slack", target: f.delivery.target.trim() };
+		if (f.schedule.kind === "once") payload.deleteAfterRun = f.deleteAfterRun;
+
+		state.create.submitting = true;
+		state.create.submitError = null;
+		updateSaveButton();
+		ctx.api("POST", "/ui/api/scheduler", payload).then(function (res) {
+			state.create.submitting = false;
+			ctx.toast("success", "Job scheduled", res.job.name);
+			if (!state.list) state.list = { jobs: [] };
+			state.list.jobs.unshift(res.job);
+			state.create = makeCreateState();
+			render();
+			closeDrawer(true);
+			ctx.navigate("#/scheduler/" + encodeURIComponent(res.job.id));
+		}).catch(function (err) {
+			state.create.submitting = false;
+			state.create.submitError = err.message || "Could not save job.";
+			renderCreateDrawer();
+			ctx.toast("error", "Could not save", err.message || String(err));
+		});
+	}
+
+	// ---- global keys + mount ----
+
+	function installGlobalKeys() {
+		if (documentKeyHandler) return;
+		documentKeyHandler = function (e) {
+			if (e.key !== "/") return;
+			var tag = (document.activeElement && document.activeElement.tagName) || "";
+			if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return;
+			if (e.metaKey || e.ctrlKey || e.altKey) return;
+			if ((window.location.hash || "").indexOf("#/scheduler") !== 0) return;
+			var search = document.getElementById("scheduler-filter-q");
+			if (search) { e.preventDefault(); search.focus(); search.select(); }
+		};
+		document.addEventListener("keydown", documentKeyHandler);
+	}
+
+	function mount(container, arg, dashCtx) {
+		ctx = dashCtx; root = container;
+		ctx.setBreadcrumb("Scheduler");
+		installGlobalKeys();
+
+		if (!dirtyRegistered) {
+			ctx.registerDirtyChecker(function () { return state.create.dirtyByUser; });
+			dirtyRegistered = true;
+		}
+
+		render();
+
+		return loadList().then(function () {
+			if (arg === "new") openDrawer("create");
+			else if (arg) { openDrawer("detail"); loadDetail(arg); }
+			else if (drawerRoot) closeDrawer(true);
+		});
+	}
+
+	if (window.PhantomDashboard && window.PhantomDashboard.registerRoute) {
+		window.PhantomDashboard.registerRoute("scheduler", { mount: mount });
+	}
+})();

--- a/src/db/__tests__/migrate.test.ts
+++ b/src/db/__tests__/migrate.test.ts
@@ -35,8 +35,9 @@ describe("runMigrations", () => {
 		runMigrations(db);
 
 		const migrationCount = db.query("SELECT COUNT(*) as count FROM _migrations").get() as { count: number };
-		// Migration history: base 28 + chat channel tables 28-39 (12 entries) + auth/push 40-43 (4 entries) = 44.
-		expect(migrationCount.count).toBe(44);
+		// Migration history: base 28 + chat channel tables 28-39 (12 entries) +
+		// auth/push 40-43 (4 entries) + scheduler audit 44-45 (2 entries) = 46.
+		expect(migrationCount.count).toBe(46);
 	});
 
 	test("tracks applied migration indices", () => {
@@ -50,7 +51,7 @@ describe("runMigrations", () => {
 
 		expect(indices).toEqual([
 			0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30,
-			31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43,
+			31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45,
 		]);
 	});
 

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -354,4 +354,23 @@ export const MIGRATIONS: string[] = [
 	"CREATE UNIQUE INDEX IF NOT EXISTS idx_chat_push_subscriptions_endpoint ON chat_push_subscriptions(endpoint)",
 
 	"CREATE INDEX IF NOT EXISTS idx_chat_push_subscriptions_user ON chat_push_subscriptions(disabled, created_at)",
+
+	// PR4 dashboard: scheduler action audit log. Every create/pause/resume/run/
+	// delete from the UI API writes a row here so the operator can see the
+	// history of what was scheduled, paused, run, or removed. Agent-originated
+	// writes via phantom_schedule bypass this path; a future PR may hook the
+	// service layer directly.
+	`CREATE TABLE IF NOT EXISTS scheduler_audit_log (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		job_id TEXT NOT NULL,
+		job_name TEXT,
+		action TEXT NOT NULL,
+		previous_status TEXT,
+		new_status TEXT,
+		actor TEXT NOT NULL,
+		detail TEXT,
+		created_at TEXT NOT NULL DEFAULT (datetime('now'))
+	)`,
+
+	"CREATE INDEX IF NOT EXISTS idx_scheduler_audit_log_job ON scheduler_audit_log(job_id, id DESC)",
 ];

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,7 +58,14 @@ import { createSecretToolServer } from "./secrets/tools.ts";
 import { createBrowserToolServer } from "./ui/browser-mcp.ts";
 import { setLoginPageAgentName } from "./ui/login-page.ts";
 import { closePreviewResources, createPreviewToolServer, getOrCreatePreviewContext } from "./ui/preview.ts";
-import { setBootstrapDb, setDashboardDb, setPublicDir, setSecretSavedCallback, setSecretsDb } from "./ui/serve.ts";
+import {
+	setBootstrapDb,
+	setDashboardDb,
+	setPublicDir,
+	setSchedulerInstance,
+	setSecretSavedCallback,
+	setSecretsDb,
+} from "./ui/serve.ts";
 import { createWebUiToolServer } from "./ui/tools.ts";
 
 async function main(): Promise<void> {
@@ -218,6 +225,7 @@ async function main(): Promise<void> {
 		// Wire scheduler into the agent (Slack channel set later after channel init)
 		scheduler = new Scheduler({ db, runtime });
 		setSchedulerHealthProvider(() => scheduler?.getHealthSummary() ?? null);
+		setSchedulerInstance(scheduler);
 
 		// Pass factories (not singletons) so each query() gets fresh MCP server instances.
 		// The underlying registries (DynamicToolRegistry, Scheduler) are singletons.

--- a/src/index.ts
+++ b/src/index.ts
@@ -225,7 +225,7 @@ async function main(): Promise<void> {
 		// Wire scheduler into the agent (Slack channel set later after channel init)
 		scheduler = new Scheduler({ db, runtime });
 		setSchedulerHealthProvider(() => scheduler?.getHealthSummary() ?? null);
-		setSchedulerInstance(scheduler);
+		setSchedulerInstance(scheduler, runtime);
 
 		// Pass factories (not singletons) so each query() gets fresh MCP server instances.
 		// The underlying registries (DynamicToolRegistry, Scheduler) are singletons.

--- a/src/scheduler/__tests__/parse-with-sonnet.test.ts
+++ b/src/scheduler/__tests__/parse-with-sonnet.test.ts
@@ -1,211 +1,118 @@
 import { describe, expect, mock, test } from "bun:test";
+import type { JudgeQueryOptions, JudgeQueryResult } from "../../agent/judge-query.ts";
+import type { AgentRuntime } from "../../agent/runtime.ts";
 import { parseJobDescription } from "../parse-with-sonnet.ts";
 
-type FakeContentBlock = { type: "text"; text: string } | { type: "tool_use"; id: string; name: string; input: unknown };
+type AnyData = Record<string, unknown>;
 
-function makeClient(handler: () => Promise<{ content: FakeContentBlock[] }>) {
-	return { messages: { create: mock(handler) } };
+function makeRuntime(handler: (opts: JudgeQueryOptions<AnyData>) => Promise<JudgeQueryResult<AnyData>>): {
+	runtime: AgentRuntime;
+	judgeQuery: ReturnType<typeof mock>;
+} {
+	const judgeQuery = mock(handler);
+	return { runtime: { judgeQuery } as unknown as AgentRuntime, judgeQuery };
 }
 
-function hnToolUse(): FakeContentBlock[] {
-	return [
-		{
-			type: "tool_use",
-			id: "tool_01",
-			name: "propose_job",
-			input: {
-				name: "hn-digest",
-				description: "Top Hacker News stories every 6 hours",
-				task: "Fetch the top 10 Hacker News stories and post a brief summary to Slack.",
-				schedule: { kind: "every", intervalMs: 21_600_000 },
-				delivery: { channel: "slack", target: "owner" },
-			},
+function hnResult(): JudgeQueryResult<AnyData> {
+	return {
+		verdict: "pass",
+		confidence: 1,
+		reasoning: "",
+		data: {
+			name: "hn-digest",
+			description: "Top Hacker News stories every 6 hours",
+			task: "Fetch the top 10 Hacker News stories and post a brief summary to Slack.",
+			schedule: { kind: "every", intervalMs: 21_600_000 },
+			delivery: { channel: "slack", target: "owner" },
 		},
-	];
+		model: "claude-sonnet-4-6",
+		inputTokens: 100,
+		outputTokens: 50,
+		costUsd: 0.01,
+		durationMs: 500,
+	};
 }
 
 describe("parseJobDescription", () => {
-	test("returns 503 when ANTHROPIC_API_KEY is unset", async () => {
-		const result = await parseJobDescription("anything", { apiKey: null });
+	test("returns 422 when runtime is not available", async () => {
+		const result = await parseJobDescription("anything", { runtime: null });
 		expect(result.ok).toBe(false);
 		if (result.ok) throw new Error("expected failure");
-		expect(result.status).toBe(503);
-		expect(result.error).toContain("ANTHROPIC_API_KEY");
+		expect(result.status).toBe(422);
 	});
 
-	test("happy path: Sonnet returns a valid proposal", async () => {
-		const client = makeClient(async () => ({ content: hnToolUse() }));
+	test("happy path: runtime returns a valid proposal", async () => {
+		const { runtime } = makeRuntime(async () => hnResult());
 		const result = await parseJobDescription("Pull top HN stories every 6 hours and post a summary to my Slack DM", {
-			apiKey: "test-key",
-			clientFactory: () => client as never,
+			runtime,
 		});
-
 		expect(result.ok).toBe(true);
 		if (!result.ok) throw new Error("expected success");
 		expect(result.proposal.name).toBe("hn-digest");
 		expect(result.proposal.schedule).toEqual({ kind: "every", intervalMs: 21_600_000 });
-		expect(result.proposal.delivery).toEqual({ channel: "slack", target: "owner" });
 	});
 
-	test("forces tool_choice to propose_job", async () => {
-		const seen: Array<unknown> = [];
-		const createMock = mock(async (args: unknown) => {
-			seen.push(args);
-			return { content: hnToolUse() };
-		});
-		const client = { messages: { create: createMock } };
-		await parseJobDescription("schedule anything", {
-			apiKey: "test-key",
-			clientFactory: () => client as never,
-		});
-
-		expect(createMock).toHaveBeenCalledTimes(1);
-		const args = seen[0] as {
-			tool_choice?: { type: string; name: string };
-			tools?: Array<{ name: string }>;
-			model?: string;
-		};
-		expect(args.tool_choice).toEqual({ type: "tool", name: "propose_job" });
-		expect(args.tools?.[0]?.name).toBe("propose_job");
-		expect(args.model).toBe("claude-sonnet-4-6");
+	test("requests sonnet model and the judge system prompt", async () => {
+		const { runtime, judgeQuery } = makeRuntime(async () => hnResult());
+		await parseJobDescription("schedule anything", { runtime });
+		expect(judgeQuery).toHaveBeenCalledTimes(1);
+		const opts = judgeQuery.mock.calls[0][0] as JudgeQueryOptions<AnyData>;
+		expect(opts.model).toBe("claude-sonnet-4-6");
+		expect(opts.omitPreset).toBe(true);
+		expect(typeof opts.systemPrompt).toBe("string");
+		expect(opts.systemPrompt).toContain("scheduled job");
 	});
 
-	test("422 when Sonnet returns no tool_use block", async () => {
-		const client = makeClient(async () => ({
-			content: [{ type: "text", text: "Sorry, I cannot help." }],
+	test("422 when the proposal fails the canonical v3 schema", async () => {
+		const { runtime } = makeRuntime(async () => ({
+			...hnResult(),
+			data: { name: "", task: "", schedule: { kind: "unknown" } } as AnyData,
 		}));
-
-		const result = await parseJobDescription("vague description", {
-			apiKey: "test-key",
-			clientFactory: () => client as never,
-		});
-
+		const result = await parseJobDescription("vague", { runtime });
 		expect(result.ok).toBe(false);
 		if (result.ok) throw new Error("expected failure");
 		expect(result.status).toBe(422);
 	});
 
-	test("422 when Sonnet returns a malformed tool input", async () => {
-		const client = makeClient(async () => ({
-			content: [
-				{
-					type: "tool_use",
-					id: "tool_01",
-					name: "propose_job",
-					// Missing required `schedule`, `task`; out-of-shape name.
-					input: { name: 123, foo: "bar" },
-				},
-			],
-		}));
-
-		const result = await parseJobDescription("try me", {
-			apiKey: "test-key",
-			clientFactory: () => client as never,
+	test("422 when judgeQuery throws", async () => {
+		const { runtime } = makeRuntime(async () => {
+			throw new Error("subprocess sigkilled");
 		});
-
-		expect(result.ok).toBe(false);
-		if (result.ok) throw new Error("expected failure");
-		expect(result.status).toBe(422);
-	});
-
-	test("504 when the SDK throws an abort/timeout error", async () => {
-		const client = makeClient(async () => {
-			const err = new Error("Request was aborted.");
-			(err as unknown as { name: string }).name = "AbortError";
-			throw err;
-		});
-
-		const result = await parseJobDescription("anything", {
-			apiKey: "test-key",
-			clientFactory: () => client as never,
-		});
-
-		expect(result.ok).toBe(false);
-		if (result.ok) throw new Error("expected failure");
-		expect(result.status).toBe(504);
-	});
-
-	test("422 when the SDK throws a non-timeout error", async () => {
-		const client = makeClient(async () => {
-			throw new Error("Internal server error");
-		});
-
-		const result = await parseJobDescription("anything", {
-			apiKey: "test-key",
-			clientFactory: () => client as never,
-		});
-
+		const result = await parseJobDescription("anything", { runtime });
 		expect(result.ok).toBe(false);
 		if (result.ok) throw new Error("expected failure");
 		expect(result.status).toBe(422);
 	});
 
 	test("cron schedules round-trip through the schema", async () => {
-		const client = makeClient(async () => ({
-			content: [
-				{
-					type: "tool_use",
-					id: "tool_02",
-					name: "propose_job",
-					input: {
-						name: "daily-standup",
-						task: "Summarize overnight activity and list three priorities.",
-						schedule: { kind: "cron", expr: "0 9 * * 1-5", tz: "America/Los_Angeles" },
-						delivery: { channel: "slack", target: "owner" },
-					},
-				},
-			],
+		const { runtime } = makeRuntime(async () => ({
+			...hnResult(),
+			data: {
+				name: "daily-standup",
+				task: "Summarize overnight activity and list three priorities.",
+				schedule: { kind: "cron", expr: "0 9 * * 1-5", tz: "America/Los_Angeles" },
+				delivery: { channel: "slack", target: "owner" },
+			},
 		}));
-
-		const result = await parseJobDescription("9am weekdays standup", {
-			apiKey: "test-key",
-			clientFactory: () => client as never,
-		});
-
+		const result = await parseJobDescription("9am weekdays standup", { runtime });
 		expect(result.ok).toBe(true);
 		if (!result.ok) throw new Error("expected success");
 		expect(result.proposal.schedule).toEqual({ kind: "cron", expr: "0 9 * * 1-5", tz: "America/Los_Angeles" });
 	});
 
 	test("at schedules accept ISO with offset", async () => {
-		const client = makeClient(async () => ({
-			content: [
-				{
-					type: "tool_use",
-					id: "tool_03",
-					name: "propose_job",
-					input: {
-						name: "one-time-health",
-						task: "Verify the deploy succeeded.",
-						schedule: { kind: "at", at: "2026-04-18T15:00:00-07:00" },
-						delivery: { channel: "slack", target: "owner" },
-					},
-				},
-			],
+		const { runtime } = makeRuntime(async () => ({
+			...hnResult(),
+			data: {
+				name: "one-time-health",
+				task: "Verify the deploy succeeded.",
+				schedule: { kind: "at", at: "2026-04-18T15:00:00-07:00" },
+				delivery: { channel: "slack", target: "owner" },
+			},
 		}));
-
-		const result = await parseJobDescription("check at 3pm tomorrow", {
-			apiKey: "test-key",
-			clientFactory: () => client as never,
-		});
-
+		const result = await parseJobDescription("check at 3pm tomorrow", { runtime });
 		expect(result.ok).toBe(true);
 		if (!result.ok) throw new Error("expected success");
 		expect(result.proposal.schedule).toEqual({ kind: "at", at: "2026-04-18T15:00:00-07:00" });
-	});
-
-	test("uses the ANTHROPIC_API_KEY env var when no apiKey passed", async () => {
-		const prev = process.env.ANTHROPIC_API_KEY;
-		process.env.ANTHROPIC_API_KEY = "env-key";
-		try {
-			const client = makeClient(async () => ({ content: hnToolUse() }));
-			const result = await parseJobDescription("every 6h HN digest", {
-				clientFactory: () => client as never,
-			});
-			expect(result.ok).toBe(true);
-		} finally {
-			if (prev === undefined) process.env.ANTHROPIC_API_KEY = undefined;
-			else process.env.ANTHROPIC_API_KEY = prev;
-		}
 	});
 });

--- a/src/scheduler/__tests__/parse-with-sonnet.test.ts
+++ b/src/scheduler/__tests__/parse-with-sonnet.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, mock, test } from "bun:test";
+import { parseJobDescription } from "../parse-with-sonnet.ts";
+
+type FakeContentBlock =
+	| { type: "text"; text: string }
+	| { type: "tool_use"; id: string; name: string; input: unknown };
+
+function makeClient(handler: () => Promise<{ content: FakeContentBlock[] }>) {
+	return { messages: { create: mock(handler) } };
+}
+
+function hnToolUse(): FakeContentBlock[] {
+	return [
+		{
+			type: "tool_use",
+			id: "tool_01",
+			name: "propose_job",
+			input: {
+				name: "hn-digest",
+				description: "Top Hacker News stories every 6 hours",
+				task: "Fetch the top 10 Hacker News stories and post a brief summary to Slack.",
+				schedule: { kind: "every", intervalMs: 21_600_000 },
+				delivery: { channel: "slack", target: "owner" },
+			},
+		},
+	];
+}
+
+describe("parseJobDescription", () => {
+	test("returns 503 when ANTHROPIC_API_KEY is unset", async () => {
+		const result = await parseJobDescription("anything", { apiKey: null });
+		expect(result.ok).toBe(false);
+		if (result.ok) throw new Error("expected failure");
+		expect(result.status).toBe(503);
+		expect(result.error).toContain("ANTHROPIC_API_KEY");
+	});
+
+	test("happy path: Sonnet returns a valid proposal", async () => {
+		const client = makeClient(async () => ({ content: hnToolUse() }));
+		const result = await parseJobDescription(
+			"Pull top HN stories every 6 hours and post a summary to my Slack DM",
+			{
+				apiKey: "test-key",
+				clientFactory: () => client as never,
+			},
+		);
+
+		expect(result.ok).toBe(true);
+		if (!result.ok) throw new Error("expected success");
+		expect(result.proposal.name).toBe("hn-digest");
+		expect(result.proposal.schedule).toEqual({ kind: "every", intervalMs: 21_600_000 });
+		expect(result.proposal.delivery).toEqual({ channel: "slack", target: "owner" });
+	});
+
+	test("forces tool_choice to propose_job", async () => {
+		const createMock = mock(async () => ({ content: hnToolUse() }));
+		const client = { messages: { create: createMock } };
+		await parseJobDescription("schedule anything", {
+			apiKey: "test-key",
+			clientFactory: () => client as never,
+		});
+
+		expect(createMock).toHaveBeenCalledTimes(1);
+		const call = createMock.mock.calls[0];
+		const args = call[0] as { tool_choice?: { type: string; name: string }; tools?: Array<{ name: string }>; model?: string };
+		expect(args.tool_choice).toEqual({ type: "tool", name: "propose_job" });
+		expect(args.tools?.[0]?.name).toBe("propose_job");
+		expect(args.model).toBe("claude-sonnet-4-6");
+	});
+
+	test("422 when Sonnet returns no tool_use block", async () => {
+		const client = makeClient(async () => ({
+			content: [{ type: "text", text: "Sorry, I cannot help." }],
+		}));
+
+		const result = await parseJobDescription("vague description", {
+			apiKey: "test-key",
+			clientFactory: () => client as never,
+		});
+
+		expect(result.ok).toBe(false);
+		if (result.ok) throw new Error("expected failure");
+		expect(result.status).toBe(422);
+	});
+
+	test("422 when Sonnet returns a malformed tool input", async () => {
+		const client = makeClient(async () => ({
+			content: [
+				{
+					type: "tool_use",
+					id: "tool_01",
+					name: "propose_job",
+					// Missing required `schedule`, `task`; out-of-shape name.
+					input: { name: 123, foo: "bar" },
+				},
+			],
+		}));
+
+		const result = await parseJobDescription("try me", {
+			apiKey: "test-key",
+			clientFactory: () => client as never,
+		});
+
+		expect(result.ok).toBe(false);
+		if (result.ok) throw new Error("expected failure");
+		expect(result.status).toBe(422);
+	});
+
+	test("504 when the SDK throws an abort/timeout error", async () => {
+		const client = makeClient(async () => {
+			const err = new Error("Request was aborted.");
+			(err as unknown as { name: string }).name = "AbortError";
+			throw err;
+		});
+
+		const result = await parseJobDescription("anything", {
+			apiKey: "test-key",
+			clientFactory: () => client as never,
+		});
+
+		expect(result.ok).toBe(false);
+		if (result.ok) throw new Error("expected failure");
+		expect(result.status).toBe(504);
+	});
+
+	test("422 when the SDK throws a non-timeout error", async () => {
+		const client = makeClient(async () => {
+			throw new Error("Internal server error");
+		});
+
+		const result = await parseJobDescription("anything", {
+			apiKey: "test-key",
+			clientFactory: () => client as never,
+		});
+
+		expect(result.ok).toBe(false);
+		if (result.ok) throw new Error("expected failure");
+		expect(result.status).toBe(422);
+	});
+
+	test("cron schedules round-trip through the schema", async () => {
+		const client = makeClient(async () => ({
+			content: [
+				{
+					type: "tool_use",
+					id: "tool_02",
+					name: "propose_job",
+					input: {
+						name: "daily-standup",
+						task: "Summarize overnight activity and list three priorities.",
+						schedule: { kind: "cron", expr: "0 9 * * 1-5", tz: "America/Los_Angeles" },
+						delivery: { channel: "slack", target: "owner" },
+					},
+				},
+			],
+		}));
+
+		const result = await parseJobDescription("9am weekdays standup", {
+			apiKey: "test-key",
+			clientFactory: () => client as never,
+		});
+
+		expect(result.ok).toBe(true);
+		if (!result.ok) throw new Error("expected success");
+		expect(result.proposal.schedule).toEqual({ kind: "cron", expr: "0 9 * * 1-5", tz: "America/Los_Angeles" });
+	});
+
+	test("at schedules accept ISO with offset", async () => {
+		const client = makeClient(async () => ({
+			content: [
+				{
+					type: "tool_use",
+					id: "tool_03",
+					name: "propose_job",
+					input: {
+						name: "one-time-health",
+						task: "Verify the deploy succeeded.",
+						schedule: { kind: "at", at: "2026-04-18T15:00:00-07:00" },
+						delivery: { channel: "slack", target: "owner" },
+					},
+				},
+			],
+		}));
+
+		const result = await parseJobDescription("check at 3pm tomorrow", {
+			apiKey: "test-key",
+			clientFactory: () => client as never,
+		});
+
+		expect(result.ok).toBe(true);
+		if (!result.ok) throw new Error("expected success");
+		expect(result.proposal.schedule).toEqual({ kind: "at", at: "2026-04-18T15:00:00-07:00" });
+	});
+
+	test("uses the ANTHROPIC_API_KEY env var when no apiKey passed", async () => {
+		const prev = process.env.ANTHROPIC_API_KEY;
+		process.env.ANTHROPIC_API_KEY = "env-key";
+		try {
+			const client = makeClient(async () => ({ content: hnToolUse() }));
+			const result = await parseJobDescription("every 6h HN digest", {
+				clientFactory: () => client as never,
+			});
+			expect(result.ok).toBe(true);
+		} finally {
+			if (prev === undefined) delete process.env.ANTHROPIC_API_KEY;
+			else process.env.ANTHROPIC_API_KEY = prev;
+		}
+	});
+});

--- a/src/scheduler/__tests__/parse-with-sonnet.test.ts
+++ b/src/scheduler/__tests__/parse-with-sonnet.test.ts
@@ -1,9 +1,7 @@
 import { describe, expect, mock, test } from "bun:test";
 import { parseJobDescription } from "../parse-with-sonnet.ts";
 
-type FakeContentBlock =
-	| { type: "text"; text: string }
-	| { type: "tool_use"; id: string; name: string; input: unknown };
+type FakeContentBlock = { type: "text"; text: string } | { type: "tool_use"; id: string; name: string; input: unknown };
 
 function makeClient(handler: () => Promise<{ content: FakeContentBlock[] }>) {
 	return { messages: { create: mock(handler) } };
@@ -37,13 +35,10 @@ describe("parseJobDescription", () => {
 
 	test("happy path: Sonnet returns a valid proposal", async () => {
 		const client = makeClient(async () => ({ content: hnToolUse() }));
-		const result = await parseJobDescription(
-			"Pull top HN stories every 6 hours and post a summary to my Slack DM",
-			{
-				apiKey: "test-key",
-				clientFactory: () => client as never,
-			},
-		);
+		const result = await parseJobDescription("Pull top HN stories every 6 hours and post a summary to my Slack DM", {
+			apiKey: "test-key",
+			clientFactory: () => client as never,
+		});
 
 		expect(result.ok).toBe(true);
 		if (!result.ok) throw new Error("expected success");
@@ -53,7 +48,11 @@ describe("parseJobDescription", () => {
 	});
 
 	test("forces tool_choice to propose_job", async () => {
-		const createMock = mock(async () => ({ content: hnToolUse() }));
+		const seen: Array<unknown> = [];
+		const createMock = mock(async (args: unknown) => {
+			seen.push(args);
+			return { content: hnToolUse() };
+		});
 		const client = { messages: { create: createMock } };
 		await parseJobDescription("schedule anything", {
 			apiKey: "test-key",
@@ -61,8 +60,11 @@ describe("parseJobDescription", () => {
 		});
 
 		expect(createMock).toHaveBeenCalledTimes(1);
-		const call = createMock.mock.calls[0];
-		const args = call[0] as { tool_choice?: { type: string; name: string }; tools?: Array<{ name: string }>; model?: string };
+		const args = seen[0] as {
+			tool_choice?: { type: string; name: string };
+			tools?: Array<{ name: string }>;
+			model?: string;
+		};
 		expect(args.tool_choice).toEqual({ type: "tool", name: "propose_job" });
 		expect(args.tools?.[0]?.name).toBe("propose_job");
 		expect(args.model).toBe("claude-sonnet-4-6");
@@ -202,7 +204,7 @@ describe("parseJobDescription", () => {
 			});
 			expect(result.ok).toBe(true);
 		} finally {
-			if (prev === undefined) delete process.env.ANTHROPIC_API_KEY;
+			if (prev === undefined) process.env.ANTHROPIC_API_KEY = undefined;
 			else process.env.ANTHROPIC_API_KEY = prev;
 		}
 	});

--- a/src/scheduler/__tests__/service.test.ts
+++ b/src/scheduler/__tests__/service.test.ts
@@ -388,16 +388,19 @@ describe("Scheduler", () => {
 		expect(nextMs).toBeLessThan(Date.now() + 120_000);
 	});
 
-	test("resumeJob resets consecutive_errors", () => {
+	test("resumeJob resets consecutive_errors when resuming a paused job", () => {
 		const scheduler = new Scheduler({ db, runtime: mockRuntime as never });
 		const job = scheduler.createJob({
 			name: "ErrorBurn",
 			schedule: { kind: "every", intervalMs: 60_000 },
 			task: "Burn",
 		});
+		// Pause first so resume is a legitimate transition.
+		scheduler.pauseJob(job.id);
 		db.run("UPDATE scheduled_jobs SET consecutive_errors = 4 WHERE id = ?", [job.id]);
 
 		const resumed = scheduler.resumeJob(job.id);
+		expect(resumed?.status).toBe("active");
 		expect(resumed?.consecutiveErrors).toBe(0);
 	});
 
@@ -405,6 +408,40 @@ describe("Scheduler", () => {
 		const scheduler = new Scheduler({ db, runtime: mockRuntime as never });
 		const resumed = scheduler.resumeJob("nope");
 		expect(resumed).toBeNull();
+	});
+
+	test("resumeJob is a no-op on a non-paused job (active, failed, completed)", () => {
+		const scheduler = new Scheduler({ db, runtime: mockRuntime as never });
+		const job = scheduler.createJob({
+			name: "ActiveJob",
+			schedule: { kind: "every", intervalMs: 60_000 },
+			task: "Fire",
+		});
+		// active -> resume must be a no-op, not flip to active again.
+		const resumed = scheduler.resumeJob(job.id);
+		expect(resumed?.status).toBe("active");
+
+		// Force terminal states and verify resumeJob refuses to revive them.
+		db.run("UPDATE scheduled_jobs SET status = 'failed' WHERE id = ?", [job.id]);
+		const stillFailed = scheduler.resumeJob(job.id);
+		expect(stillFailed?.status).toBe("failed");
+
+		db.run("UPDATE scheduled_jobs SET status = 'completed' WHERE id = ?", [job.id]);
+		const stillCompleted = scheduler.resumeJob(job.id);
+		expect(stillCompleted?.status).toBe("completed");
+	});
+
+	test("createJob honors enabled=false by inserting an inactive row", () => {
+		const scheduler = new Scheduler({ db, runtime: mockRuntime as never });
+		const job = scheduler.createJob({
+			name: "DisabledJob",
+			schedule: { kind: "every", intervalMs: 60_000 },
+			task: "Fire",
+			enabled: false,
+		});
+		expect(job.enabled).toBe(false);
+		const row = db.query("SELECT enabled FROM scheduled_jobs WHERE id = ?").get(job.id) as { enabled: number };
+		expect(row.enabled).toBe(0);
 	});
 
 	test("paused job is excluded from the armTimer MIN query", async () => {

--- a/src/scheduler/__tests__/service.test.ts
+++ b/src/scheduler/__tests__/service.test.ts
@@ -336,4 +336,93 @@ describe("Scheduler", () => {
 		const updated = scheduler.getJob(job.id);
 		expect(updated?.status).toBe("completed");
 	});
+
+	test("pauseJob flips status from active to paused", () => {
+		const scheduler = new Scheduler({ db, runtime: mockRuntime as never });
+		const job = scheduler.createJob({
+			name: "Pauseable",
+			schedule: { kind: "every", intervalMs: 60_000 },
+			task: "Hold",
+		});
+		expect(job.status).toBe("active");
+
+		const paused = scheduler.pauseJob(job.id);
+		expect(paused).not.toBeNull();
+		expect(paused?.status).toBe("paused");
+	});
+
+	test("pauseJob returns null for unknown id", () => {
+		const scheduler = new Scheduler({ db, runtime: mockRuntime as never });
+		const paused = scheduler.pauseJob("does-not-exist");
+		expect(paused).toBeNull();
+	});
+
+	test("pauseJob is a no-op on an already-paused job", () => {
+		const scheduler = new Scheduler({ db, runtime: mockRuntime as never });
+		const job = scheduler.createJob({
+			name: "DoublePause",
+			schedule: { kind: "every", intervalMs: 60_000 },
+			task: "Hold",
+		});
+		scheduler.pauseJob(job.id);
+		const again = scheduler.pauseJob(job.id);
+		expect(again?.status).toBe("paused");
+	});
+
+	test("resumeJob flips paused to active and recomputes next_run_at", () => {
+		const scheduler = new Scheduler({ db, runtime: mockRuntime as never });
+		const job = scheduler.createJob({
+			name: "Resumable",
+			schedule: { kind: "every", intervalMs: 60_000 },
+			task: "Go",
+		});
+		scheduler.pauseJob(job.id);
+		const before = scheduler.getJob(job.id);
+		expect(before?.status).toBe("paused");
+
+		const resumed = scheduler.resumeJob(job.id);
+		expect(resumed?.status).toBe("active");
+		expect(resumed?.nextRunAt).toBeTruthy();
+		const nextMs = resumed?.nextRunAt ? new Date(resumed.nextRunAt).getTime() : 0;
+		expect(nextMs).toBeGreaterThan(Date.now() - 5_000);
+		expect(nextMs).toBeLessThan(Date.now() + 120_000);
+	});
+
+	test("resumeJob resets consecutive_errors", () => {
+		const scheduler = new Scheduler({ db, runtime: mockRuntime as never });
+		const job = scheduler.createJob({
+			name: "ErrorBurn",
+			schedule: { kind: "every", intervalMs: 60_000 },
+			task: "Burn",
+		});
+		db.run("UPDATE scheduled_jobs SET consecutive_errors = 4 WHERE id = ?", [job.id]);
+
+		const resumed = scheduler.resumeJob(job.id);
+		expect(resumed?.consecutiveErrors).toBe(0);
+	});
+
+	test("resumeJob returns null for unknown id", () => {
+		const scheduler = new Scheduler({ db, runtime: mockRuntime as never });
+		const resumed = scheduler.resumeJob("nope");
+		expect(resumed).toBeNull();
+	});
+
+	test("paused job is excluded from the armTimer MIN query", async () => {
+		const scheduler = new Scheduler({ db, runtime: mockRuntime as never });
+		await scheduler.start();
+		const job = scheduler.createJob({
+			name: "Armed",
+			schedule: { kind: "every", intervalMs: 60_000 },
+			task: "Fire",
+		});
+		scheduler.pauseJob(job.id);
+
+		const row = db
+			.query(
+				"SELECT MIN(next_run_at) as next FROM scheduled_jobs WHERE enabled = 1 AND status = 'active' AND next_run_at IS NOT NULL",
+			)
+			.get() as { next: string | null };
+		expect(row.next).toBeNull();
+		scheduler.stop();
+	});
 });

--- a/src/scheduler/human.ts
+++ b/src/scheduler/human.ts
@@ -1,0 +1,72 @@
+// Tiny cron-to-English helper. Covers the handful of shapes the templates
+// and the create form emit; falls through to the raw expression otherwise.
+// Deliberately small: no cron-to-English dependency, no lookup tables of
+// 1000 patterns. Keep it honest and readable.
+
+import type { Schedule } from "./types.ts";
+
+const DAY_NAMES = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+
+function humanEvery(intervalMs: number): string {
+	const sec = Math.round(intervalMs / 1000);
+	if (sec < 60) return `every ${sec}s`;
+	const min = Math.round(sec / 60);
+	if (min < 60) return `every ${min}m`;
+	const hrs = intervalMs / 3_600_000;
+	if (Number.isInteger(hrs) && hrs < 48) return `every ${hrs}h`;
+	const days = intervalMs / 86_400_000;
+	if (Number.isInteger(days)) return `every ${days}d`;
+	return `every ${Math.round(min / 60)}h`;
+}
+
+function humanCron(expr: string, tz?: string): string {
+	const parts = expr.trim().split(/\s+/);
+	if (parts.length !== 5) return expr + (tz ? ` ${tz}` : "");
+	const [min, hour, dom, month, dow] = parts;
+
+	const tzSuffix = tz ? ` (${tz})` : "";
+	const m = Number(min);
+	const h = Number(hour);
+	const validTime = Number.isFinite(m) && Number.isFinite(h) && m >= 0 && m <= 59 && h >= 0 && h <= 23;
+
+	if (validTime && dom === "*" && month === "*" && dow === "*") {
+		return `${formatHhMm(h, m)} every day${tzSuffix}`;
+	}
+	if (validTime && dom === "*" && month === "*" && dow === "1-5") {
+		return `${formatHhMm(h, m)} Mon-Fri${tzSuffix}`;
+	}
+	if (validTime && dom === "*" && month === "*" && /^[0-6]$/.test(dow)) {
+		return `${formatHhMm(h, m)} every ${DAY_NAMES[Number(dow)]}${tzSuffix}`;
+	}
+	if (validTime && /^\d+$/.test(dom) && month === "*" && dow === "*") {
+		return `${formatHhMm(h, m)} on the ${ordinal(Number(dom))} of the month${tzSuffix}`;
+	}
+	if (/^\*\/\d+$/.test(min) && hour === "*" && dom === "*" && month === "*" && dow === "*") {
+		const step = min.slice(2);
+		return `every ${step} minutes${tzSuffix}`;
+	}
+	return expr + tzSuffix;
+}
+
+function formatHhMm(h: number, m: number): string {
+	const hh = String(h).padStart(2, "0");
+	const mm = String(m).padStart(2, "0");
+	return `${hh}:${mm}`;
+}
+
+function ordinal(n: number): string {
+	const s = ["th", "st", "nd", "rd"];
+	const v = n % 100;
+	return n + (s[(v - 20) % 10] || s[v] || s[0]);
+}
+
+export function humanReadableSchedule(schedule: Schedule): string {
+	switch (schedule.kind) {
+		case "at":
+			return `once at ${schedule.at}`;
+		case "every":
+			return humanEvery(schedule.intervalMs);
+		case "cron":
+			return humanCron(schedule.expr, schedule.tz);
+	}
+}

--- a/src/scheduler/parse-with-sonnet.ts
+++ b/src/scheduler/parse-with-sonnet.ts
@@ -1,0 +1,268 @@
+// Sonnet describe-your-job assist.
+//
+// CARDINAL RULE: This endpoint helps the OPERATOR fill a form. The operator
+// reviews and edits the structured output before saving. It does NOT classify
+// user intent, and it does NOT drive the agent at run time. When the job
+// fires, the agent gets the operator's final `task` prompt and decides what
+// to do with it. Sonnet here is form plumbing, not a routing layer.
+//
+// A tiny one-shot Messages API call with forced tool-use is the simplest
+// shape that produces validated structured output. We do not use the Agent
+// SDK for this: a raw Messages call avoids the subprocess overhead and the
+// full tool surface we do not need.
+
+import Anthropic from "@anthropic-ai/sdk";
+import { JobCreateInputSchema, type JobCreateInputParsed } from "./tool-schema.ts";
+
+type AnthropicClient = InstanceType<typeof Anthropic>;
+
+export type ParseSuccess = {
+	ok: true;
+	proposal: JobCreateInputParsed;
+	warnings: string[];
+};
+
+export type ParseFailure = {
+	ok: false;
+	status: 422 | 503 | 504;
+	error: string;
+};
+
+export type ParseResult = ParseSuccess | ParseFailure;
+
+export type ParseDeps = {
+	apiKey?: string | null;
+	clientFactory?: (apiKey: string) => AnthropicClient;
+	timeoutMs?: number;
+	model?: string;
+};
+
+const DEFAULT_MODEL = "claude-sonnet-4-6";
+const DEFAULT_TIMEOUT_MS = 15_000;
+
+// JSON Schema matching JobCreateInputSchema in tool-schema.ts. Hand-written
+// because the repo does not pull zod-to-json-schema; keeping it local avoids
+// adding a dependency for a ~40-line conversion. The Zod parse on the server
+// is the source of truth; this schema is advisory for Sonnet.
+const PROPOSE_JOB_INPUT_SCHEMA: {
+	type: "object";
+	properties: Record<string, unknown>;
+	required: string[];
+	additionalProperties: boolean;
+} = {
+	type: "object",
+	properties: {
+		name: {
+			type: "string",
+			minLength: 1,
+			maxLength: 200,
+			description: "Short, kebab-case-ish job name, 1..200 chars (e.g. hn-digest, pr-review-reminder).",
+		},
+		description: {
+			type: "string",
+			maxLength: 1000,
+			description: "One-sentence human summary of what this job does.",
+		},
+		schedule: {
+			oneOf: [
+				{
+					type: "object",
+					properties: {
+						kind: { const: "at" },
+						at: {
+							type: "string",
+							description: "ISO 8601 with explicit offset (e.g. 2026-04-18T15:00:00-07:00).",
+						},
+					},
+					required: ["kind", "at"],
+					additionalProperties: false,
+				},
+				{
+					type: "object",
+					properties: {
+						kind: { const: "every" },
+						intervalMs: {
+							type: "integer",
+							minimum: 1,
+							description: "Interval in milliseconds. 6 hours = 21600000.",
+						},
+					},
+					required: ["kind", "intervalMs"],
+					additionalProperties: false,
+				},
+				{
+					type: "object",
+					properties: {
+						kind: { const: "cron" },
+						expr: {
+							type: "string",
+							description: "5-field cron: minute hour day-of-month month day-of-week. No nicknames.",
+						},
+						tz: { type: "string", description: "IANA timezone name." },
+					},
+					required: ["kind", "expr"],
+					additionalProperties: false,
+				},
+			],
+		},
+		task: {
+			type: "string",
+			minLength: 1,
+			maxLength: 32 * 1024,
+			description:
+				"Self-contained instruction for the agent to execute when the job fires. Include every piece of context the run will need.",
+		},
+		delivery: {
+			type: "object",
+			properties: {
+				channel: { enum: ["slack", "none"] },
+				target: {
+					type: "string",
+					description: '"owner" for owner DM, or a Slack channel id (C...) or user id (U...).',
+				},
+			},
+			additionalProperties: false,
+		},
+		deleteAfterRun: { type: "boolean" },
+	},
+	required: ["name", "schedule", "task"],
+	additionalProperties: false,
+};
+
+const SYSTEM_PROMPT = [
+	"You are helping an operator author a scheduled job for an autonomous AI agent.",
+	"Convert the operator's plain-English description into a structured job proposal.",
+	"",
+	"Fields:",
+	"- name: kebab-case short label (hn-digest, pr-review-reminder, daily-standup).",
+	'- description: one sentence summary.',
+	"- task: self-contained instruction the agent will execute when the job fires.",
+	"  The agent will not have the current conversation context. Include every URL,",
+	"  repo name, channel, or constraint the run needs. Write imperative, concrete.",
+	"- schedule: one of",
+	'  { "kind": "at", "at": "<ISO 8601 with offset>" } for one-shot runs,',
+	'  { "kind": "every", "intervalMs": <ms> } for simple intervals,',
+	'  { "kind": "cron", "expr": "<5-field cron>", "tz": "<IANA tz>" } for calendar patterns.',
+	"- delivery: default { channel: 'slack', target: 'owner' } unless the operator specified a Slack channel id (C...) or user id (U...).",
+	"",
+	"Heuristics:",
+	"- 'every 6 hours' -> every, intervalMs 21600000.",
+	"- 'every 30 minutes' -> every, intervalMs 1800000.",
+	"- '9am weekdays' / 'weekday mornings' -> cron, '0 9 * * 1-5', tz America/Los_Angeles.",
+	"- '9am daily' -> cron, '0 9 * * *', tz America/Los_Angeles.",
+	"- 'Friday 5pm' -> cron, '0 17 * * 5', tz America/Los_Angeles.",
+	"- 'tomorrow at 3pm' or a specific date -> at with ISO 8601 and an explicit offset.",
+	"- Default timezone America/Los_Angeles when the operator did not specify one.",
+	"",
+	"Always call the `propose_job` tool exactly once with a valid argument object.",
+	"If the description is incoherent or you cannot infer a schedule, still call the",
+	"tool with your best-effort values and set `task` to an empty string so the",
+	"operator fills it in manually.",
+].join("\n");
+
+function defaultClientFactory(apiKey: string): AnthropicClient {
+	return new Anthropic({ apiKey });
+}
+
+function extractErrorMessage(err: unknown): string {
+	if (err instanceof Error) return err.message;
+	return String(err);
+}
+
+/**
+ * Call Sonnet with a forced tool-use schema and return a structured proposal
+ * the operator can review before saving. Does not mutate any state; the
+ * actual job creation happens only when the operator hits Save in the UI.
+ *
+ * The caller is responsible for length-validating `description` before
+ * invoking this function. On any failure we return a typed error so the
+ * UI can surface it inline without exposing the raw SDK error to the client.
+ */
+export async function parseJobDescription(description: string, deps: ParseDeps = {}): Promise<ParseResult> {
+	// Explicit null in deps means "no key available" (test seam). Undefined
+	// means "fall back to the env var".
+	const apiKey = "apiKey" in deps ? deps.apiKey : process.env.ANTHROPIC_API_KEY;
+	if (!apiKey) {
+		return {
+			ok: false,
+			status: 503,
+			error: "Sonnet assist requires ANTHROPIC_API_KEY.",
+		};
+	}
+
+	const clientFactory = deps.clientFactory ?? defaultClientFactory;
+	const client = clientFactory(apiKey);
+	const timeoutMs = deps.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+	const model = deps.model ?? DEFAULT_MODEL;
+
+	const controller = new AbortController();
+	const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+	try {
+		const response = await client.messages.create(
+			{
+				model,
+				max_tokens: 1024,
+				system: SYSTEM_PROMPT,
+				tools: [
+					{
+						name: "propose_job",
+						description:
+							"Propose a structured scheduled-job payload that the operator will review and edit before saving.",
+						input_schema: PROPOSE_JOB_INPUT_SCHEMA as unknown as {
+							type: "object";
+							properties?: unknown;
+							required?: string[];
+						},
+					},
+				],
+				tool_choice: { type: "tool", name: "propose_job" },
+				messages: [{ role: "user", content: description }],
+			},
+			{ signal: controller.signal },
+		);
+
+		const toolBlock = response.content.find((b): b is { type: "tool_use"; input: unknown; name: string; id: string } => {
+			return (b as { type?: string }).type === "tool_use" && (b as { name?: string }).name === "propose_job";
+		});
+
+		if (!toolBlock) {
+			return {
+				ok: false,
+				status: 422,
+				error: "Could not parse description, please fill the form manually.",
+			};
+		}
+
+		const parsed = JobCreateInputSchema.safeParse(toolBlock.input);
+		if (!parsed.success) {
+			return {
+				ok: false,
+				status: 422,
+				error: "Could not parse description, please fill the form manually.",
+			};
+		}
+
+		return {
+			ok: true,
+			proposal: parsed.data,
+			warnings: [],
+		};
+	} catch (err: unknown) {
+		const msg = extractErrorMessage(err);
+		if (controller.signal.aborted || /abort|timeout/i.test(msg)) {
+			return {
+				ok: false,
+				status: 504,
+				error: "Sonnet assist timed out, please fill the form manually.",
+			};
+		}
+		return {
+			ok: false,
+			status: 422,
+			error: "Could not parse description, please fill the form manually.",
+		};
+	} finally {
+		clearTimeout(timer);
+	}
+}

--- a/src/scheduler/parse-with-sonnet.ts
+++ b/src/scheduler/parse-with-sonnet.ts
@@ -6,170 +6,102 @@
 // fires, the agent gets the operator's final `task` prompt and decides what
 // to do with it. Sonnet here is form plumbing, not a routing layer.
 //
-// A tiny one-shot Messages API call with forced tool-use. We do not use the
-// Agent SDK: a raw Messages call avoids subprocess overhead and the full
-// tool surface we do not need.
+// Uses the Agent SDK subprocess via runtime.judgeQuery so the operator's
+// existing auth (Claude subscription or ANTHROPIC_API_KEY) carries through
+// the same path as every other LLM call in Phantom. Any failure - auth
+// missing, network, timeout, malformed output - collapses to a 422 so the
+// operator can fall back to manual entry without ceremony.
 
-import Anthropic from "@anthropic-ai/sdk";
+import { z as zv4 } from "zod/v4";
+import type { AgentRuntime } from "../agent/runtime.ts";
 import { type JobCreateInputParsed, JobCreateInputSchema } from "./tool-schema.ts";
 
-type AnthropicClient = InstanceType<typeof Anthropic>;
-
 export type ParseSuccess = { ok: true; proposal: JobCreateInputParsed; warnings: string[] };
-export type ParseFailure = { ok: false; status: 422 | 503 | 504; error: string };
+export type ParseFailure = { ok: false; status: 422; error: string };
 export type ParseResult = ParseSuccess | ParseFailure;
 
 export type ParseDeps = {
-	apiKey?: string | null;
-	clientFactory?: (apiKey: string) => AnthropicClient;
-	timeoutMs?: number;
+	runtime?: AgentRuntime | null;
 	model?: string;
 };
 
 const DEFAULT_MODEL = "claude-sonnet-4-6";
-const DEFAULT_TIMEOUT_MS = 15_000;
 const GENERIC_ERROR = "Could not parse description, please fill the form manually.";
 
-// JSON Schema for the forced tool-use. The Zod parse on the server is the
-// source of truth; this schema guides Sonnet's output. Hand-written so we do
-// not pull zod-to-json-schema for a ~40-line conversion.
-const PROPOSE_JOB_INPUT_SCHEMA = {
-	type: "object",
-	properties: {
-		name: { type: "string", minLength: 1, maxLength: 200, description: "Short kebab-case job name (e.g. hn-digest)." },
-		description: { type: "string", maxLength: 1000, description: "One-sentence human summary." },
-		schedule: {
-			oneOf: [
-				{
-					type: "object",
-					properties: {
-						kind: { const: "at" },
-						at: { type: "string", description: "ISO 8601 with explicit offset (2026-04-18T15:00:00-07:00)." },
-					},
-					required: ["kind", "at"],
-					additionalProperties: false,
-				},
-				{
-					type: "object",
-					properties: {
-						kind: { const: "every" },
-						intervalMs: { type: "integer", minimum: 1, description: "Interval in ms. 6h = 21600000." },
-					},
-					required: ["kind", "intervalMs"],
-					additionalProperties: false,
-				},
-				{
-					type: "object",
-					properties: {
-						kind: { const: "cron" },
-						expr: { type: "string", description: "5-field cron, no nicknames." },
-						tz: { type: "string", description: "IANA timezone name." },
-					},
-					required: ["kind", "expr"],
-					additionalProperties: false,
-				},
-			],
-		},
-		task: {
-			type: "string",
-			minLength: 1,
-			maxLength: 32 * 1024,
-			description: "Self-contained instruction the agent runs when the job fires.",
-		},
-		delivery: {
-			type: "object",
-			properties: {
-				channel: { enum: ["slack", "none"] },
-				target: { type: "string", description: '"owner", C... channel id, or U... user id.' },
-			},
-			additionalProperties: false,
-		},
-		deleteAfterRun: { type: "boolean" },
-	},
-	required: ["name", "schedule", "task"],
-	additionalProperties: false,
-} as const;
+// Permissive v4 schema shape we hand to judgeQuery so its `z.toJSONSchema`
+// call succeeds. We re-validate the returned object through the v3
+// JobCreateInputSchema below, which is the single source of truth for the
+// MCP tool, the create endpoint, and this helper. The v4 schema exists only
+// because the Agent SDK judge path is typed against zod/v4.
+const JudgeProposalSchema = zv4
+	.object({
+		name: zv4.string().min(1).max(200),
+		description: zv4.string().max(1000).optional(),
+		task: zv4.string().max(32 * 1024),
+		schedule: zv4.union([
+			zv4.object({ kind: zv4.literal("at"), at: zv4.string() }),
+			zv4.object({ kind: zv4.literal("every"), intervalMs: zv4.number().int().positive() }),
+			zv4.object({
+				kind: zv4.literal("cron"),
+				expr: zv4.string(),
+				tz: zv4.string().optional(),
+			}),
+		]),
+		delivery: zv4
+			.object({
+				channel: zv4.enum(["slack", "none"]).optional(),
+				target: zv4.string().optional(),
+			})
+			.optional(),
+		deleteAfterRun: zv4.boolean().optional(),
+	})
+	.passthrough();
+
+type JudgeProposal = zv4.infer<typeof JudgeProposalSchema>;
 
 const SYSTEM_PROMPT = [
 	"You help an operator author a scheduled job for an autonomous AI agent.",
 	"Convert their English description into structured fields.",
 	"- name: kebab-case label.",
 	"- task: imperative, self-contained instruction. The scheduled run does not see current context; include every URL, repo, channel.",
-	'- schedule: { kind:"at", at:<ISO8601+offset> } | { kind:"every", intervalMs:<n> } | { kind:"cron", expr:<5-field>, tz:<IANA> }.',
-	"- delivery defaults to { channel:'slack', target:'owner' }.",
-	"Heuristics: 'every 6h'->every/21600000; '9am weekdays'->cron '0 9 * * 1-5' tz America/Los_Angeles; 'Friday 5pm'->cron '0 17 * * 5'; specific date->at with offset. Default tz America/Los_Angeles if unspecified.",
-	"Call `propose_job` once. If the description is incoherent, emit best-effort values and set task to empty string so the operator fills it.",
+	'- schedule: one of { "kind":"at", "at":"<ISO 8601 with offset>" }, { "kind":"every", "intervalMs":<ms> }, { "kind":"cron", "expr":"<5-field>", "tz":"<IANA>" }.',
+	'- delivery defaults to { "channel":"slack", "target":"owner" }.',
+	"Heuristics:",
+	"- 'every 6 hours' -> every, intervalMs 21600000.",
+	"- '9am weekdays' -> cron '0 9 * * 1-5' tz America/Los_Angeles.",
+	"- '9am daily' -> cron '0 9 * * *' tz America/Los_Angeles.",
+	"- 'Friday 5pm' -> cron '0 17 * * 5' tz America/Los_Angeles.",
+	"- Specific date/time -> at with ISO 8601 and explicit offset.",
+	"Default timezone America/Los_Angeles if unspecified.",
+	"If the description is incoherent, emit best-effort values and set task to the empty string so the operator fills it in.",
 ].join("\n");
 
-function defaultClientFactory(apiKey: string): AnthropicClient {
-	return new Anthropic({ apiKey });
-}
-
-function errorMessage(err: unknown): string {
-	return err instanceof Error ? err.message : String(err);
-}
-
 /**
- * Call Sonnet with a forced tool-use schema and return a structured proposal
- * the operator can review before saving. Does not mutate any state; the job
- * is created only when the operator hits Save.
+ * Call Sonnet via the Agent SDK subprocess and return a structured proposal
+ * the operator can review before saving. Does not mutate state; the job is
+ * created only when the operator hits Save in the UI.
  */
 export async function parseJobDescription(description: string, deps: ParseDeps = {}): Promise<ParseResult> {
-	// Explicit null in deps means "no key available" (test seam). Undefined
-	// means "fall back to the env var".
-	const apiKey = "apiKey" in deps ? deps.apiKey : process.env.ANTHROPIC_API_KEY;
-	if (!apiKey) {
-		return { ok: false, status: 503, error: "Sonnet assist requires ANTHROPIC_API_KEY." };
+	if (!deps.runtime) {
+		return { ok: false, status: 422, error: GENERIC_ERROR };
 	}
 
-	const clientFactory = deps.clientFactory ?? defaultClientFactory;
-	const client = clientFactory(apiKey);
-	const timeoutMs = deps.timeoutMs ?? DEFAULT_TIMEOUT_MS;
-	const model = deps.model ?? DEFAULT_MODEL;
-
-	const controller = new AbortController();
-	const timer = setTimeout(() => controller.abort(), timeoutMs);
-
 	try {
-		const response = await client.messages.create(
-			{
-				model,
-				max_tokens: 1024,
-				system: SYSTEM_PROMPT,
-				tools: [
-					{
-						name: "propose_job",
-						description: "Structured scheduled-job payload the operator reviews and edits before saving.",
-						input_schema: PROPOSE_JOB_INPUT_SCHEMA as unknown as {
-							type: "object";
-							properties?: unknown;
-							required?: string[];
-						},
-					},
-				],
-				tool_choice: { type: "tool", name: "propose_job" },
-				messages: [{ role: "user", content: description }],
-			},
-			{ signal: controller.signal },
-		);
-
-		const blocks = response.content as Array<{ type: string; name?: string; input?: unknown }>;
-		const toolBlock = blocks.find((b) => b.type === "tool_use" && b.name === "propose_job");
-		if (!toolBlock || toolBlock.input === undefined) {
-			return { ok: false, status: 422, error: GENERIC_ERROR };
-		}
-
-		const parsed = JobCreateInputSchema.safeParse(toolBlock.input);
+		const result = await deps.runtime.judgeQuery<JudgeProposal>({
+			systemPrompt: SYSTEM_PROMPT,
+			userMessage: description,
+			schema: JudgeProposalSchema,
+			model: deps.model ?? DEFAULT_MODEL,
+			maxTokens: 1024,
+			omitPreset: true,
+		});
+		// Re-validate through the canonical v3 schema. Shared with the MCP
+		// tool and the create endpoint so a proposal that would fail at
+		// createJob is rejected here too.
+		const parsed = JobCreateInputSchema.safeParse(result.data);
 		if (!parsed.success) return { ok: false, status: 422, error: GENERIC_ERROR };
-
 		return { ok: true, proposal: parsed.data, warnings: [] };
-	} catch (err: unknown) {
-		const msg = errorMessage(err);
-		if (controller.signal.aborted || /abort|timeout/i.test(msg)) {
-			return { ok: false, status: 504, error: "Sonnet assist timed out, please fill the form manually." };
-		}
+	} catch {
 		return { ok: false, status: 422, error: GENERIC_ERROR };
-	} finally {
-		clearTimeout(timer);
 	}
 }

--- a/src/scheduler/parse-with-sonnet.ts
+++ b/src/scheduler/parse-with-sonnet.ts
@@ -6,28 +6,17 @@
 // fires, the agent gets the operator's final `task` prompt and decides what
 // to do with it. Sonnet here is form plumbing, not a routing layer.
 //
-// A tiny one-shot Messages API call with forced tool-use is the simplest
-// shape that produces validated structured output. We do not use the Agent
-// SDK for this: a raw Messages call avoids the subprocess overhead and the
-// full tool surface we do not need.
+// A tiny one-shot Messages API call with forced tool-use. We do not use the
+// Agent SDK: a raw Messages call avoids subprocess overhead and the full
+// tool surface we do not need.
 
 import Anthropic from "@anthropic-ai/sdk";
-import { JobCreateInputSchema, type JobCreateInputParsed } from "./tool-schema.ts";
+import { type JobCreateInputParsed, JobCreateInputSchema } from "./tool-schema.ts";
 
 type AnthropicClient = InstanceType<typeof Anthropic>;
 
-export type ParseSuccess = {
-	ok: true;
-	proposal: JobCreateInputParsed;
-	warnings: string[];
-};
-
-export type ParseFailure = {
-	ok: false;
-	status: 422 | 503 | 504;
-	error: string;
-};
-
+export type ParseSuccess = { ok: true; proposal: JobCreateInputParsed; warnings: string[] };
+export type ParseFailure = { ok: false; status: 422 | 503 | 504; error: string };
 export type ParseResult = ParseSuccess | ParseFailure;
 
 export type ParseDeps = {
@@ -39,40 +28,23 @@ export type ParseDeps = {
 
 const DEFAULT_MODEL = "claude-sonnet-4-6";
 const DEFAULT_TIMEOUT_MS = 15_000;
+const GENERIC_ERROR = "Could not parse description, please fill the form manually.";
 
-// JSON Schema matching JobCreateInputSchema in tool-schema.ts. Hand-written
-// because the repo does not pull zod-to-json-schema; keeping it local avoids
-// adding a dependency for a ~40-line conversion. The Zod parse on the server
-// is the source of truth; this schema is advisory for Sonnet.
-const PROPOSE_JOB_INPUT_SCHEMA: {
-	type: "object";
-	properties: Record<string, unknown>;
-	required: string[];
-	additionalProperties: boolean;
-} = {
+// JSON Schema for the forced tool-use. The Zod parse on the server is the
+// source of truth; this schema guides Sonnet's output. Hand-written so we do
+// not pull zod-to-json-schema for a ~40-line conversion.
+const PROPOSE_JOB_INPUT_SCHEMA = {
 	type: "object",
 	properties: {
-		name: {
-			type: "string",
-			minLength: 1,
-			maxLength: 200,
-			description: "Short, kebab-case-ish job name, 1..200 chars (e.g. hn-digest, pr-review-reminder).",
-		},
-		description: {
-			type: "string",
-			maxLength: 1000,
-			description: "One-sentence human summary of what this job does.",
-		},
+		name: { type: "string", minLength: 1, maxLength: 200, description: "Short kebab-case job name (e.g. hn-digest)." },
+		description: { type: "string", maxLength: 1000, description: "One-sentence human summary." },
 		schedule: {
 			oneOf: [
 				{
 					type: "object",
 					properties: {
 						kind: { const: "at" },
-						at: {
-							type: "string",
-							description: "ISO 8601 with explicit offset (e.g. 2026-04-18T15:00:00-07:00).",
-						},
+						at: { type: "string", description: "ISO 8601 with explicit offset (2026-04-18T15:00:00-07:00)." },
 					},
 					required: ["kind", "at"],
 					additionalProperties: false,
@@ -81,11 +53,7 @@ const PROPOSE_JOB_INPUT_SCHEMA: {
 					type: "object",
 					properties: {
 						kind: { const: "every" },
-						intervalMs: {
-							type: "integer",
-							minimum: 1,
-							description: "Interval in milliseconds. 6 hours = 21600000.",
-						},
+						intervalMs: { type: "integer", minimum: 1, description: "Interval in ms. 6h = 21600000." },
 					},
 					required: ["kind", "intervalMs"],
 					additionalProperties: false,
@@ -94,10 +62,7 @@ const PROPOSE_JOB_INPUT_SCHEMA: {
 					type: "object",
 					properties: {
 						kind: { const: "cron" },
-						expr: {
-							type: "string",
-							description: "5-field cron: minute hour day-of-month month day-of-week. No nicknames.",
-						},
+						expr: { type: "string", description: "5-field cron, no nicknames." },
 						tz: { type: "string", description: "IANA timezone name." },
 					},
 					required: ["kind", "expr"],
@@ -109,17 +74,13 @@ const PROPOSE_JOB_INPUT_SCHEMA: {
 			type: "string",
 			minLength: 1,
 			maxLength: 32 * 1024,
-			description:
-				"Self-contained instruction for the agent to execute when the job fires. Include every piece of context the run will need.",
+			description: "Self-contained instruction the agent runs when the job fires.",
 		},
 		delivery: {
 			type: "object",
 			properties: {
 				channel: { enum: ["slack", "none"] },
-				target: {
-					type: "string",
-					description: '"owner" for owner DM, or a Slack channel id (C...) or user id (U...).',
-				},
+				target: { type: "string", description: '"owner", C... channel id, or U... user id.' },
 			},
 			additionalProperties: false,
 		},
@@ -127,67 +88,38 @@ const PROPOSE_JOB_INPUT_SCHEMA: {
 	},
 	required: ["name", "schedule", "task"],
 	additionalProperties: false,
-};
+} as const;
 
 const SYSTEM_PROMPT = [
-	"You are helping an operator author a scheduled job for an autonomous AI agent.",
-	"Convert the operator's plain-English description into a structured job proposal.",
-	"",
-	"Fields:",
-	"- name: kebab-case short label (hn-digest, pr-review-reminder, daily-standup).",
-	'- description: one sentence summary.',
-	"- task: self-contained instruction the agent will execute when the job fires.",
-	"  The agent will not have the current conversation context. Include every URL,",
-	"  repo name, channel, or constraint the run needs. Write imperative, concrete.",
-	"- schedule: one of",
-	'  { "kind": "at", "at": "<ISO 8601 with offset>" } for one-shot runs,',
-	'  { "kind": "every", "intervalMs": <ms> } for simple intervals,',
-	'  { "kind": "cron", "expr": "<5-field cron>", "tz": "<IANA tz>" } for calendar patterns.',
-	"- delivery: default { channel: 'slack', target: 'owner' } unless the operator specified a Slack channel id (C...) or user id (U...).",
-	"",
-	"Heuristics:",
-	"- 'every 6 hours' -> every, intervalMs 21600000.",
-	"- 'every 30 minutes' -> every, intervalMs 1800000.",
-	"- '9am weekdays' / 'weekday mornings' -> cron, '0 9 * * 1-5', tz America/Los_Angeles.",
-	"- '9am daily' -> cron, '0 9 * * *', tz America/Los_Angeles.",
-	"- 'Friday 5pm' -> cron, '0 17 * * 5', tz America/Los_Angeles.",
-	"- 'tomorrow at 3pm' or a specific date -> at with ISO 8601 and an explicit offset.",
-	"- Default timezone America/Los_Angeles when the operator did not specify one.",
-	"",
-	"Always call the `propose_job` tool exactly once with a valid argument object.",
-	"If the description is incoherent or you cannot infer a schedule, still call the",
-	"tool with your best-effort values and set `task` to an empty string so the",
-	"operator fills it in manually.",
+	"You help an operator author a scheduled job for an autonomous AI agent.",
+	"Convert their English description into structured fields.",
+	"- name: kebab-case label.",
+	"- task: imperative, self-contained instruction. The scheduled run does not see current context; include every URL, repo, channel.",
+	'- schedule: { kind:"at", at:<ISO8601+offset> } | { kind:"every", intervalMs:<n> } | { kind:"cron", expr:<5-field>, tz:<IANA> }.',
+	"- delivery defaults to { channel:'slack', target:'owner' }.",
+	"Heuristics: 'every 6h'->every/21600000; '9am weekdays'->cron '0 9 * * 1-5' tz America/Los_Angeles; 'Friday 5pm'->cron '0 17 * * 5'; specific date->at with offset. Default tz America/Los_Angeles if unspecified.",
+	"Call `propose_job` once. If the description is incoherent, emit best-effort values and set task to empty string so the operator fills it.",
 ].join("\n");
 
 function defaultClientFactory(apiKey: string): AnthropicClient {
 	return new Anthropic({ apiKey });
 }
 
-function extractErrorMessage(err: unknown): string {
-	if (err instanceof Error) return err.message;
-	return String(err);
+function errorMessage(err: unknown): string {
+	return err instanceof Error ? err.message : String(err);
 }
 
 /**
  * Call Sonnet with a forced tool-use schema and return a structured proposal
- * the operator can review before saving. Does not mutate any state; the
- * actual job creation happens only when the operator hits Save in the UI.
- *
- * The caller is responsible for length-validating `description` before
- * invoking this function. On any failure we return a typed error so the
- * UI can surface it inline without exposing the raw SDK error to the client.
+ * the operator can review before saving. Does not mutate any state; the job
+ * is created only when the operator hits Save.
  */
 export async function parseJobDescription(description: string, deps: ParseDeps = {}): Promise<ParseResult> {
 	// Explicit null in deps means "no key available" (test seam). Undefined
 	// means "fall back to the env var".
 	const apiKey = "apiKey" in deps ? deps.apiKey : process.env.ANTHROPIC_API_KEY;
 	if (!apiKey) {
-		return {
-			ok: false,
-			status: 503,
-			error: "Sonnet assist requires ANTHROPIC_API_KEY.",
-		};
+		return { ok: false, status: 503, error: "Sonnet assist requires ANTHROPIC_API_KEY." };
 	}
 
 	const clientFactory = deps.clientFactory ?? defaultClientFactory;
@@ -207,8 +139,7 @@ export async function parseJobDescription(description: string, deps: ParseDeps =
 				tools: [
 					{
 						name: "propose_job",
-						description:
-							"Propose a structured scheduled-job payload that the operator will review and edit before saving.",
+						description: "Structured scheduled-job payload the operator reviews and edits before saving.",
 						input_schema: PROPOSE_JOB_INPUT_SCHEMA as unknown as {
 							type: "object";
 							properties?: unknown;
@@ -222,46 +153,22 @@ export async function parseJobDescription(description: string, deps: ParseDeps =
 			{ signal: controller.signal },
 		);
 
-		const toolBlock = response.content.find((b): b is { type: "tool_use"; input: unknown; name: string; id: string } => {
-			return (b as { type?: string }).type === "tool_use" && (b as { name?: string }).name === "propose_job";
-		});
-
-		if (!toolBlock) {
-			return {
-				ok: false,
-				status: 422,
-				error: "Could not parse description, please fill the form manually.",
-			};
+		const blocks = response.content as Array<{ type: string; name?: string; input?: unknown }>;
+		const toolBlock = blocks.find((b) => b.type === "tool_use" && b.name === "propose_job");
+		if (!toolBlock || toolBlock.input === undefined) {
+			return { ok: false, status: 422, error: GENERIC_ERROR };
 		}
 
 		const parsed = JobCreateInputSchema.safeParse(toolBlock.input);
-		if (!parsed.success) {
-			return {
-				ok: false,
-				status: 422,
-				error: "Could not parse description, please fill the form manually.",
-			};
-		}
+		if (!parsed.success) return { ok: false, status: 422, error: GENERIC_ERROR };
 
-		return {
-			ok: true,
-			proposal: parsed.data,
-			warnings: [],
-		};
+		return { ok: true, proposal: parsed.data, warnings: [] };
 	} catch (err: unknown) {
-		const msg = extractErrorMessage(err);
+		const msg = errorMessage(err);
 		if (controller.signal.aborted || /abort|timeout/i.test(msg)) {
-			return {
-				ok: false,
-				status: 504,
-				error: "Sonnet assist timed out, please fill the form manually.",
-			};
+			return { ok: false, status: 504, error: "Sonnet assist timed out, please fill the form manually." };
 		}
-		return {
-			ok: false,
-			status: 422,
-			error: "Could not parse description, please fill the form manually.",
-		};
+		return { ok: false, status: 422, error: GENERIC_ERROR };
 	} finally {
 		clearTimeout(timer);
 	}

--- a/src/scheduler/service.ts
+++ b/src/scheduler/service.ts
@@ -99,12 +99,13 @@ export class Scheduler {
 		}
 
 		this.db.run(
-			`INSERT INTO scheduled_jobs (id, name, description, schedule_kind, schedule_value, task, delivery_channel, delivery_target, next_run_at, delete_after_run, created_by)
-			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			`INSERT INTO scheduled_jobs (id, name, description, enabled, schedule_kind, schedule_value, task, delivery_channel, delivery_target, next_run_at, delete_after_run, created_by)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 			[
 				id,
 				input.name,
 				input.description ?? null,
+				input.enabled === false ? 0 : 1,
 				input.schedule.kind,
 				scheduleValue,
 				input.task,
@@ -159,6 +160,11 @@ export class Scheduler {
 	resumeJob(id: string): ScheduledJob | null {
 		const job = this.getJob(id);
 		if (!job) return null;
+		// Only paused jobs may be resumed. Failed and completed are terminal
+		// states; force-reviving them would bypass the lifecycle (e.g.,
+		// re-running a one-shot that already deleted itself, or restarting a
+		// circuit-broken job without addressing the failure).
+		if (job.status !== "paused") return job;
 		const nextRun = computeNextRunAt(job.schedule);
 		const nextRunIso = nextRun ? nextRun.toISOString() : null;
 		this.db.run(
@@ -167,7 +173,7 @@ export class Scheduler {
 					next_run_at = ?,
 					consecutive_errors = 0,
 					updated_at = datetime('now')
-				WHERE id = ?`,
+				WHERE id = ? AND status = 'paused'`,
 			[nextRunIso, id],
 		);
 		this.armTimer();

--- a/src/scheduler/service.ts
+++ b/src/scheduler/service.ts
@@ -133,6 +133,48 @@ export class Scheduler {
 	}
 
 	/**
+	 * Flip an active job to paused. armTimer already filters by
+	 * `status = 'active'` so the paused row stops firing automatically.
+	 * Returns the updated job, or null if the id does not exist.
+	 */
+	pauseJob(id: string): ScheduledJob | null {
+		const result = this.db.run(
+			"UPDATE scheduled_jobs SET status = 'paused', updated_at = datetime('now') WHERE id = ? AND status = 'active'",
+			[id],
+		);
+		if (result.changes === 0) {
+			return this.getJob(id);
+		}
+		this.armTimer();
+		return this.getJob(id);
+	}
+
+	/**
+	 * Flip a paused job back to active. Recomputes next_run_at from the stored
+	 * schedule so a job paused mid-interval resumes on a fresh cadence.
+	 * Resets consecutive_errors so a job paused in its backoff fan-out gets a
+	 * clean retry budget. Returns the updated job, or null if the id does not
+	 * exist.
+	 */
+	resumeJob(id: string): ScheduledJob | null {
+		const job = this.getJob(id);
+		if (!job) return null;
+		const nextRun = computeNextRunAt(job.schedule);
+		const nextRunIso = nextRun ? nextRun.toISOString() : null;
+		this.db.run(
+			`UPDATE scheduled_jobs
+				SET status = 'active',
+					next_run_at = ?,
+					consecutive_errors = 0,
+					updated_at = datetime('now')
+				WHERE id = ?`,
+			[nextRunIso, id],
+		);
+		this.armTimer();
+		return this.getJob(id);
+	}
+
+	/**
 	 * Defensive read: one corrupt row (a future kind, a truncated write) must
 	 * not brick the whole list. Bad rows are logged and skipped. See M8.
 	 */

--- a/src/scheduler/tool-schema.ts
+++ b/src/scheduler/tool-schema.ts
@@ -1,0 +1,27 @@
+// Single source of truth for the shape of a "create a scheduled job" input.
+// Both the phantom_schedule MCP tool (src/scheduler/tool.ts) and the UI
+// create endpoint (src/ui/api/scheduler.ts) parse through the same Zod
+// schema so field-for-field parity is automatic. The Sonnet describe-assist
+// endpoint validates Sonnet's structured output against the same schema
+// before surfacing the proposal to the operator.
+
+import { z } from "zod";
+import { AtScheduleSchema, CronScheduleSchema, EveryScheduleSchema, JobDeliverySchema } from "./types.ts";
+
+export const ScheduleInputSchema = z.discriminatedUnion("kind", [
+	AtScheduleSchema,
+	EveryScheduleSchema,
+	CronScheduleSchema,
+]);
+
+export const JobCreateInputSchema = z.object({
+	name: z.string().min(1).max(200),
+	description: z.string().max(1000).optional(),
+	schedule: ScheduleInputSchema,
+	task: z.string().min(1).max(32 * 1024),
+	delivery: JobDeliverySchema.optional(),
+	deleteAfterRun: z.boolean().optional(),
+	createdBy: z.enum(["agent", "user"]).optional(),
+});
+
+export type JobCreateInputParsed = z.infer<typeof JobCreateInputSchema>;

--- a/src/scheduler/tool-schema.ts
+++ b/src/scheduler/tool-schema.ts
@@ -24,6 +24,7 @@ export const JobCreateInputSchema = z.object({
 		.max(32 * 1024),
 	delivery: JobDeliverySchema.optional(),
 	deleteAfterRun: z.boolean().optional(),
+	enabled: z.boolean().optional(),
 	createdBy: z.enum(["agent", "user"]).optional(),
 });
 

--- a/src/scheduler/tool-schema.ts
+++ b/src/scheduler/tool-schema.ts
@@ -18,7 +18,10 @@ export const JobCreateInputSchema = z.object({
 	name: z.string().min(1).max(200),
 	description: z.string().max(1000).optional(),
 	schedule: ScheduleInputSchema,
-	task: z.string().min(1).max(32 * 1024),
+	task: z
+		.string()
+		.min(1)
+		.max(32 * 1024),
 	delivery: JobDeliverySchema.optional(),
 	deleteAfterRun: z.boolean().optional(),
 	createdBy: z.enum(["agent", "user"]).optional(),

--- a/src/scheduler/tool.ts
+++ b/src/scheduler/tool.ts
@@ -2,9 +2,8 @@ import { createSdkMcpServer, tool } from "@anthropic-ai/claude-agent-sdk";
 import type { McpSdkServerConfigWithInstance } from "@anthropic-ai/claude-agent-sdk";
 import { z } from "zod";
 import type { Scheduler } from "./service.ts";
-import { AtScheduleSchema, CronScheduleSchema, EveryScheduleSchema, JobDeliverySchema } from "./types.ts";
-
-const ScheduleInputSchema = z.discriminatedUnion("kind", [AtScheduleSchema, EveryScheduleSchema, CronScheduleSchema]);
+import { ScheduleInputSchema } from "./tool-schema.ts";
+import { JobDeliverySchema } from "./types.ts";
 
 function ok(data: Record<string, unknown>): { content: Array<{ type: "text"; text: string }> } {
 	return { content: [{ type: "text" as const, text: JSON.stringify(data, null, 2) }] };

--- a/src/scheduler/types.ts
+++ b/src/scheduler/types.ts
@@ -68,6 +68,7 @@ export type JobCreateInput = {
 	task: string;
 	delivery?: JobDelivery;
 	deleteAfterRun?: boolean;
+	enabled?: boolean;
 	createdBy?: string;
 };
 

--- a/src/ui/api/__tests__/scheduler.test.ts
+++ b/src/ui/api/__tests__/scheduler.test.ts
@@ -1,0 +1,453 @@
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { resolve } from "node:path";
+import { MIGRATIONS } from "../../../db/schema.ts";
+import { Scheduler } from "../../../scheduler/service.ts";
+import {
+	clearSchedulerInstanceForTests,
+	handleUiRequest,
+	setDashboardDb,
+	setPublicDir,
+	setSchedulerInstance,
+	setSchedulerParserOverrideForTests,
+} from "../../serve.ts";
+import { createSession, revokeAllSessions } from "../../session.ts";
+
+setPublicDir(resolve(import.meta.dir, "../../../../public"));
+
+let db: Database;
+let sessionToken: string;
+let scheduler: Scheduler;
+
+function runMigrations(target: Database): void {
+	for (const migration of MIGRATIONS) {
+		try {
+			target.run(migration);
+		} catch {
+			// ignore ALTER TABLE duplicate failures on repeated migrations
+		}
+	}
+}
+
+function createMockRuntime() {
+	return {
+		handleMessage: mock(async () => ({
+			text: "Mock response from agent",
+			sessionId: "mock-session",
+			cost: { totalUsd: 0.01, inputTokens: 100, outputTokens: 50, modelUsage: {} },
+			durationMs: 500,
+		})),
+		isSessionBusy: mock(() => false),
+		setMemoryContextBuilder: mock(() => {}),
+		setEvolvedConfig: mock(() => {}),
+		setRoleTemplate: mock(() => {}),
+		setOnboardingPrompt: mock(() => {}),
+		setMcpServers: mock(() => {}),
+		getLastTrackedFiles: mock(() => []),
+		getActiveSessionCount: mock(() => 0),
+	};
+}
+
+beforeEach(() => {
+	db = new Database(":memory:");
+	runMigrations(db);
+	setDashboardDb(db);
+	scheduler = new Scheduler({ db, runtime: createMockRuntime() as never });
+	setSchedulerInstance(scheduler);
+	sessionToken = createSession().sessionToken;
+});
+
+afterEach(() => {
+	clearSchedulerInstanceForTests();
+	db.close();
+	revokeAllSessions();
+});
+
+function req(path: string, init?: RequestInit): Request {
+	return new Request(`http://localhost${path}`, {
+		...init,
+		headers: {
+			Cookie: `phantom_session=${encodeURIComponent(sessionToken)}`,
+			Accept: "application/json",
+			"Content-Type": "application/json",
+			...((init?.headers as Record<string, string>) ?? {}),
+		},
+	});
+}
+
+function hnBody(overrides: Record<string, unknown> = {}): string {
+	return JSON.stringify({
+		name: "hn-digest",
+		description: "Top Hacker News stories every 6 hours",
+		task: "Fetch the top 10 HN stories and post a brief summary to Slack.",
+		schedule: { kind: "every", intervalMs: 21_600_000 },
+		delivery: { channel: "slack", target: "owner" },
+		...overrides,
+	});
+}
+
+describe("scheduler API", () => {
+	test("401 without session cookie", async () => {
+		const res = await handleUiRequest(
+			new Request("http://localhost/ui/api/scheduler", { headers: { Accept: "application/json" } }),
+		);
+		expect(res.status).toBe(401);
+	});
+
+	test("GET list on empty DB returns summary and empty jobs", async () => {
+		const res = await handleUiRequest(req("/ui/api/scheduler"));
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as {
+			summary: { total: number; active: number; paused: number };
+			jobs: unknown[];
+		};
+		expect(body.jobs).toEqual([]);
+		expect(body.summary.total).toBe(0);
+	});
+
+	test("POST creates the cheeks HN canonical job", async () => {
+		const res = await handleUiRequest(req("/ui/api/scheduler", { method: "POST", body: hnBody() }));
+		expect(res.status).toBe(201);
+		const body = (await res.json()) as {
+			job: { id: string; name: string; schedule: { kind: string; intervalMs: number } };
+		};
+		expect(body.job.name).toBe("hn-digest");
+		expect(body.job.schedule).toEqual({ kind: "every", intervalMs: 21_600_000 });
+
+		const auditRows = db.query("SELECT * FROM scheduler_audit_log WHERE job_id = ?").all(body.job.id) as Array<{
+			action: string;
+			actor: string;
+		}>;
+		expect(auditRows.length).toBe(1);
+		expect(auditRows[0].action).toBe("create");
+		expect(auditRows[0].actor).toBe("user");
+	});
+
+	test("POST with invalid schedule returns 400", async () => {
+		const res = await handleUiRequest(
+			req("/ui/api/scheduler", {
+				method: "POST",
+				body: hnBody({ schedule: { kind: "cron", expr: "not a valid cron" } }),
+			}),
+		);
+		expect(res.status).toBe(400);
+		const body = (await res.json()) as { error: string };
+		expect(body.error).toMatch(/invalid schedule|invalid cron/i);
+	});
+
+	test("POST with duplicate name returns 409", async () => {
+		await handleUiRequest(req("/ui/api/scheduler", { method: "POST", body: hnBody() }));
+		const res = await handleUiRequest(req("/ui/api/scheduler", { method: "POST", body: hnBody() }));
+		expect(res.status).toBe(409);
+	});
+
+	test("POST with oversized task returns 413", async () => {
+		const big = "x".repeat(40 * 1024);
+		const res = await handleUiRequest(
+			req("/ui/api/scheduler", { method: "POST", body: hnBody({ name: "big-task", task: big }) }),
+		);
+		expect(res.status).toBe(413);
+	});
+
+	test("POST with invalid delivery target returns 400", async () => {
+		const res = await handleUiRequest(
+			req("/ui/api/scheduler", {
+				method: "POST",
+				body: hnBody({ name: "bad-target", delivery: { channel: "slack", target: "#general" } }),
+			}),
+		);
+		expect(res.status).toBe(400);
+	});
+
+	test("POST with at schedule auto-enables deleteAfterRun via service", async () => {
+		const future = new Date(Date.now() + 3_600_000).toISOString();
+		const res = await handleUiRequest(
+			req("/ui/api/scheduler", {
+				method: "POST",
+				body: hnBody({ name: "one-shot", schedule: { kind: "at", at: future }, deleteAfterRun: true }),
+			}),
+		);
+		expect(res.status).toBe(201);
+		const body = (await res.json()) as { job: { deleteAfterRun: boolean } };
+		expect(body.job.deleteAfterRun).toBe(true);
+	});
+
+	test("GET /:id returns a specific job", async () => {
+		const created = await handleUiRequest(req("/ui/api/scheduler", { method: "POST", body: hnBody() }));
+		const createdBody = (await created.json()) as { job: { id: string } };
+		const res = await handleUiRequest(req(`/ui/api/scheduler/${createdBody.job.id}`));
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as { job: { id: string; name: string } };
+		expect(body.job.id).toBe(createdBody.job.id);
+		expect(body.job.name).toBe("hn-digest");
+	});
+
+	test("GET /:id returns 404 for unknown", async () => {
+		const res = await handleUiRequest(req("/ui/api/scheduler/nope"));
+		expect(res.status).toBe(404);
+	});
+
+	test("POST /:id/pause flips to paused and audits", async () => {
+		const job = scheduler.createJob({
+			name: "pauseable",
+			schedule: { kind: "every", intervalMs: 60_000 },
+			task: "hold",
+		});
+		const res = await handleUiRequest(req(`/ui/api/scheduler/${job.id}/pause`, { method: "POST" }));
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as { job: { status: string } };
+		expect(body.job.status).toBe("paused");
+
+		const audit = db
+			.query("SELECT action, previous_status, new_status FROM scheduler_audit_log WHERE job_id = ? ORDER BY id")
+			.all(job.id) as Array<{ action: string; previous_status: string; new_status: string }>;
+		expect(audit.at(-1)?.action).toBe("pause");
+		expect(audit.at(-1)?.previous_status).toBe("active");
+		expect(audit.at(-1)?.new_status).toBe("paused");
+	});
+
+	test("POST /:id/pause returns 404 for unknown", async () => {
+		const res = await handleUiRequest(req("/ui/api/scheduler/nope/pause", { method: "POST" }));
+		expect(res.status).toBe(404);
+	});
+
+	test("POST /:id/resume flips paused back to active", async () => {
+		const job = scheduler.createJob({
+			name: "resumable",
+			schedule: { kind: "every", intervalMs: 60_000 },
+			task: "go",
+		});
+		scheduler.pauseJob(job.id);
+		const res = await handleUiRequest(req(`/ui/api/scheduler/${job.id}/resume`, { method: "POST" }));
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as { job: { status: string; consecutiveErrors: number } };
+		expect(body.job.status).toBe("active");
+		expect(body.job.consecutiveErrors).toBe(0);
+	});
+
+	test("POST /:id/run runs the job and returns the result", async () => {
+		const job = scheduler.createJob({
+			name: "run-me",
+			schedule: { kind: "every", intervalMs: 60_000 },
+			task: "do it",
+		});
+		const res = await handleUiRequest(req(`/ui/api/scheduler/${job.id}/run`, { method: "POST" }));
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as { result: string; job: { runCount: number } };
+		expect(body.result).toBe("Mock response from agent");
+		expect(body.job.runCount).toBe(1);
+
+		const audit = db.query("SELECT action FROM scheduler_audit_log WHERE job_id = ?").all(job.id) as Array<{
+			action: string;
+		}>;
+		expect(audit.some((a) => a.action === "run")).toBe(true);
+	});
+
+	test("POST /:id/run returns 404 for unknown", async () => {
+		const res = await handleUiRequest(req("/ui/api/scheduler/nope/run", { method: "POST" }));
+		expect(res.status).toBe(404);
+	});
+
+	test("POST /:id/run returns 409 when target is paused", async () => {
+		const job = scheduler.createJob({
+			name: "paused-run",
+			schedule: { kind: "every", intervalMs: 60_000 },
+			task: "do it",
+		});
+		scheduler.pauseJob(job.id);
+		const res = await handleUiRequest(req(`/ui/api/scheduler/${job.id}/run`, { method: "POST" }));
+		expect(res.status).toBe(409);
+	});
+
+	test("DELETE /:id removes the job and audits", async () => {
+		const job = scheduler.createJob({
+			name: "deletable",
+			schedule: { kind: "every", intervalMs: 60_000 },
+			task: "bye",
+		});
+		const res = await handleUiRequest(req(`/ui/api/scheduler/${job.id}`, { method: "DELETE" }));
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as { deleted: boolean };
+		expect(body.deleted).toBe(true);
+		expect(scheduler.getJob(job.id)).toBeNull();
+
+		const audit = db.query("SELECT action FROM scheduler_audit_log WHERE job_id = ?").all(job.id) as Array<{
+			action: string;
+		}>;
+		expect(audit.some((a) => a.action === "delete")).toBe(true);
+	});
+
+	test("DELETE /:id returns 404 for unknown", async () => {
+		const res = await handleUiRequest(req("/ui/api/scheduler/nope", { method: "DELETE" }));
+		expect(res.status).toBe(404);
+	});
+
+	test("POST /preview returns nextRunAt and human-readable label", async () => {
+		const res = await handleUiRequest(
+			req("/ui/api/scheduler/preview", {
+				method: "POST",
+				body: JSON.stringify({ schedule: { kind: "every", intervalMs: 21_600_000 } }),
+			}),
+		);
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as { nextRunAt: string | null; humanReadable: string | null; error: string | null };
+		expect(body.error).toBeNull();
+		expect(body.nextRunAt).not.toBeNull();
+		expect(body.humanReadable).toBe("every 6h");
+	});
+
+	test("POST /preview returns error text for bad cron", async () => {
+		const res = await handleUiRequest(
+			req("/ui/api/scheduler/preview", {
+				method: "POST",
+				body: JSON.stringify({ schedule: { kind: "cron", expr: "@daily" } }),
+			}),
+		);
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as { nextRunAt: string | null; error: string | null };
+		expect(body.nextRunAt).toBeNull();
+		expect(body.error).toMatch(/nicknames/i);
+	});
+
+	test("POST /preview rejects malformed schedule with 400", async () => {
+		const res = await handleUiRequest(
+			req("/ui/api/scheduler/preview", { method: "POST", body: JSON.stringify({ schedule: { kind: "bogus" } }) }),
+		);
+		expect(res.status).toBe(400);
+	});
+
+	test("GET /:id/audit returns entries in descending order", async () => {
+		const job = scheduler.createJob({
+			name: "audited",
+			schedule: { kind: "every", intervalMs: 60_000 },
+			task: "audit",
+		});
+		await handleUiRequest(req(`/ui/api/scheduler/${job.id}/pause`, { method: "POST" }));
+		await handleUiRequest(req(`/ui/api/scheduler/${job.id}/resume`, { method: "POST" }));
+
+		const res = await handleUiRequest(req(`/ui/api/scheduler/${job.id}/audit`));
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as { entries: Array<{ action: string }> };
+		expect(body.entries.length).toBe(2);
+		expect(body.entries[0].action).toBe("resume");
+		expect(body.entries[1].action).toBe("pause");
+	});
+
+	test("GET /:id/audit clamps limit", async () => {
+		const job = scheduler.createJob({
+			name: "clamp",
+			schedule: { kind: "every", intervalMs: 60_000 },
+			task: "clamp",
+		});
+		const res = await handleUiRequest(req(`/ui/api/scheduler/${job.id}/audit?limit=99999`));
+		expect(res.status).toBe(200);
+	});
+
+	test("GET /:id/audit with invalid limit returns 400", async () => {
+		const job = scheduler.createJob({
+			name: "clamp2",
+			schedule: { kind: "every", intervalMs: 60_000 },
+			task: "clamp",
+		});
+		const res = await handleUiRequest(req(`/ui/api/scheduler/${job.id}/audit?limit=-5`));
+		expect(res.status).toBe(400);
+	});
+
+	test("POST /parse returns a structured proposal when Sonnet parser succeeds", async () => {
+		const spy = mock(async () => ({
+			ok: true as const,
+			proposal: {
+				name: "hn-digest",
+				task: "Fetch the top 10 HN stories and post to Slack.",
+				schedule: { kind: "every" as const, intervalMs: 21_600_000 },
+				delivery: { channel: "slack" as const, target: "owner" },
+			},
+			warnings: [],
+		}));
+		setSchedulerParserOverrideForTests(spy as never);
+
+		const res = await handleUiRequest(
+			req("/ui/api/scheduler/parse", {
+				method: "POST",
+				body: JSON.stringify({ description: "every 6h HN digest" }),
+			}),
+		);
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as { proposal: { name: string; schedule: { kind: string; intervalMs: number } } };
+		expect(body.proposal.name).toBe("hn-digest");
+		expect(body.proposal.schedule.intervalMs).toBe(21_600_000);
+		expect(spy).toHaveBeenCalledTimes(1);
+	});
+
+	test("POST /parse surfaces 422 when the parser cannot extract a proposal", async () => {
+		setSchedulerParserOverrideForTests((async () => ({
+			ok: false as const,
+			status: 422 as const,
+			error: "Could not parse description, please fill the form manually.",
+		})) as never);
+		const res = await handleUiRequest(
+			req("/ui/api/scheduler/parse", {
+				method: "POST",
+				body: JSON.stringify({ description: "gibberish" }),
+			}),
+		);
+		expect(res.status).toBe(422);
+	});
+
+	test("POST /parse surfaces 503 when ANTHROPIC_API_KEY is missing", async () => {
+		setSchedulerParserOverrideForTests((async () => ({
+			ok: false as const,
+			status: 503 as const,
+			error: "Sonnet assist requires ANTHROPIC_API_KEY.",
+		})) as never);
+		const res = await handleUiRequest(
+			req("/ui/api/scheduler/parse", {
+				method: "POST",
+				body: JSON.stringify({ description: "pull HN stories" }),
+			}),
+		);
+		expect(res.status).toBe(503);
+		const body = (await res.json()) as { error: string };
+		expect(body.error).toContain("ANTHROPIC_API_KEY");
+	});
+
+	test("POST /parse surfaces 504 on timeout", async () => {
+		setSchedulerParserOverrideForTests((async () => ({
+			ok: false as const,
+			status: 504 as const,
+			error: "Sonnet assist timed out, please fill the form manually.",
+		})) as never);
+		const res = await handleUiRequest(
+			req("/ui/api/scheduler/parse", {
+				method: "POST",
+				body: JSON.stringify({ description: "something" }),
+			}),
+		);
+		expect(res.status).toBe(504);
+	});
+
+	test("POST /parse rejects empty description with 400", async () => {
+		const res = await handleUiRequest(
+			req("/ui/api/scheduler/parse", { method: "POST", body: JSON.stringify({ description: "" }) }),
+		);
+		expect(res.status).toBe(400);
+	});
+
+	test("POST /parse rejects oversized description with 400", async () => {
+		const desc = "x".repeat(5000);
+		const res = await handleUiRequest(
+			req("/ui/api/scheduler/parse", { method: "POST", body: JSON.stringify({ description: desc }) }),
+		);
+		expect(res.status).toBe(400);
+	});
+
+	test("POST on an unknown path under /ui/api/scheduler returns 404", async () => {
+		const res = await handleUiRequest(req("/ui/api/scheduler/no-such-thing/boom", { method: "POST" }));
+		expect(res.status).toBe(404);
+	});
+
+	test("PUT on /ui/api/scheduler returns 405", async () => {
+		const res = await handleUiRequest(req("/ui/api/scheduler", { method: "PUT" }));
+		expect(res.status).toBe(405);
+	});
+});

--- a/src/ui/api/__tests__/scheduler.test.ts
+++ b/src/ui/api/__tests__/scheduler.test.ts
@@ -394,28 +394,11 @@ describe("scheduler API", () => {
 		expect(res.status).toBe(422);
 	});
 
-	test("POST /parse surfaces 503 when ANTHROPIC_API_KEY is missing", async () => {
+	test("POST /parse collapses subprocess failures to 422", async () => {
 		setSchedulerParserOverrideForTests((async () => ({
 			ok: false as const,
-			status: 503 as const,
-			error: "Sonnet assist requires ANTHROPIC_API_KEY.",
-		})) as never);
-		const res = await handleUiRequest(
-			req("/ui/api/scheduler/parse", {
-				method: "POST",
-				body: JSON.stringify({ description: "pull HN stories" }),
-			}),
-		);
-		expect(res.status).toBe(503);
-		const body = (await res.json()) as { error: string };
-		expect(body.error).toContain("ANTHROPIC_API_KEY");
-	});
-
-	test("POST /parse surfaces 504 on timeout", async () => {
-		setSchedulerParserOverrideForTests((async () => ({
-			ok: false as const,
-			status: 504 as const,
-			error: "Sonnet assist timed out, please fill the form manually.",
+			status: 422 as const,
+			error: "Could not parse description, please fill the form manually.",
 		})) as never);
 		const res = await handleUiRequest(
 			req("/ui/api/scheduler/parse", {
@@ -423,7 +406,9 @@ describe("scheduler API", () => {
 				body: JSON.stringify({ description: "something" }),
 			}),
 		);
-		expect(res.status).toBe(504);
+		expect(res.status).toBe(422);
+		const body = (await res.json()) as { error: string };
+		expect(body.error).toContain("Could not parse");
 	});
 
 	test("POST /parse rejects empty description with 400", async () => {

--- a/src/ui/api/__tests__/scheduler.test.ts
+++ b/src/ui/api/__tests__/scheduler.test.ts
@@ -123,6 +123,27 @@ describe("scheduler API", () => {
 		expect(auditRows[0].actor).toBe("user");
 	});
 
+	test("POST honors enabled=false and persists the disabled state", async () => {
+		const res = await handleUiRequest(
+			req("/ui/api/scheduler", {
+				method: "POST",
+				body: hnBody({ name: "disabled-on-create", enabled: false }),
+			}),
+		);
+		expect(res.status).toBe(201);
+		const body = (await res.json()) as { job: { id: string; enabled: boolean } };
+		expect(body.job.enabled).toBe(false);
+		const row = db.query("SELECT enabled FROM scheduled_jobs WHERE id = ?").get(body.job.id) as { enabled: number };
+		expect(row.enabled).toBe(0);
+	});
+
+	test("POST defaults enabled=true when the field is omitted", async () => {
+		const res = await handleUiRequest(req("/ui/api/scheduler", { method: "POST", body: hnBody() }));
+		expect(res.status).toBe(201);
+		const body = (await res.json()) as { job: { enabled: boolean } };
+		expect(body.job.enabled).toBe(true);
+	});
+
 	test("POST with invalid schedule returns 400", async () => {
 		const res = await handleUiRequest(
 			req("/ui/api/scheduler", {

--- a/src/ui/api/scheduler.ts
+++ b/src/ui/api/scheduler.ts
@@ -193,6 +193,7 @@ async function handleCreate(req: Request, deps: SchedulerApiDeps): Promise<Respo
 		schedule: input.schedule,
 		task: input.task,
 		deleteAfterRun: input.deleteAfterRun,
+		enabled: input.enabled,
 		createdBy: input.createdBy ?? "user",
 		...(input.delivery
 			? {

--- a/src/ui/api/scheduler.ts
+++ b/src/ui/api/scheduler.ts
@@ -1,0 +1,373 @@
+// UI API routes for the scheduler dashboard tab.
+//
+// All routes live under /ui/api/scheduler and are cookie-auth gated by the
+// dispatcher in src/ui/serve.ts.
+//
+//   GET    /ui/api/scheduler
+//   GET    /ui/api/scheduler/:id
+//   GET    /ui/api/scheduler/:id/audit?limit=20
+//   POST   /ui/api/scheduler
+//   POST   /ui/api/scheduler/preview
+//   POST   /ui/api/scheduler/parse          (Sonnet describe-assist)
+//   POST   /ui/api/scheduler/:id/pause
+//   POST   /ui/api/scheduler/:id/resume
+//   POST   /ui/api/scheduler/:id/run
+//   DELETE /ui/api/scheduler/:id
+//
+// Create/pause/resume/run/delete flow through scheduler.* methods so the UI
+// path and the phantom_schedule MCP path share the same validation and side
+// effects. The audit log records every mutation the UI issues.
+//
+// CARDINAL RULE: the /parse endpoint fills a form. The operator reviews and
+// edits the proposal before calling POST /ui/api/scheduler. Sonnet never
+// drives the agent at run time. See src/scheduler/parse-with-sonnet.ts for
+// the full comment.
+
+import type { Database } from "bun:sqlite";
+import { z } from "zod";
+import { humanReadableSchedule } from "../../scheduler/human.ts";
+import { type ParseResult, parseJobDescription } from "../../scheduler/parse-with-sonnet.ts";
+import { computeNextRunAt, validateSchedule } from "../../scheduler/schedule.ts";
+import type { Scheduler } from "../../scheduler/service.ts";
+import { JobCreateInputSchema, ScheduleInputSchema } from "../../scheduler/tool-schema.ts";
+import type { JobCreateInput } from "../../scheduler/types.ts";
+
+export type SchedulerApiDeps = {
+	db: Database;
+	scheduler: Scheduler;
+	// Test seam so the parse endpoint can be exercised without a real
+	// Anthropic API key. Production wiring omits this and falls back to
+	// parseJobDescription with the env var.
+	parser?: (description: string) => Promise<ParseResult>;
+};
+
+const AUDIT_LIMIT_DEFAULT = 20;
+const AUDIT_LIMIT_MAX = 100;
+const DESCRIPTION_MAX = 2000;
+
+const DescribeSchema = z.object({
+	description: z.string().min(1).max(DESCRIPTION_MAX),
+});
+
+const PreviewSchema = z.object({
+	schedule: ScheduleInputSchema,
+});
+
+function json(body: unknown, init?: ResponseInit): Response {
+	return new Response(JSON.stringify(body), {
+		...init,
+		headers: {
+			"Content-Type": "application/json",
+			"Cache-Control": "no-store",
+			...((init?.headers as Record<string, string>) ?? {}),
+		},
+	});
+}
+
+function errJson(error: string, status: number): Response {
+	return json({ error }, { status });
+}
+
+function zodErrorMessage(err: z.ZodError): string {
+	const issue = err.issues[0];
+	const path = issue?.path?.length ? issue.path.join(".") : "body";
+	return `${path}: ${issue?.message ?? "invalid input"}`;
+}
+
+async function parseJsonBody<T>(
+	req: Request,
+	schema: z.ZodType<T>,
+): Promise<{ ok: true; value: T } | { ok: false; error: string; status: number }> {
+	let raw: unknown;
+	try {
+		raw = await req.json();
+	} catch {
+		return { ok: false, error: "Invalid JSON body", status: 400 };
+	}
+	const parsed = schema.safeParse(raw);
+	if (!parsed.success) {
+		return { ok: false, error: zodErrorMessage(parsed.error), status: 400 };
+	}
+	return { ok: true, value: parsed.data };
+}
+
+function writeAudit(
+	db: Database,
+	row: {
+		jobId: string;
+		jobName: string | null;
+		action: string;
+		previousStatus?: string | null;
+		newStatus?: string | null;
+		detail?: string | null;
+		actor?: string;
+	},
+): void {
+	db.run(
+		`INSERT INTO scheduler_audit_log (job_id, job_name, action, previous_status, new_status, actor, detail)
+			VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		[
+			row.jobId,
+			row.jobName,
+			row.action,
+			row.previousStatus ?? null,
+			row.newStatus ?? null,
+			row.actor ?? "user",
+			row.detail ?? null,
+		],
+	);
+}
+
+// -- GET handlers ---------------------------------------------------------
+
+function handleList(deps: SchedulerApiDeps): Response {
+	const summary = deps.scheduler.getHealthSummary();
+	const jobs = deps.scheduler.listJobs();
+	return json({ summary, jobs });
+}
+
+function handleDetail(deps: SchedulerApiDeps, id: string): Response {
+	const job = deps.scheduler.getJob(id);
+	if (!job) return errJson("Job not found", 404);
+	return json({ job });
+}
+
+function handleAudit(deps: SchedulerApiDeps, id: string, url: URL): Response {
+	const limitParam = url.searchParams.get("limit");
+	let limit = AUDIT_LIMIT_DEFAULT;
+	if (limitParam !== null) {
+		const n = Number(limitParam);
+		if (!Number.isFinite(n) || n <= 0) return errJson("limit must be a positive integer", 400);
+		limit = Math.min(Math.floor(n), AUDIT_LIMIT_MAX);
+	}
+	const rows = deps.db
+		.query(
+			"SELECT id, job_id, job_name, action, previous_status, new_status, actor, detail, created_at FROM scheduler_audit_log WHERE job_id = ? ORDER BY id DESC LIMIT ?",
+		)
+		.all(id, limit) as Array<{
+		id: number;
+		job_id: string;
+		job_name: string | null;
+		action: string;
+		previous_status: string | null;
+		new_status: string | null;
+		actor: string;
+		detail: string | null;
+		created_at: string;
+	}>;
+	return json({ entries: rows });
+}
+
+// -- POST handlers --------------------------------------------------------
+
+async function handleCreate(req: Request, deps: SchedulerApiDeps): Promise<Response> {
+	// Parse JSON once so we can tell "oversized task" (413) apart from other
+	// validation failures (400) before Zod rejects the over-limit string.
+	let raw: unknown;
+	try {
+		raw = await req.json();
+	} catch {
+		return errJson("Invalid JSON body", 400);
+	}
+	if (raw && typeof raw === "object" && "task" in raw) {
+		const task = (raw as { task?: unknown }).task;
+		if (typeof task === "string" && Buffer.byteLength(task, "utf8") > 32 * 1024) {
+			return errJson("task text exceeds 32 KB limit", 413);
+		}
+	}
+
+	const parsed = JobCreateInputSchema.safeParse(raw);
+	if (!parsed.success) return errJson(zodErrorMessage(parsed.error), 400);
+
+	const input = parsed.data;
+
+	// Zod's output type leaves fields with .default() as optional on the
+	// inferred type, even though the parser always fills them. Normalize the
+	// delivery shape here so scheduler.createJob receives the full JobDelivery.
+	const serviceInput: JobCreateInput = {
+		name: input.name,
+		description: input.description,
+		schedule: input.schedule,
+		task: input.task,
+		deleteAfterRun: input.deleteAfterRun,
+		createdBy: input.createdBy ?? "user",
+		...(input.delivery
+			? {
+					delivery: {
+						channel: input.delivery.channel ?? "slack",
+						target: input.delivery.target ?? "owner",
+					},
+				}
+			: {}),
+	};
+
+	try {
+		const job = deps.scheduler.createJob(serviceInput);
+		writeAudit(deps.db, {
+			jobId: job.id,
+			jobName: job.name,
+			action: "create",
+			newStatus: job.status,
+			actor: input.createdBy ?? "user",
+		});
+		return json({ job }, { status: 201 });
+	} catch (err: unknown) {
+		const msg = err instanceof Error ? err.message : String(err);
+		if (/already exists/i.test(msg)) return errJson(msg, 409);
+		if (/job limit reached/i.test(msg)) return errJson(msg, 429);
+		if (/exceeds\s+\d+\s+byte limit/i.test(msg)) return errJson(msg, 413);
+		return errJson(msg, 400);
+	}
+}
+
+async function handlePreview(req: Request): Promise<Response> {
+	const body = await parseJsonBody(req, PreviewSchema);
+	if (!body.ok) return errJson(body.error, body.status);
+
+	const scheduleError = validateSchedule(body.value.schedule);
+	if (scheduleError) {
+		return json({ nextRunAt: null, humanReadable: null, error: scheduleError });
+	}
+	const next = computeNextRunAt(body.value.schedule);
+	return json({
+		nextRunAt: next ? next.toISOString() : null,
+		humanReadable: humanReadableSchedule(body.value.schedule),
+		error: null,
+	});
+}
+
+async function handleParse(req: Request, deps: SchedulerApiDeps): Promise<Response> {
+	const body = await parseJsonBody(req, DescribeSchema);
+	if (!body.ok) return errJson(body.error, body.status);
+
+	const parse = deps.parser ?? parseJobDescription;
+	const result = await parse(body.value.description);
+	if (result.ok) {
+		return json({ proposal: result.proposal, warnings: result.warnings });
+	}
+	return errJson(result.error, result.status);
+}
+
+function handlePause(deps: SchedulerApiDeps, id: string): Response {
+	const before = deps.scheduler.getJob(id);
+	if (!before) return errJson("Job not found", 404);
+	const updated = deps.scheduler.pauseJob(id);
+	if (!updated) return errJson("Job not found", 404);
+	writeAudit(deps.db, {
+		jobId: updated.id,
+		jobName: updated.name,
+		action: "pause",
+		previousStatus: before.status,
+		newStatus: updated.status,
+	});
+	return json({ job: updated });
+}
+
+function handleResume(deps: SchedulerApiDeps, id: string): Response {
+	const before = deps.scheduler.getJob(id);
+	if (!before) return errJson("Job not found", 404);
+	const updated = deps.scheduler.resumeJob(id);
+	if (!updated) return errJson("Job not found", 404);
+	writeAudit(deps.db, {
+		jobId: updated.id,
+		jobName: updated.name,
+		action: "resume",
+		previousStatus: before.status,
+		newStatus: updated.status,
+	});
+	return json({ job: updated });
+}
+
+async function handleRun(deps: SchedulerApiDeps, id: string): Promise<Response> {
+	const before = deps.scheduler.getJob(id);
+	if (!before) return errJson("Job not found", 404);
+	try {
+		const result = await deps.scheduler.runJobNow(id);
+		const after = deps.scheduler.getJob(id);
+		writeAudit(deps.db, {
+			jobId: id,
+			jobName: before.name,
+			action: "run",
+			previousStatus: before.status,
+			newStatus: after?.status ?? before.status,
+			detail: result.length > 256 ? `${result.slice(0, 256)}...` : result,
+		});
+		return json({ result, job: after });
+	} catch (err: unknown) {
+		const msg = err instanceof Error ? err.message : String(err);
+		if (/currently executing/i.test(msg)) return errJson(msg, 409);
+		if (/status\s+'[^']+'/.test(msg)) return errJson(msg, 409);
+		if (/disabled/i.test(msg)) return errJson(msg, 409);
+		if (/not found/i.test(msg)) return errJson(msg, 404);
+		return errJson(msg, 500);
+	}
+}
+
+function handleDelete(deps: SchedulerApiDeps, id: string): Response {
+	const before = deps.scheduler.getJob(id);
+	if (!before) return errJson("Job not found", 404);
+	const deleted = deps.scheduler.deleteJob(id);
+	if (!deleted) return errJson("Job not found", 404);
+	writeAudit(deps.db, {
+		jobId: id,
+		jobName: before.name,
+		action: "delete",
+		previousStatus: before.status,
+		newStatus: null,
+	});
+	return json({ deleted: true });
+}
+
+// -- Dispatcher -----------------------------------------------------------
+
+export async function handleSchedulerApi(req: Request, url: URL, deps: SchedulerApiDeps): Promise<Response | null> {
+	const pathname = url.pathname;
+
+	if (pathname === "/ui/api/scheduler") {
+		if (req.method === "GET") return handleList(deps);
+		if (req.method === "POST") return handleCreate(req, deps);
+		return errJson("Method not allowed", 405);
+	}
+
+	if (pathname === "/ui/api/scheduler/preview" && req.method === "POST") {
+		return handlePreview(req);
+	}
+
+	if (pathname === "/ui/api/scheduler/parse" && req.method === "POST") {
+		return handleParse(req, deps);
+	}
+
+	const auditMatch = pathname.match(/^\/ui\/api\/scheduler\/([^/]+)\/audit$/);
+	if (auditMatch) {
+		if (req.method !== "GET") return errJson("Method not allowed", 405);
+		return handleAudit(deps, auditMatch[1], url);
+	}
+
+	const pauseMatch = pathname.match(/^\/ui\/api\/scheduler\/([^/]+)\/pause$/);
+	if (pauseMatch) {
+		if (req.method !== "POST") return errJson("Method not allowed", 405);
+		return handlePause(deps, pauseMatch[1]);
+	}
+
+	const resumeMatch = pathname.match(/^\/ui\/api\/scheduler\/([^/]+)\/resume$/);
+	if (resumeMatch) {
+		if (req.method !== "POST") return errJson("Method not allowed", 405);
+		return handleResume(deps, resumeMatch[1]);
+	}
+
+	const runMatch = pathname.match(/^\/ui\/api\/scheduler\/([^/]+)\/run$/);
+	if (runMatch) {
+		if (req.method !== "POST") return errJson("Method not allowed", 405);
+		return handleRun(deps, runMatch[1]);
+	}
+
+	const detailMatch = pathname.match(/^\/ui\/api\/scheduler\/([^/]+)$/);
+	if (detailMatch) {
+		const id = detailMatch[1];
+		if (req.method === "GET") return handleDetail(deps, id);
+		if (req.method === "DELETE") return handleDelete(deps, id);
+		return errJson("Method not allowed", 405);
+	}
+
+	return null;
+}

--- a/src/ui/api/scheduler.ts
+++ b/src/ui/api/scheduler.ts
@@ -20,11 +20,13 @@
 //
 // CARDINAL RULE: the /parse endpoint fills a form. The operator reviews and
 // edits the proposal before calling POST /ui/api/scheduler. Sonnet never
-// drives the agent at run time. See src/scheduler/parse-with-sonnet.ts for
-// the full comment.
+// drives the agent at run time. Uses the Agent SDK subprocess so the
+// operator's existing auth (Claude subscription or ANTHROPIC_API_KEY) carries
+// through. See src/scheduler/parse-with-sonnet.ts for the full comment.
 
 import type { Database } from "bun:sqlite";
 import { z } from "zod";
+import type { AgentRuntime } from "../../agent/runtime.ts";
 import { humanReadableSchedule } from "../../scheduler/human.ts";
 import { type ParseResult, parseJobDescription } from "../../scheduler/parse-with-sonnet.ts";
 import { computeNextRunAt, validateSchedule } from "../../scheduler/schedule.ts";
@@ -35,9 +37,10 @@ import type { JobCreateInput } from "../../scheduler/types.ts";
 export type SchedulerApiDeps = {
 	db: Database;
 	scheduler: Scheduler;
-	// Test seam so the parse endpoint can be exercised without a real
-	// Anthropic API key. Production wiring omits this and falls back to
-	// parseJobDescription with the env var.
+	runtime?: AgentRuntime | null;
+	// Test seam so the parse endpoint can be exercised without spawning a
+	// subprocess. Production wiring leaves this undefined and the handler
+	// falls back to parseJobDescription with the runtime.
 	parser?: (description: string) => Promise<ParseResult>;
 };
 
@@ -240,8 +243,9 @@ async function handleParse(req: Request, deps: SchedulerApiDeps): Promise<Respon
 	const body = await parseJsonBody(req, DescribeSchema);
 	if (!body.ok) return errJson(body.error, body.status);
 
-	const parse = deps.parser ?? parseJobDescription;
-	const result = await parse(body.value.description);
+	const result = deps.parser
+		? await deps.parser(body.value.description)
+		: await parseJobDescription(body.value.description, { runtime: deps.runtime ?? null });
 	if (result.ok) {
 		return json({ proposal: result.proposal, warnings: result.warnings });
 	}

--- a/src/ui/serve.ts
+++ b/src/ui/serve.ts
@@ -5,6 +5,7 @@ import { createSSEResponse } from "./events.ts";
 import { loginPageHtml } from "./login-page.ts";
 import { consumeMagicLink, createSession, isValidSession } from "./session.ts";
 
+import type { AgentRuntime } from "../agent/runtime.ts";
 import type { ParseResult } from "../scheduler/parse-with-sonnet.ts";
 import type { Scheduler } from "../scheduler/service.ts";
 import { secretsExpiredHtml, secretsFormHtml } from "../secrets/form-page.ts";
@@ -27,6 +28,7 @@ let secretsDb: Database | null = null;
 let dashboardDb: Database | null = null;
 let bootstrapDb: Database | null = null;
 let schedulerInstance: Scheduler | null = null;
+let schedulerRuntime: AgentRuntime | null = null;
 let schedulerParserOverride: ((description: string) => Promise<ParseResult>) | null = null;
 let pluginsApiOverrides: Pick<PluginsApiDeps, "fetcher" | "settingsPath" | "overlayPath"> = {};
 
@@ -45,12 +47,14 @@ export function setDashboardDb(db: Database): void {
 	dashboardDb = db;
 }
 
-export function setSchedulerInstance(scheduler: Scheduler): void {
+export function setSchedulerInstance(scheduler: Scheduler, runtime?: AgentRuntime): void {
 	schedulerInstance = scheduler;
+	if (runtime) schedulerRuntime = runtime;
 }
 
 export function clearSchedulerInstanceForTests(): void {
 	schedulerInstance = null;
+	schedulerRuntime = null;
 	schedulerParserOverride = null;
 }
 
@@ -259,6 +263,7 @@ export async function handleUiRequest(req: Request): Promise<Response> {
 		const apiResponse = await handleSchedulerApi(req, url, {
 			db: dashboardDb,
 			scheduler: schedulerInstance,
+			runtime: schedulerRuntime,
 			...(schedulerParserOverride ? { parser: schedulerParserOverride } : {}),
 		});
 		if (apiResponse) return apiResponse;

--- a/src/ui/serve.ts
+++ b/src/ui/serve.ts
@@ -5,12 +5,15 @@ import { createSSEResponse } from "./events.ts";
 import { loginPageHtml } from "./login-page.ts";
 import { consumeMagicLink, createSession, isValidSession } from "./session.ts";
 
+import type { ParseResult } from "../scheduler/parse-with-sonnet.ts";
+import type { Scheduler } from "../scheduler/service.ts";
 import { secretsExpiredHtml, secretsFormHtml } from "../secrets/form-page.ts";
 import { getSecretRequest, saveSecrets, validateMagicToken } from "../secrets/store.ts";
 import { handleCostApi } from "./api/cost.ts";
 import { handleHooksApi } from "./api/hooks.ts";
 import { handleMemoryFilesApi } from "./api/memory-files.ts";
 import { type PluginsApiDeps, handlePluginsApi } from "./api/plugins.ts";
+import { handleSchedulerApi } from "./api/scheduler.ts";
 import { handleSessionsApi } from "./api/sessions.ts";
 import { handleSettingsApi } from "./api/settings.ts";
 import { handleSkillsApi } from "./api/skills.ts";
@@ -23,6 +26,8 @@ let publicDir = resolve(process.cwd(), "public");
 let secretsDb: Database | null = null;
 let dashboardDb: Database | null = null;
 let bootstrapDb: Database | null = null;
+let schedulerInstance: Scheduler | null = null;
+let schedulerParserOverride: ((description: string) => Promise<ParseResult>) | null = null;
 let pluginsApiOverrides: Pick<PluginsApiDeps, "fetcher" | "settingsPath" | "overlayPath"> = {};
 
 type SecretSavedCallback = (requestId: string, secretNames: string[]) => Promise<void>;
@@ -38,6 +43,21 @@ export function setSecretsDb(db: Database): void {
 
 export function setDashboardDb(db: Database): void {
 	dashboardDb = db;
+}
+
+export function setSchedulerInstance(scheduler: Scheduler): void {
+	schedulerInstance = scheduler;
+}
+
+export function clearSchedulerInstanceForTests(): void {
+	schedulerInstance = null;
+	schedulerParserOverride = null;
+}
+
+// Test-only seam. Production wiring leaves this null so the handler falls
+// back to the default parseJobDescription (Anthropic SDK + env var).
+export function setSchedulerParserOverrideForTests(fn: (description: string) => Promise<ParseResult>): void {
+	schedulerParserOverride = fn;
 }
 
 // Test-only seam. Production wiring leaves these undefined and the plugins
@@ -227,6 +247,20 @@ export async function handleUiRequest(req: Request): Promise<Response> {
 			return Response.json({ error: "Dashboard API not initialized" }, { status: 503 });
 		}
 		const apiResponse = await handleCostApi(req, url, { db: dashboardDb });
+		if (apiResponse) return apiResponse;
+	}
+	if (url.pathname.startsWith("/ui/api/scheduler")) {
+		if (!dashboardDb) {
+			return Response.json({ error: "Dashboard API not initialized" }, { status: 503 });
+		}
+		if (!schedulerInstance) {
+			return Response.json({ error: "Scheduler not initialized" }, { status: 503 });
+		}
+		const apiResponse = await handleSchedulerApi(req, url, {
+			db: dashboardDb,
+			scheduler: schedulerInstance,
+			...(schedulerParserOverride ? { parser: schedulerParserOverride } : {}),
+		});
 		if (apiResponse) return apiResponse;
 	}
 

--- a/src/ui/serve.ts
+++ b/src/ui/serve.ts
@@ -59,7 +59,9 @@ export function clearSchedulerInstanceForTests(): void {
 }
 
 // Test-only seam. Production wiring leaves this null so the handler falls
-// back to the default parseJobDescription (Anthropic SDK + env var).
+// back to the default parseJobDescription, which routes through the Agent
+// SDK subprocess (runJudgeQuery) so subscription auth or API key auth both
+// work without code changes.
 export function setSchedulerParserOverrideForTests(fn: (description: string) => Promise<ParseResult>): void {
 	schedulerParserOverride = fn;
 }


### PR DESCRIPTION
## Summary

- Read-only Scheduler list with filters, summary strip, and a detail drawer that holds pause/resume/run-now/delete action buttons plus a 20-entry audit history.
- Create-job side drawer with four templates (canonical `hn-digest`, `daily-standup`, `pr-review-reminder`, `weekly-metrics`), four schedule kinds (Every interval, Daily time, Cron, Once), live debounced next-run preview, full validation parity with the `phantom_schedule` MCP tool, delivery picker with ARIA-correct radio group.
- `POST /ui/api/scheduler/parse` Sonnet describe-assist endpoint. Operator types a plain-English description, Sonnet returns a structured `JobCreateInput` proposal that fills the form. Operator reviews and edits before saving. Cardinal Rule preserved: form plumbing, not intent classification. Routes through the Agent SDK subprocess (`runtime.judgeQuery`) so the operator's existing Claude subscription or `ANTHROPIC_API_KEY` carries through the same auth path as every other LLM call. Any failure collapses to 422 with "Could not parse description, please fill the form manually."
- Extracted `JobCreateInputSchema` to `src/scheduler/tool-schema.ts` so the MCP tool, the UI create endpoint, and the describe-assist helper all validate through one Zod schema. Non-breaking; existing `phantom_schedule` tool tests still pass.

## Scope

| Area | LOC |
|------|-----|
| `public/dashboard/scheduler.js` | 1,274 |
| CSS additions | 287 |
| `src/ui/api/scheduler.ts` | 377 |
| `src/scheduler/parse-with-sonnet.ts` | 107 |
| `src/scheduler/tool-schema.ts` | 30 |
| `src/scheduler/human.ts` (cron-to-english helper) | 72 |
| `src/scheduler/service.ts` (pause/resume) | +42 |
| `src/db/schema.ts` (`scheduler_audit_log` migration) | +19 |
| Tests (scheduler.test.ts, parse-with-sonnet.test.ts, service.test.ts addends) | 584 |
| Wiring (`index.ts`, `serve.ts`, `index.html`, `dashboard.js`, `tool.ts`) | 61 |
| **Total (net insertions)** | **2,909** |

Within the 2,925 ceiling set for this PR. `scheduler.js` landed at 1,274, which is over the 1,000 soft ceiling; the surface (list, detail drawer with four action buttons and an audit list, create drawer with four templates, four per-kind schedule editors, live preview, describe-assist, delivery radio group, validation) drove it. Not a regression in quality: every field has a label, every error is `role="alert"`, the task prompt renders via `textContent` to defeat XSS, the drawer is focus-trapped and full-width below 720px.

## Sonnet describe-assist design (Cardinal Rule preservation)

The `/parse` endpoint helps the operator fill a form. Sonnet proposes name, description, task, schedule, and delivery fields. The frontend pre-fills the form and shows a banner: "Filled from your description. Review and edit before saving." The operator must interact with the form before the Save button does anything meaningful. At run time, the agent that fires the job sees only the operator's final `task` text, not the parsed intent.

Auth: the endpoint routes through `runtime.judgeQuery` from `src/agent/judge-query.ts`. Both Claude subscription and `ANTHROPIC_API_KEY` flow through the Agent SDK's subprocess. No raw Anthropic SDK dependency.

## Schema extraction (non-breaking)

`JobCreateInputSchema` now lives in `src/scheduler/tool-schema.ts`. `src/scheduler/tool.ts` imports it; the MCP tool's input validation is unchanged field-for-field. The UI create endpoint validates the same way. The describe-assist path re-validates Sonnet's output against the same schema, so a proposal that would fail at `scheduler.createJob` is rejected before the UI surfaces it.

## Test plan

Automated:
- `bun test` (1,690 pass, 0 fail across 132 files).
- `bun run typecheck` clean.
- `bun run lint` clean.
- Scheduler API tests (`src/ui/api/__tests__/scheduler.test.ts`): 29 cases cover every endpoint: list, detail, audit, create (including duplicate 409, oversized task 413, invalid schedule 400, invalid delivery target 400), preview (happy/error), pause/resume/run/delete, 404s, 405 method guard, parse endpoint via injected parser.
- Parse helper tests (`src/scheduler/__tests__/parse-with-sonnet.test.ts`): 7 cases mock `runtime.judgeQuery` and cover happy path, malformed output, subprocess throw, cron/at schedule round-trips, and the no-runtime fallback. No real API calls in CI.
- Service tests (`src/scheduler/__tests__/service.test.ts`): 6 new cases cover `pauseJob` and `resumeJob` including no-op semantics, `consecutive_errors` reset on resume, and the armTimer exclusion invariant for paused rows.

Manual (recommended before merge):
- [ ] Open `#/scheduler`, confirm list renders with summary strip.
- [ ] Click "+ New job", select the HN digest template, verify fields populate.
- [ ] Switch schedule kind to Cron, enter `0 */12 * * *`, watch the preview update within ~300 ms.
- [ ] Type "alert me when pull requests get reviewed" in the describe textarea, click Fill form, confirm fields pre-fill and banner appears.
- [ ] Save, confirm the row appears in the list and navigates into the detail drawer.
- [ ] Run now, pause, resume, delete from the detail drawer, watch toasts and list updates.
- [ ] Re-do the create flow on dark theme.
- [ ] Re-do at 380px viewport (drawer full-width).

Cardinal Rule audit:
- [x] `/parse` is commented as form plumbing, not intent classification.
- [x] List and detail are read-only over existing data.
- [x] Create endpoint is UI plumbing for a structured form.
- [x] Task prompt and last-run-error render via `textContent`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)