### PR TITLE
phantom: inject tenant self-knowledge into system prompt overlay (Phase 9)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,6 +171,27 @@ The metrics module owns a private `prom-client` Registry (no global registry pol
 
 Cross-repo invariant: `slack-channel-factory.ts` exports a frozen `AllowedSecretNamesMirror` array (`slack_bot_token`, `slack_app_token`, `slack_gateway_signing_secret`). The same names MUST appear in phantomd's `internal/secrets/types.go` `AllowedSecretNames` map. Drift breaks tenant boot with HTTP 404 (the gateway maps `ErrInvalidName` to 404 to defeat name enumeration). The factory test pins the mirror against its `SECRET_RESPONSES` test fixture; phantomd's `TestIsAllowedName_AcceptsSlackAppToken` (and the existing `*_AcceptsSlackGatewaySigningSecret`) pin the symmetric assertion.
 
+## Tenant self-knowledge overlay (Phase 9)
+
+The agent's system prompt carries a per-tenant identity block injected by `src/agent/prompt-blocks/tenant-self-knowledge.ts`. The assembler (`src/agent/prompt-assembler.ts`) slots it as section 1b, between Identity and Environment, so the agent reads its own facts before the environment description. The overlay is purely additive and degrades to the empty string in single-tenant dev mode (no env vars set).
+
+Env vars consumed (all non-secret tenant identifiers):
+
+- `PHANTOM_TENANT_SLUG`: short identifier, also the wildcard subdomain. Source: phantomd firstboot via `internal/firstboot/firstboot.go:270`.
+- `PHANTOM_TENANT_ID`: read but currently not surfaced on its own; reserved for future debugging context.
+- `PHANTOM_OWNER_EMAIL`: tenant owner email. Source: phantomd firstboot via `internal/firstboot/firstboot.go:273`.
+- `PHANTOM_OWNER_NAME`: optional human name. Source: phantomd firstboot, queued addition (per phantomd CLAUDE.md "What's queued").
+- `PHANTOM_DOMAIN`: full per-tenant origin, e.g. `gilded-hearth.phantom.ghostwright.dev`. Source: phantomd firstboot, queued addition. Falls back to `<slug>.phantom.ghostwright.dev` when missing.
+- `PHANTOM_DASHBOARD_URL`: the operator's control surface URL. Source: `phantom-rootfs/systemd/phantom.service` Environment= line.
+- `PHANTOM_AGENT_RUNTIME`: `anthropic` or `murph`. Source: `phantom.service` (Phase 0 hardcode) or tenant.env (Phase 1 wizard).
+- `PHANTOM_MODEL`: model id. Source: tenant.env when operator picked a non-default; rootfs phantom.yaml default otherwise.
+- `PHANTOM_GRANTED_INTEGRATIONS`: comma-separated list of granted integrations (Phase 7 hook; silent today).
+- `PHANTOM_CHANNEL_ALLOWLIST`: comma-separated Slack channel ids (Phase 8b hook; silent today).
+
+The tenant.env C7 invariant (consumed once at firstboot, then deleted) does NOT affect the overlay: phantom-firstboot stamps these values into `/etc/default/phantom`, which `phantom.service` sources via `EnvironmentFile=`, so they survive in `process.env` for the lifetime of the agent process.
+
+The overlay never carries provider keys, OAuth tokens, or secrets. Every var is a non-secret identifier or label.
+
 ## Key Design Decisions
 
 **Qdrant over LanceDB:** WAL durability with crash recovery. Native hybrid search (dense + BM25 sparse vectors). Named vectors for separate embedding spaces. Mmap mode for low memory. TypeScript REST client works with Bun (no NAPI addon risk).
@@ -262,7 +283,8 @@ Verify after every deploy with `docker exec phantom sh -c 'touch /app/public/_w 
 | File | Why |
 |------|-----|
 | `src/index.ts` | Main wiring. How everything connects. |
-| `src/agent/prompt-assembler.ts` | The system prompt. How identity, role, evolved config, and memory are composed. |
+| `src/agent/prompt-assembler.ts` | The system prompt. How identity, role, evolved config, and memory are composed. Slot 1b is the tenant self-knowledge overlay (Phase 9). |
+| `src/agent/prompt-blocks/tenant-self-knowledge.ts` | Phase 9 self-knowledge overlay. Reads PHANTOM_TENANT_SLUG, PHANTOM_OWNER_EMAIL/NAME, PHANTOM_DOMAIN, PHANTOM_DASHBOARD_URL, PHANTOM_AGENT_RUNTIME, PHANTOM_MODEL, PHANTOM_GRANTED_INTEGRATIONS, PHANTOM_CHANNEL_ALLOWLIST. Empty in single-tenant dev. |
 | `src/agent/runtime.ts` | How the Agent SDK is called. Session management, hooks, cost tracking. |
 | `src/evolution/engine.ts` | The self-evolution pipeline. The core differentiator. |
 | `src/channels/slack.ts` | Primary channel. Owner access control, threading, reactions. |

--- a/src/agent/__tests__/prompt-assembler.test.ts
+++ b/src/agent/__tests__/prompt-assembler.test.ts
@@ -127,6 +127,114 @@ describe("assemblePrompt agent memory instructions", () => {
 	});
 });
 
+describe("assemblePrompt tenant self-knowledge overlay", () => {
+	const SELF_KNOWLEDGE_ENV_KEYS = [
+		"PHANTOM_TENANT_SLUG",
+		"PHANTOM_TENANT_ID",
+		"PHANTOM_OWNER_EMAIL",
+		"PHANTOM_OWNER_NAME",
+		"PHANTOM_DOMAIN",
+		"PHANTOM_DASHBOARD_URL",
+		"PHANTOM_AGENT_RUNTIME",
+		"PHANTOM_MODEL",
+		"PHANTOM_GRANTED_INTEGRATIONS",
+		"PHANTOM_CHANNEL_ALLOWLIST",
+	] as const;
+
+	const originalEnv: Record<string, string | undefined> = {};
+
+	beforeEach(() => {
+		// Snapshot every key we plan to touch so we can restore exactly
+		// what the surrounding process saw before we start mutating env.
+		for (const key of SELF_KNOWLEDGE_ENV_KEYS) {
+			originalEnv[key] = process.env[key];
+			delete process.env[key];
+		}
+	});
+
+	afterEach(() => {
+		// Restore. Using the snapshot is more conservative than blanket
+		// delete because the process running the tests may have its own
+		// values for these keys (e.g. a tenant-aware dev shell).
+		for (const key of SELF_KNOWLEDGE_ENV_KEYS) {
+			const original = originalEnv[key];
+			if (original === undefined) {
+				delete process.env[key];
+			} else {
+				process.env[key] = original;
+			}
+		}
+	});
+
+	test("omits the overlay entirely when no tenant env vars are set", () => {
+		const prompt = assemblePrompt(baseConfig);
+		expect(prompt).not.toContain("# Who You Are In This Workspace");
+	});
+
+	test("injects the overlay between Identity and Environment when tenant env is present", () => {
+		process.env.PHANTOM_TENANT_SLUG = "gilded-hearth";
+		process.env.PHANTOM_OWNER_EMAIL = "cheema@example.com";
+		process.env.PHANTOM_OWNER_NAME = "Cheema";
+		process.env.PHANTOM_DOMAIN = "gilded-hearth.phantom.ghostwright.dev";
+		process.env.PHANTOM_DASHBOARD_URL = "https://app.ghostwright.dev";
+		process.env.PHANTOM_AGENT_RUNTIME = "murph";
+		process.env.PHANTOM_MODEL = "claude-sonnet-4-6";
+
+		const prompt = assemblePrompt(baseConfig);
+		const identityIdx = prompt.indexOf("autonomous AI co-worker");
+		const overlayIdx = prompt.indexOf("# Who You Are In This Workspace");
+		const environmentIdx = prompt.indexOf("# Your Environment");
+
+		expect(identityIdx).toBeGreaterThanOrEqual(0);
+		expect(overlayIdx).toBeGreaterThan(identityIdx);
+		expect(environmentIdx).toBeGreaterThan(overlayIdx);
+
+		// The overlay carries the cardinal facts.
+		expect(prompt).toContain(
+			"You are the Phantom assigned to Cheema (cheema@example.com)'s workspace `gilded-hearth`.",
+		);
+		expect(prompt).toContain("Your home URL is https://gilded-hearth.phantom.ghostwright.dev.");
+		expect(prompt).toContain("Your dashboard control surface is https://app.ghostwright.dev.");
+		expect(prompt).toContain("Runtime: murph.");
+		expect(prompt).toContain("Model: claude-sonnet-4-6.");
+	});
+
+	test("renders the overlay with only the slug + dashboard set (defensive shape)", () => {
+		// Intermediate phantomd versions inject only PHANTOM_TENANT_SLUG +
+		// PHANTOM_OWNER_EMAIL today. The overlay must still produce a
+		// useful block in that interim shape so the agent gets self-
+		// knowledge as soon as ANY tenant signal is present.
+		process.env.PHANTOM_TENANT_SLUG = "gilded-hearth";
+		process.env.PHANTOM_OWNER_EMAIL = "cheema@example.com";
+		process.env.PHANTOM_DASHBOARD_URL = "https://ghostwright.dev/phantom/dashboard";
+
+		const prompt = assemblePrompt(baseConfig);
+		expect(prompt).toContain("# Who You Are In This Workspace");
+		expect(prompt).toContain("You are the Phantom assigned to cheema@example.com's workspace `gilded-hearth`.");
+		// Without PHANTOM_DOMAIN the home URL falls back to the wildcard
+		// derivation from the slug.
+		expect(prompt).toContain("Your home URL is https://gilded-hearth.phantom.ghostwright.dev.");
+		expect(prompt).toContain("Your dashboard control surface is https://ghostwright.dev/phantom/dashboard.");
+		// No runtime or model line should appear.
+		expect(prompt).not.toContain("Runtime:");
+		expect(prompt).not.toContain("Model:");
+	});
+
+	test("surfaces granted integrations and channel allowlist when phantomd emits them", () => {
+		// Phase 7 + Phase 8b will start emitting these lists; the overlay
+		// has to render them today so the system prompt does not need a
+		// second round of changes when those phases ship.
+		process.env.PHANTOM_TENANT_SLUG = "gilded-hearth";
+		process.env.PHANTOM_OWNER_EMAIL = "cheema@example.com";
+		process.env.PHANTOM_GRANTED_INTEGRATIONS = "github,linear,notion";
+		process.env.PHANTOM_CHANNEL_ALLOWLIST = "C0123,C0456";
+
+		const prompt = assemblePrompt(baseConfig);
+		expect(prompt).toContain("You have been granted these integrations: github, linear, notion.");
+		expect(prompt).toContain("Your Slack channel allowlist: C0123, C0456.");
+	});
+});
+
 describe("assemblePrompt UI vocabulary guidance", () => {
 	test("includes phantom-* vocabulary references", () => {
 		const prompt = assemblePrompt(baseConfig);

--- a/src/agent/prompt-assembler.ts
+++ b/src/agent/prompt-assembler.ts
@@ -8,6 +8,7 @@ import { buildDashboardAwarenessLines } from "./prompt-blocks/dashboard-awarenes
 import { buildEvolvedSections } from "./prompt-blocks/evolved.ts";
 import { buildInstructions } from "./prompt-blocks/instructions.ts";
 import { buildSecurity } from "./prompt-blocks/security.ts";
+import { buildTenantSelfKnowledge } from "./prompt-blocks/tenant-self-knowledge.ts";
 import { buildUIGuidanceLines } from "./prompt-blocks/ui-guidance.ts";
 import { buildWorkingMemory } from "./prompt-blocks/working-memory.ts";
 
@@ -24,6 +25,17 @@ export function assemblePrompt(
 
 	// 1. Identity - who you are
 	sections.push(buildIdentity(config));
+
+	// 1b. Tenant self-knowledge overlay (Phase 9, mission v1 step 4).
+	// Reads PHANTOM_TENANT_SLUG, PHANTOM_OWNER_EMAIL/NAME, PHANTOM_DOMAIN,
+	// PHANTOM_DASHBOARD_URL, PHANTOM_AGENT_RUNTIME, PHANTOM_MODEL, plus the
+	// PHANTOM_GRANTED_INTEGRATIONS and PHANTOM_CHANNEL_ALLOWLIST hooks for
+	// later phases. Returns the empty string in single-tenant or laptop dev
+	// mode where none of these are set; in that case nothing is appended.
+	const selfKnowledge = buildTenantSelfKnowledge();
+	if (selfKnowledge) {
+		sections.push(selfKnowledge);
+	}
 
 	// 2. Environment - what you have access to
 	sections.push(buildEnvironment(config));

--- a/src/agent/prompt-blocks/__tests__/tenant-self-knowledge.test.ts
+++ b/src/agent/prompt-blocks/__tests__/tenant-self-knowledge.test.ts
@@ -1,0 +1,243 @@
+// Tests for the tenant self-knowledge overlay (Phase 9). Covers the pure
+// builder function (no env coupling) AND the env reader (process.env shape).
+// Failure-path coverage: missing vars, empty strings, malformed list values,
+// the no-tenant fallback (every var unset, overlay returns empty).
+
+import { describe, expect, test } from "bun:test";
+import {
+	type TenantSelfKnowledgeEnv,
+	buildTenantSelfKnowledge,
+	readTenantSelfKnowledgeEnv,
+} from "../tenant-self-knowledge.ts";
+
+const fullEnv: TenantSelfKnowledgeEnv = {
+	tenantSlug: "gilded-hearth",
+	tenantId: "cheema",
+	ownerEmail: "cheema@example.com",
+	ownerName: "Cheema",
+	domain: "gilded-hearth.phantom.ghostwright.dev",
+	dashboardUrl: "https://app.ghostwright.dev",
+	agentRuntime: "murph",
+	model: "claude-sonnet-4-6",
+	grantedIntegrations: undefined,
+	channelAllowlist: undefined,
+};
+
+describe("buildTenantSelfKnowledge", () => {
+	test("composes the canonical block from a full env shape", () => {
+		const block = buildTenantSelfKnowledge(fullEnv);
+		expect(block).toContain("# Who You Are In This Workspace");
+		expect(block).toContain("You are the Phantom assigned to Cheema (cheema@example.com)'s workspace `gilded-hearth`.");
+		expect(block).toContain("Your home URL is https://gilded-hearth.phantom.ghostwright.dev.");
+		expect(block).toContain("The user reaches you here.");
+		expect(block).toContain("Your dashboard control surface is https://app.ghostwright.dev.");
+		expect(block).toContain("Runtime: murph.");
+		expect(block).toContain("Model: claude-sonnet-4-6.");
+	});
+
+	test("falls back to email-only owner phrase when name is absent", () => {
+		const block = buildTenantSelfKnowledge({ ...fullEnv, ownerName: undefined });
+		expect(block).toContain("You are the Phantom assigned to cheema@example.com's workspace `gilded-hearth`.");
+		// Make sure the empty name does not produce an awkward " ()" parenthetical.
+		expect(block).not.toContain("()");
+	});
+
+	test("falls back to name-only owner phrase when email is absent", () => {
+		const block = buildTenantSelfKnowledge({ ...fullEnv, ownerEmail: undefined });
+		expect(block).toContain("You are the Phantom assigned to Cheema's workspace `gilded-hearth`.");
+		expect(block).not.toContain("()");
+	});
+
+	test("omits owner phrase entirely when both name and email are absent", () => {
+		const block = buildTenantSelfKnowledge({
+			...fullEnv,
+			ownerName: undefined,
+			ownerEmail: undefined,
+		});
+		expect(block).toContain("You are the Phantom for workspace `gilded-hearth`.");
+		expect(block).not.toContain("Phantom assigned to");
+	});
+
+	test("derives home URL from slug when PHANTOM_DOMAIN is missing", () => {
+		const block = buildTenantSelfKnowledge({ ...fullEnv, domain: undefined });
+		// Defensive against intermediate phantomd versions that have not yet
+		// landed PHANTOM_DOMAIN injection: derive the canonical wildcard URL
+		// from the slug + ghostwright.dev.
+		expect(block).toContain("Your home URL is https://gilded-hearth.phantom.ghostwright.dev.");
+	});
+
+	test("strips an accidental https:// prefix from PHANTOM_DOMAIN before composing the URL", () => {
+		// Defensive against a phantomd-side change that emits
+		// PHANTOM_DOMAIN=https://gilded-hearth.phantom.ghostwright.dev/
+		// instead of the bare hostname. We always rebuild as https://<host>.
+		const block = buildTenantSelfKnowledge({
+			...fullEnv,
+			domain: "https://gilded-hearth.phantom.ghostwright.dev/",
+		});
+		expect(block).toContain("Your home URL is https://gilded-hearth.phantom.ghostwright.dev.");
+		expect(block).not.toContain("https://https://");
+	});
+
+	test("omits the home URL line when neither domain nor slug is known", () => {
+		const block = buildTenantSelfKnowledge({
+			...fullEnv,
+			domain: undefined,
+			tenantSlug: undefined,
+			ownerEmail: "cheema@example.com",
+			ownerName: undefined,
+		});
+		expect(block).not.toContain("Your home URL is");
+		// The owner sentence should still appear even without a slug.
+		expect(block).toContain("You are the Phantom assigned to cheema@example.com's workspace.");
+	});
+
+	test("omits the dashboard line when PHANTOM_DASHBOARD_URL is missing", () => {
+		const block = buildTenantSelfKnowledge({ ...fullEnv, dashboardUrl: undefined });
+		expect(block).not.toContain("dashboard control surface");
+	});
+
+	test("omits the runtime line when PHANTOM_AGENT_RUNTIME and PHANTOM_MODEL are both missing", () => {
+		const block = buildTenantSelfKnowledge({
+			...fullEnv,
+			agentRuntime: undefined,
+			model: undefined,
+		});
+		expect(block).not.toContain("Runtime:");
+		expect(block).not.toContain("Model:");
+	});
+
+	test("emits only the runtime when model is missing", () => {
+		const block = buildTenantSelfKnowledge({ ...fullEnv, model: undefined });
+		expect(block).toContain("Runtime: murph.");
+		expect(block).not.toContain("Model:");
+	});
+
+	test("emits only the model when runtime is missing", () => {
+		const block = buildTenantSelfKnowledge({ ...fullEnv, agentRuntime: undefined });
+		expect(block).toContain("Model: claude-sonnet-4-6.");
+		expect(block).not.toContain("Runtime:");
+	});
+
+	test("renders granted integrations when PHANTOM_GRANTED_INTEGRATIONS is present", () => {
+		const block = buildTenantSelfKnowledge({
+			...fullEnv,
+			grantedIntegrations: "github, linear ,notion",
+		});
+		expect(block).toContain("You have been granted these integrations: github, linear, notion.");
+	});
+
+	test("renders channel allowlist when PHANTOM_CHANNEL_ALLOWLIST is present", () => {
+		const block = buildTenantSelfKnowledge({
+			...fullEnv,
+			channelAllowlist: "C0123,C0456,,",
+		});
+		expect(block).toContain("Your Slack channel allowlist: C0123, C0456.");
+	});
+
+	test("omits the integrations line when the value is an empty list", () => {
+		const block = buildTenantSelfKnowledge({
+			...fullEnv,
+			grantedIntegrations: " , , ",
+		});
+		expect(block).not.toContain("granted these integrations");
+	});
+
+	test("omits the channel allowlist line when the value is whitespace-only", () => {
+		const block = buildTenantSelfKnowledge({
+			...fullEnv,
+			channelAllowlist: "   ",
+		});
+		expect(block).not.toContain("channel allowlist");
+	});
+
+	test("returns the empty string when every tenant signal is absent", () => {
+		const block = buildTenantSelfKnowledge({});
+		expect(block).toBe("");
+	});
+
+	test("returns the empty string when only tenantId is set (tenantId alone never enters the prompt)", () => {
+		// The block is keyed off slug, owner, domain, etc. Just having a
+		// tenantId is not enough to surface anything user-relevant. This
+		// asserts the block stays silent in that degenerate case so a
+		// half-injected env never produces a stub heading.
+		const block = buildTenantSelfKnowledge({ tenantId: "abc-123" });
+		expect(block).toBe("");
+	});
+
+	test("treats whitespace-only env values as unset", () => {
+		const block = buildTenantSelfKnowledge({
+			tenantSlug: "   ",
+			ownerEmail: "\t",
+			domain: " ",
+		});
+		expect(block).toBe("");
+	});
+});
+
+describe("readTenantSelfKnowledgeEnv", () => {
+	test("reads every supported env var into the shape", () => {
+		const shape = readTenantSelfKnowledgeEnv({
+			PHANTOM_TENANT_SLUG: "gilded-hearth",
+			PHANTOM_TENANT_ID: "cheema",
+			PHANTOM_OWNER_EMAIL: "cheema@example.com",
+			PHANTOM_OWNER_NAME: "Cheema",
+			PHANTOM_DOMAIN: "gilded-hearth.phantom.ghostwright.dev",
+			PHANTOM_DASHBOARD_URL: "https://app.ghostwright.dev",
+			PHANTOM_AGENT_RUNTIME: "murph",
+			PHANTOM_MODEL: "claude-sonnet-4-6",
+			PHANTOM_GRANTED_INTEGRATIONS: "github,linear",
+			PHANTOM_CHANNEL_ALLOWLIST: "C0123",
+		});
+		expect(shape).toEqual({
+			tenantSlug: "gilded-hearth",
+			tenantId: "cheema",
+			ownerEmail: "cheema@example.com",
+			ownerName: "Cheema",
+			domain: "gilded-hearth.phantom.ghostwright.dev",
+			dashboardUrl: "https://app.ghostwright.dev",
+			agentRuntime: "murph",
+			model: "claude-sonnet-4-6",
+			grantedIntegrations: "github,linear",
+			channelAllowlist: "C0123",
+		});
+	});
+
+	test("returns undefined for missing env vars", () => {
+		const shape = readTenantSelfKnowledgeEnv({});
+		expect(shape.tenantSlug).toBeUndefined();
+		expect(shape.tenantId).toBeUndefined();
+		expect(shape.ownerEmail).toBeUndefined();
+		expect(shape.ownerName).toBeUndefined();
+		expect(shape.domain).toBeUndefined();
+		expect(shape.dashboardUrl).toBeUndefined();
+		expect(shape.agentRuntime).toBeUndefined();
+		expect(shape.model).toBeUndefined();
+		expect(shape.grantedIntegrations).toBeUndefined();
+		expect(shape.channelAllowlist).toBeUndefined();
+	});
+
+	test("treats whitespace-only env values as undefined", () => {
+		const shape = readTenantSelfKnowledgeEnv({
+			PHANTOM_TENANT_SLUG: "   ",
+			PHANTOM_OWNER_EMAIL: "\t\n",
+		});
+		expect(shape.tenantSlug).toBeUndefined();
+		expect(shape.ownerEmail).toBeUndefined();
+	});
+
+	test("trims surrounding whitespace from real values", () => {
+		const shape = readTenantSelfKnowledgeEnv({
+			PHANTOM_TENANT_SLUG: "  gilded-hearth\n",
+			PHANTOM_OWNER_EMAIL: " cheema@example.com ",
+		});
+		expect(shape.tenantSlug).toBe("gilded-hearth");
+		expect(shape.ownerEmail).toBe("cheema@example.com");
+	});
+
+	test("defaults to process.env when no override is passed", () => {
+		// Spot check: at least one well-known shape key exists with the right
+		// type. We do not assert content because process.env is per-environment.
+		const shape = readTenantSelfKnowledgeEnv();
+		expect(typeof shape).toBe("object");
+	});
+});

--- a/src/agent/prompt-blocks/tenant-self-knowledge.ts
+++ b/src/agent/prompt-blocks/tenant-self-knowledge.ts
@@ -1,0 +1,239 @@
+// Tenant self-knowledge overlay (Phase 9, mission v1 sequencing step 4).
+//
+// Purpose: tell the agent who it is, who it works for, where it lives, and
+// what catalog of integrations it has been granted. Today the agent learns
+// its public URL passively through buildIdentity / buildEnvironment, but it
+// does NOT know its tenant slug, owner identity, dashboard URL, runtime, or
+// model. Without this overlay the agent cannot reason about "you are the
+// Phantom assigned to <user>" when a sidekick or operator asks; it cannot
+// hand its own URL back to the user; it cannot reference its dashboard.
+//
+// The overlay slots in between buildIdentity and buildEnvironment in the
+// assembled prompt so the agent reads its own identity facts before the
+// environment description. The block is purely additive: every line is
+// gated on a real env var so unset values silently disappear (single-tenant
+// or laptop dev runs see no change to today's prompt).
+//
+// Source of the env vars (verified 2026-05-01):
+//   PHANTOM_TENANT_ID, PHANTOM_TENANT_SLUG, PHANTOM_OWNER_EMAIL come from
+//   phantomd's firstbootStep at internal/state/orchestrator.go:623-662 via
+//   internal/firstboot/firstboot.go:263-292 (writeEnvFile). phantom-firstboot
+//   stamps them into /etc/default/phantom which phantom.service sources via
+//   EnvironmentFile=, so they survive in process.env post-firstboot.
+//
+//   PHANTOM_OWNER_NAME and PHANTOM_DOMAIN are queued in phantomd CLAUDE.md
+//   as a one-line addition to firstbootStep; the overlay reads them
+//   defensively today so this Phantom-side PR ships without waiting on the
+//   phantomd-side wiring.
+//
+//   PHANTOM_DASHBOARD_URL is set as an Environment= line in
+//   phantom-rootfs/systemd/phantom.service:34 (currently
+//   https://ghostwright.dev/phantom/dashboard, will move to
+//   https://app.ghostwright.dev when Phase 3 lands).
+//
+//   PHANTOM_AGENT_RUNTIME comes from phantom.service:40 (Phase 0 hardcode
+//   today; Phase 1 wizard injects per-tenant via tenant.env).
+//   PHANTOM_MODEL comes from tenant.env when phantomd's firstbootStep
+//   ($req.Model$) is non-empty; otherwise the rootfs phantom.yaml default
+//   ("claude-sonnet-4-6") wins through loader.ts.
+//
+//   PHANTOM_GRANTED_INTEGRATIONS and PHANTOM_CHANNEL_ALLOWLIST are hooks
+//   that today's tenant.env does NOT carry. They land in Phase 7
+//   (integration platform) and Phase 8b (Slack channel allowlist) per
+//   master plan section 3. The overlay reads them defensively so the
+//   shape is in place when phantomd starts emitting them.
+//
+// Caching note: process.env values are stable for the lifetime of the
+// process (we never mutate the relevant keys after startup). The
+// assembler invokes this builder once per query() to keep the contract
+// consistent with the other prompt blocks. The cost is negligible
+// (few-microsecond string concat against a tiny env shape) and the
+// alternative (capture-once at startup) costs flexibility for future
+// tests that want to vary the env per-call.
+
+export interface TenantSelfKnowledgeEnv {
+	tenantSlug?: string;
+	tenantId?: string;
+	ownerEmail?: string;
+	ownerName?: string;
+	domain?: string;
+	dashboardUrl?: string;
+	agentRuntime?: string;
+	model?: string;
+	grantedIntegrations?: string;
+	channelAllowlist?: string;
+}
+
+// Read every relevant env var into a plain shape so tests can build the
+// same input without mutating process.env. The reader trims and treats
+// the empty string as "unset" so a downstream env injector that emits
+// PHANTOM_OWNER_NAME= (no value) does not produce a half-finished line.
+export function readTenantSelfKnowledgeEnv(env: NodeJS.ProcessEnv = process.env): TenantSelfKnowledgeEnv {
+	return {
+		tenantSlug: cleanString(env.PHANTOM_TENANT_SLUG),
+		tenantId: cleanString(env.PHANTOM_TENANT_ID),
+		ownerEmail: cleanString(env.PHANTOM_OWNER_EMAIL),
+		ownerName: cleanString(env.PHANTOM_OWNER_NAME),
+		domain: cleanString(env.PHANTOM_DOMAIN),
+		dashboardUrl: cleanString(env.PHANTOM_DASHBOARD_URL),
+		agentRuntime: cleanString(env.PHANTOM_AGENT_RUNTIME),
+		model: cleanString(env.PHANTOM_MODEL),
+		grantedIntegrations: cleanString(env.PHANTOM_GRANTED_INTEGRATIONS),
+		channelAllowlist: cleanString(env.PHANTOM_CHANNEL_ALLOWLIST),
+	};
+}
+
+// Build the overlay text from a TenantSelfKnowledgeEnv shape. Returns the
+// empty string when there is nothing to say, so the caller can skip the
+// section entirely (no leading or trailing blank lines polluting the
+// surrounding blocks). Order matches the way a colleague would introduce
+// themselves: identity first, then where to reach them, then capabilities,
+// then the optional catalog.
+//
+// The builder defensively re-cleans every string field so a caller that
+// hand-builds the shape (rather than going through readTenantSelfKnowledgeEnv)
+// still gets the same whitespace and empty-string handling. The cleaning is
+// idempotent: a value that is already trimmed is returned unchanged.
+export function buildTenantSelfKnowledge(envShape: TenantSelfKnowledgeEnv = readTenantSelfKnowledgeEnv()): string {
+	const e: TenantSelfKnowledgeEnv = {
+		tenantSlug: cleanString(envShape.tenantSlug),
+		tenantId: cleanString(envShape.tenantId),
+		ownerEmail: cleanString(envShape.ownerEmail),
+		ownerName: cleanString(envShape.ownerName),
+		domain: cleanString(envShape.domain),
+		dashboardUrl: cleanString(envShape.dashboardUrl),
+		agentRuntime: cleanString(envShape.agentRuntime),
+		model: cleanString(envShape.model),
+		grantedIntegrations: cleanString(envShape.grantedIntegrations),
+		channelAllowlist: cleanString(envShape.channelAllowlist),
+	};
+
+	// If we have nothing tenant-specific to say, return empty so the
+	// assembler drops the block instead of emitting a stub heading.
+	const hasAnything = Boolean(
+		e.tenantSlug ||
+			e.ownerEmail ||
+			e.ownerName ||
+			e.domain ||
+			e.dashboardUrl ||
+			e.agentRuntime ||
+			e.model ||
+			e.grantedIntegrations ||
+			e.channelAllowlist,
+	);
+	if (!hasAnything) return "";
+
+	const lines: string[] = ["# Who You Are In This Workspace", ""];
+
+	// Owner + tenant slug. Compose into one sentence so the agent reads
+	// "you are the Phantom assigned to X's workspace `slug`" as a unit.
+	const ownerPhrase = composeOwnerPhrase(e.ownerName, e.ownerEmail);
+	if (ownerPhrase && e.tenantSlug) {
+		lines.push(`You are the Phantom assigned to ${ownerPhrase}'s workspace \`${e.tenantSlug}\`.`);
+	} else if (ownerPhrase) {
+		lines.push(`You are the Phantom assigned to ${ownerPhrase}'s workspace.`);
+	} else if (e.tenantSlug) {
+		lines.push(`You are the Phantom for workspace \`${e.tenantSlug}\`.`);
+	}
+
+	// Per-tenant home URL. Prefer the explicit PHANTOM_DOMAIN injection
+	// because it is the canonical operator-set value; fall back to deriving
+	// from slug + ghostwright.dev only when domain is unset and slug is
+	// present (defensive against intermediate phantomd versions that have
+	// not landed the PHANTOM_DOMAIN injection yet).
+	const homeUrl = composeHomeUrl(e.domain, e.tenantSlug);
+	if (homeUrl) {
+		lines.push(`Your home URL is ${homeUrl}. The user reaches you here.`);
+	}
+
+	// Dashboard URL: where the operator manages the Phantom from outside
+	// the chat surface. Today this points at ghostwright.dev/phantom/dashboard;
+	// after Phase 3 it points at app.ghostwright.dev.
+	if (e.dashboardUrl) {
+		lines.push(`Your dashboard control surface is ${e.dashboardUrl}.`);
+	}
+
+	// Runtime + model in one line because they are tightly coupled
+	// (Murph runtime selects a per-provider model, Anthropic-runtime
+	// pins the Anthropic model directly). Skip the line entirely when
+	// neither is known.
+	const runtimeLine = composeRuntimeLine(e.agentRuntime, e.model);
+	if (runtimeLine) {
+		lines.push(runtimeLine);
+	}
+
+	// Granted integrations hook (Phase 7). When phantomd starts emitting
+	// PHANTOM_GRANTED_INTEGRATIONS as a comma-separated list, the agent
+	// gets a one-line summary of its scoped integrations. Until then
+	// this stays silent.
+	const grants = formatList(e.grantedIntegrations);
+	if (grants.length > 0) {
+		lines.push(`You have been granted these integrations: ${grants.join(", ")}.`);
+	}
+
+	// Channel allowlist hook (Phase 8b). Same shape as grantedIntegrations:
+	// comma-separated channel identifiers (e.g. C0123,C0456). Stays silent
+	// until phantomd emits it.
+	const channels = formatList(e.channelAllowlist);
+	if (channels.length > 0) {
+		lines.push(`Your Slack channel allowlist: ${channels.join(", ")}.`);
+	}
+
+	return lines.join("\n");
+}
+
+// Compose a human-readable phrase for the owner. Prefers "Name (email)" when
+// both are known, falls back to either alone. Returns undefined when neither
+// is present so the caller can decide how to introduce the workspace without
+// an owner.
+function composeOwnerPhrase(ownerName: string | undefined, ownerEmail: string | undefined): string | undefined {
+	if (ownerName && ownerEmail) return `${ownerName} (${ownerEmail})`;
+	if (ownerName) return ownerName;
+	if (ownerEmail) return ownerEmail;
+	return undefined;
+}
+
+// Compose the canonical https URL for the agent's per-tenant origin. Prefers
+// PHANTOM_DOMAIN when set (operator-controlled, includes any future custom
+// domain). Otherwise derives `https://<slug>.phantom.ghostwright.dev` from
+// the slug, which matches phantom-cloud-deploy's wildcard DNS-01 invariant.
+// Returns undefined if we have neither (single-tenant dev mode).
+function composeHomeUrl(domain: string | undefined, tenantSlug: string | undefined): string | undefined {
+	if (domain) {
+		const trimmed = domain.replace(/^https?:\/\//i, "").replace(/\/+$/, "");
+		if (trimmed) return `https://${trimmed}`;
+	}
+	if (tenantSlug) {
+		return `https://${tenantSlug}.phantom.ghostwright.dev`;
+	}
+	return undefined;
+}
+
+// Compose the runtime + model line. Both fields are optional individually;
+// emit whatever is known. Capitalize the runtime kind for readability.
+function composeRuntimeLine(agentRuntime: string | undefined, model: string | undefined): string | undefined {
+	const parts: string[] = [];
+	if (agentRuntime) parts.push(`Runtime: ${agentRuntime}.`);
+	if (model) parts.push(`Model: ${model}.`);
+	if (parts.length === 0) return undefined;
+	return parts.join(" ");
+}
+
+// Trim and reject empty strings as "unset". Returns undefined for missing
+// values so consumers can use simple boolean checks.
+function cleanString(value: string | undefined): string | undefined {
+	if (!value) return undefined;
+	const trimmed = value.trim();
+	return trimmed === "" ? undefined : trimmed;
+}
+
+// Parse a comma-separated env var into a clean list. Returns [] for missing
+// or all-empty input so the caller can use a length check instead of a null
+// check.
+function formatList(value: string | undefined): string[] {
+	if (!value) return [];
+	return value
+		.split(",")
+		.map((entry) => entry.trim())
+		.filter((entry) => entry.length > 0);
+}


### PR DESCRIPTION
## Summary

Inject per-tenant identity into the agent's system prompt so it knows its own URL, owner, dashboard, runtime, and model. Mission v1 sequencing step 4 (master plan section 3 Phase 9).

The overlay slots between Identity and Environment in `src/agent/prompt-assembler.ts`, reads non-secret env vars stamped into the process by phantom-firstboot, and degrades to the empty string in single-tenant or laptop dev mode.

## What changed

- New `src/agent/prompt-blocks/tenant-self-knowledge.ts` exporting `buildTenantSelfKnowledge()` and `readTenantSelfKnowledgeEnv()`.
- `prompt-assembler.ts` now slots the overlay as section 1b, between Identity and Environment.
- `CLAUDE.md` documents the overlay, the env var contract, and the source of each var.
- 23 unit tests (builder + reader) + 4 integration tests (assembler position + defensive shape + integration hooks).

## Env vars consumed

All non-secret tenant identifiers; the overlay never carries provider keys, OAuth tokens, or other secrets.

| Env var | Source | Phase |
| --- | --- | --- |
| `PHANTOM_TENANT_SLUG` | phantomd firstboot, currently injected | Phase 1+ |
| `PHANTOM_TENANT_ID` | phantomd firstboot, currently injected | Phase 1+ |
| `PHANTOM_OWNER_EMAIL` | phantomd firstboot, currently injected | Phase 1+ |
| `PHANTOM_OWNER_NAME` | phantomd firstboot, queued | Phase 1+ (one-line addition) |
| `PHANTOM_DOMAIN` | phantomd firstboot, queued | Phase 1+ (one-line addition); falls back to `<slug>.phantom.ghostwright.dev` |
| `PHANTOM_DASHBOARD_URL` | phantom-rootfs systemd unit | shipped |
| `PHANTOM_AGENT_RUNTIME` | phantom-rootfs systemd unit (Phase 0) or tenant.env (Phase 1) | shipped |
| `PHANTOM_MODEL` | tenant.env (Phase 1 wizard) | shipped |
| `PHANTOM_GRANTED_INTEGRATIONS` | hook only; silent today | Phase 7 |
| `PHANTOM_CHANNEL_ALLOWLIST` | hook only; silent today | Phase 8b |

## Failure-path coverage

The overlay is defensive against intermediate phantomd versions: every line is gated on a real value, so missing optional vars silently disappear. Specific cases covered by tests:

- All vars unset: overlay returns the empty string; assembler drops the section.
- Only slug + email + dashboard set: overlay still produces a useful block; home URL falls back to `<slug>.phantom.ghostwright.dev`.
- Owner phrase falls back to email-only, name-only, or omits entirely if both are absent.
- `PHANTOM_DOMAIN=https://example.com/` (with scheme/trailing slash): stripped to bare host before composing.
- Whitespace-only env values treated as unset.
- Empty / whitespace-only list values for `PHANTOM_GRANTED_INTEGRATIONS` and `PHANTOM_CHANNEL_ALLOWLIST` produce no line.

## Refresh / restart survival

The C7 invariant (tenant.env consumed once at firstboot, then deleted) does not affect this overlay: phantom-firstboot stamps these values into `/etc/default/phantom`, which `phantom.service` sources via `EnvironmentFile=`, so they survive in `process.env` for the lifetime of the agent process across systemd restarts.

## Coordination with phantomd

No phantomd or phantom-rootfs change is required for this PR. `PHANTOM_OWNER_NAME` and `PHANTOM_DOMAIN` are queued as a one-line addition to `phantomd/internal/state/orchestrator.go` `firstbootStep` (per phantomd CLAUDE.md "What's queued"); when those land, the overlay starts surfacing them automatically with no Phantom-side change.

## Test plan

- [x] `bun test src/agent/prompt-blocks/__tests__/tenant-self-knowledge.test.ts` (23 tests)
- [x] `bun test src/agent/__tests__/prompt-assembler.test.ts` (22 tests)
- [x] `bun test` full suite: 2152 pass, 0 fail, 10 skip, 1 todo
- [x] `bun run lint` clean
- [x] `bun run typecheck` clean
- [ ] Codex review round
- [ ] Human verification of overlay text in a real tenant after merge

## Out of scope

- phantomd-side injection of `PHANTOM_OWNER_NAME` and `PHANTOM_DOMAIN` (queued separately per phantomd CLAUDE.md).
- Phase 7 / Phase 8b emission of granted integrations and channel allowlist.
- Magic-link auth (Phase 6) and per-agent grants UI (Phase 7).

@codex review