### PR TITLE
fix(runtime): clear stale SDK session IDs on startup to prevent CLI deadlock

### DIFF
--- a/src/agent/__tests__/session-store.test.ts
+++ b/src/agent/__tests__/session-store.test.ts
@@ -73,6 +73,29 @@ describe("SessionStore", () => {
 		expect(session?.status).toBe("active");
 	});
 
+	test("clearAllSdkSessionIds clears every stale SDK ID", () => {
+		store.create("cli", "conv-1");
+		store.create("slack", "conv-2");
+		store.create("web", "conv-3");
+
+		store.updateSdkSessionId("cli:conv-1", "sdk-aaa");
+		store.updateSdkSessionId("slack:conv-2", "sdk-bbb");
+		// web:conv-3 has no SDK session ID
+
+		const cleared = store.clearAllSdkSessionIds();
+		expect(cleared).toBe(2);
+
+		expect(store.getByKey("cli:conv-1")?.sdk_session_id).toBeNull();
+		expect(store.getByKey("slack:conv-2")?.sdk_session_id).toBeNull();
+		expect(store.getByKey("web:conv-3")?.sdk_session_id).toBeNull();
+	});
+
+	test("clearAllSdkSessionIds returns 0 when no sessions have SDK IDs", () => {
+		store.create("cli", "conv-1");
+		const cleared = store.clearAllSdkSessionIds();
+		expect(cleared).toBe(0);
+	});
+
 	test("create reactivates an expired session with the same key", () => {
 		store.create("cli", "conv-1");
 		store.updateSdkSessionId("cli:conv-1", "old-sdk-id");

--- a/src/agent/runtime.ts
+++ b/src/agent/runtime.ts
@@ -280,6 +280,22 @@ export class AgentRuntime {
 						resultText = `Error: ${retryMsg}`;
 						onEvent?.({ type: "error", message: retryMsg });
 					}
+				} else if (isResume) {
+					// Any other error during a resume attempt — the SDK session is
+					// likely unusable.  Discard it and retry fresh.  See #25.
+					console.log(`[runtime] Resume failed (${errorMsg}), retrying without resume: ${sessionKey}`);
+					this.sessionStore.clearSdkSessionId(sessionKey);
+					sdkSessionId = "";
+					resultText = "";
+					cost = emptyCost();
+					emittedThinking = false;
+					try {
+						await runSdkQuery(false);
+					} catch (retryErr: unknown) {
+						const retryMsg = retryErr instanceof Error ? retryErr.message : String(retryErr);
+						resultText = `Error: ${retryMsg}`;
+						onEvent?.({ type: "error", message: retryMsg });
+					}
 				} else {
 					resultText = `Error: ${errorMsg}`;
 					onEvent?.({ type: "error", message: errorMsg });

--- a/src/agent/session-store.ts
+++ b/src/agent/session-store.ts
@@ -77,6 +77,21 @@ export class SessionStore {
 		);
 	}
 
+	/**
+	 * Clear all SDK session IDs on startup.
+	 *
+	 * SDK session IDs are process-local and do not survive restarts.
+	 * Without this, container recreates leave stale IDs in SQLite
+	 * (persisted volume), causing the runtime to attempt impossible
+	 * resumes that deadlock the CLI channel.  See #25.
+	 */
+	clearAllSdkSessionIds(): number {
+		const result = this.db.run(
+			"UPDATE sessions SET sdk_session_id = NULL WHERE sdk_session_id IS NOT NULL",
+		);
+		return result.changes;
+	}
+
 	touch(sessionKey: string): void {
 		this.db.run("UPDATE sessions SET last_active_at = datetime('now') WHERE session_key = ?", [sessionKey]);
 	}

--- a/src/index.ts
+++ b/src/index.ts
@@ -122,6 +122,14 @@ async function main(): Promise<void> {
 	// agent, which means a single auth path and a single provider switch.
 	const runtime = new AgentRuntime(config, db);
 
+	// SDK session IDs are process-local and never survive restarts.
+	// Clear them so the runtime does not attempt impossible resumes
+	// that deadlock CLI or other persistent channels.  See #25.
+	{
+		const result = db.run("UPDATE sessions SET sdk_session_id = NULL WHERE sdk_session_id IS NOT NULL");
+		if (result.changes > 0) console.log(`[phantom] Cleared ${result.changes} stale SDK session ID(s)`);
+	}
+
 	let evolution: EvolutionEngine | null = null;
 	let evolutionCadence: EvolutionCadence | null = null;
 	try {


### PR DESCRIPTION
## Summary

Fixes #25 — CLI channel deadlocks when `persistSession: true` attempts to resume a stale SDK session after a container restart.

## Root Cause

SDK session IDs are process-local (they live in the Claude Agent SDK subprocess) and never survive restarts. But when SQLite is on a persistent volume, the old `sdk_session_id` values remain in the `sessions` table. On next boot, `findActive()` returns a session with a stale ID → `runSdkQuery(true)` tries to resume → the SDK throws "No conversation found" (or another error) → the existing catch only handles that one specific error string → any other resume failure falls through to the generic error path, leaving the session in a stuck state.

## Fix (three layers)

1. **Startup cleanup** (`src/index.ts`): Clear all `sdk_session_id` values immediately after migrations. They are guaranteed stale after any restart. This is the primary fix — it prevents the resume attempt entirely.

2. **Broader retry** (`src/agent/runtime.ts`): Any error during a resume attempt now triggers a fresh-session retry, not just the specific "No conversation found" message. This is a safety net for edge cases where the startup cleanup missed a session (e.g., if a session was created between cleanup and the first message).

3. **New method** (`src/agent/session-store.ts`): `clearAllSdkSessionIds()` — a bulk cleanup method with JSDoc explaining why it exists.

## Testing

- Added 2 unit tests for `clearAllSdkSessionIds()`:
  - Clears multiple sessions with stale SDK IDs, leaves sessions without IDs untouched
  - Returns 0 when no sessions have SDK IDs (no-op case)

## Files Changed

| File | Change |
|------|--------|
| `src/index.ts` | Add startup cleanup call after `AgentRuntime` creation |
| `src/agent/runtime.ts` | Widen resume error catch to retry on any error, not just "No conversation found" |
| `src/agent/session-store.ts` | Add `clearAllSdkSessionIds()` method |
| `src/agent/__tests__/session-store.test.ts` | Add 2 tests for the new method |