### PR TITLE
hooks: strip heredoc bodies before dangerous-command scan

### DIFF
--- a/src/agent/__tests__/hooks.test.ts
+++ b/src/agent/__tests__/hooks.test.ts
@@ -210,4 +210,81 @@ describe("createDangerousCommandBlocker", () => {
 
 		expect(result).toEqual({ continue: true });
 	});
+
+	test("allows heredoc body that names a forbidden phrase as data", async () => {
+		const hook = createDangerousCommandBlocker();
+		const callback = hook.hooks[0];
+
+		const result = await callback(
+			makeHookInput({
+				hook_event_name: "PreToolUse",
+				tool_name: "Bash",
+				tool_input: {
+					command: "cat > note.md <<EOF\nReminder: git push --force is forbidden\nEOF",
+				},
+			}),
+			undefined,
+			{ signal: new AbortController().signal },
+		);
+
+		expect(result).toEqual({ continue: true });
+	});
+
+	test("allows heredoc with quoted delimiter and dangerous-looking body", async () => {
+		const hook = createDangerousCommandBlocker();
+		const callback = hook.hooks[0];
+
+		const result = await callback(
+			makeHookInput({
+				hook_event_name: "PreToolUse",
+				tool_name: "Bash",
+				tool_input: {
+					command:
+						"node <<'NODEEOF'\n// repro: docker compose down should not be triggered\nconsole.log('ok');\nNODEEOF",
+				},
+			}),
+			undefined,
+			{ signal: new AbortController().signal },
+		);
+
+		expect(result).toEqual({ continue: true });
+	});
+
+	test("blocks real dangerous command outside the heredoc", async () => {
+		const hook = createDangerousCommandBlocker();
+		const callback = hook.hooks[0];
+
+		const result = await callback(
+			makeHookInput({
+				hook_event_name: "PreToolUse",
+				tool_name: "Bash",
+				tool_input: {
+					command: "cat > note.md <<EOF\nharmless body\nEOF\ngit push --force origin main",
+				},
+			}),
+			undefined,
+			{ signal: new AbortController().signal },
+		);
+
+		expect(result).toHaveProperty("decision", "block");
+	});
+
+	test("blocks dash-stripped heredoc opener with real dangerous trailing command", async () => {
+		const hook = createDangerousCommandBlocker();
+		const callback = hook.hooks[0];
+
+		const result = await callback(
+			makeHookInput({
+				hook_event_name: "PreToolUse",
+				tool_name: "Bash",
+				tool_input: {
+					command: "cat <<-EOF\n\tharmless body\n\tEOF\nrm -rf /",
+				},
+			}),
+			undefined,
+			{ signal: new AbortController().signal },
+		);
+
+		expect(result).toHaveProperty("decision", "block");
+	});
 });

--- a/src/agent/hooks.ts
+++ b/src/agent/hooks.ts
@@ -25,6 +25,19 @@ const DANGEROUS_COMMANDS: { pattern: RegExp; label: string }[] = [
 	{ pattern: /kill\s+-9\s+1(\s|$)/, label: "kill init" },
 ];
 
+// Heredoc bodies are data, not commands. Stripping them before the
+// dangerous-command scan prevents prose, repros, and journal entries
+// that quote a forbidden phrase from tripping the blocker.
+// Matches `<<DELIM`, `<<-DELIM`, `<<"DELIM"`, `<<'DELIM'`; replaces the
+// payload (and the closing delimiter line) with an empty string and
+// keeps the surrounding command text so a real destructive command
+// outside the heredoc still matches. The optional `[ \t]*` before the
+// closing delimiter handles `<<-` heredocs where Bash strips leading
+// tabs from the terminator at parse time.
+function stripHeredocBodies(command: string): string {
+	return command.replace(/<<-?\s*['"]?(\w+)['"]?\n[\s\S]*?\n[ \t]*\1\s*$/gm, "");
+}
+
 export function createFileTracker(): {
 	hook: HookCallbackMatcher;
 	getTrackedFiles: () => string[];
@@ -59,8 +72,9 @@ export function createDangerousCommandBlocker(): HookCallbackMatcher {
 				if (input.hook_event_name !== "PreToolUse") return { continue: true };
 				const command = (input.tool_input as Record<string, unknown>)?.command;
 				if (typeof command === "string") {
+					const scannable = stripHeredocBodies(command);
 					for (const { pattern, label } of DANGEROUS_COMMANDS) {
-						if (pattern.test(command)) {
+						if (pattern.test(scannable)) {
 							return {
 								decision: "block",
 								reason: `Blocked dangerous command: "${label}"`,


### PR DESCRIPTION
Closes #100.

## Problem

The `createDangerousCommandBlocker` hook regex-matches against the
raw `command` string. Bodies of bash heredocs are data, not commands,
so a journal entry, repro, or doc snippet that quotes a forbidden
phrase like `git push --force` or `docker compose down` was tripping
the blocker and refusing benign Bash invocations:

```sh
cat > note.md <<EOF
Reminder: avoid git push --force on shared branches.
EOF
```

The agent had no way to write the prose without the blocker firing.

## Fix

This is option 2 from #100: strip heredoc bodies before the
pattern loop. No new dependency, no shell parser.

```ts
function stripHeredocBodies(command: string): string {
    return command.replace(
        /<<-?\s*['"]?(\w+)['"]?\n[\s\S]*?\n[ \t]*\1\s*$/gm,
        "",
    );
}
```

Handles `<<DELIM`, `<<-DELIM`, `<<"DELIM"`, `<<'DELIM'`. The `[ \t]*`
before the closing delimiter covers `<<-` heredocs where bash strips
leading tabs from the terminator line. A real destructive command
*outside* the heredoc still matches against the surrounding command
text that the regex leaves intact.

## Tests

Four new cases in `src/agent/__tests__/hooks.test.ts`:

| Case | Expected | Why |
|------|----------|-----|
| Heredoc body that says `git push --force is forbidden` | allow | data, not command |
| `<<'NODEEOF'` body that says the docker-compose teardown phrase | allow | quoted-delim heredoc |
| Heredoc + trailing `git push --force origin main` | block | real command outside |
| `<<-EOF\n\tbody\n\tEOF\nrm -rf /` | block | dash-stripped + real command |

Stash-bisect (stashing only `src/agent/hooks.ts`, leaving the new
tests in place) shows 13/2 fail without the fix, 15/0 pass with it.

```
$ git stash -- src/agent/hooks.ts
$ bun test src/agent/__tests__/hooks.test.ts
 13 pass
 2 fail   # the two new "allows heredoc body..." cases

$ git stash pop
$ bun test src/agent/__tests__/hooks.test.ts
 15 pass
 0 fail
```

## What this leaves on the table

Echo/printf false positives still exist, e.g.
`echo 'git push --force is bad'` would still trip the blocker. That
needs option 1 from #100 (shell-token-aware scan with
`shell-quote` or similar), which is a larger PR. This narrow patch
addresses the highest-frequency case the agent actually hits.

## Verification

- `bun test src/agent/__tests__/hooks.test.ts` — 15/15 pass
- `bun run typecheck` — clean
- `bun run lint` — clean (formatter normalized the new strings to one line each)
- Full suite — same 9 pre-existing failures as `origin/main` (Resend domain, env-pollution between provider tests); none touched by this PR
