### PR TITLE
phantom: Phase 10 PR 10-3 email tool upgrade with metadata-gateway key fetch + tags + tenant-salted idempotency + recipient policy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,10 +166,36 @@ Metric families exposed today (Slack Socket Mode lifecycle):
 - `phantom_slack_socket_reconnects_total` (counter). Bolt's auto-reconnect is on by default; this measures "the network wobbled". Alert at sustained >5/min.
 - `phantom_slack_socket_connection_seconds` (histogram). Lifetime of a single Socket Mode connection from connect to disconnect. p99 should hold above 1 hour.
 - `phantom_slack_event_dispatch_seconds{event_type=...}` (histogram). End-to-end Bolt middleware time. Slack's ack deadline is 3 seconds; alert on p99 > 2.5s.
+- `phantom_email_send_total{outcome, purpose}` (counter; Phase 10 PR 10-3). One increment per `phantom_send_email` invocation regardless of whether the send reached Resend. Outcome label is one of `ok`, `recipient_denied`, `rate_limited_local`, `key_unavailable`, `rate_limited_resend`, `validation_error`, `service_down`, `auth_failed`. Purpose is the caller-supplied tag (sanitized to ASCII letters/numbers/underscores/dashes; oversized or invalid becomes `unknown`).
 
-The metrics module owns a private `prom-client` Registry (no global registry pollution). Adding more channels (Telegram, email) means adding a sibling registry and merging at request time in `core/server.ts`. Future cross-channel metrics generalize via Phase 17 polish.
+Each emitter owns its own private `prom-client` Registry (no global registry pollution). The provider in `core/server.ts` returns the array of registries (`[slackMetrics.registry, emailMetrics.registry]`) and `/metrics` renders each text exposition concatenated by a single newline. Adding more channels (Telegram, webhook) means appending one more registry to the provider's return; nothing else changes.
 
-Cross-repo invariant: `slack-channel-factory.ts` exports a frozen `AllowedSecretNamesMirror` array (`slack_bot_token`, `slack_app_token`, `slack_gateway_signing_secret`). The same names MUST appear in phantomd's `internal/secrets/types.go` `AllowedSecretNames` map. Drift breaks tenant boot with HTTP 404 (the gateway maps `ErrInvalidName` to 404 to defeat name enumeration). The factory test pins the mirror against its `SECRET_RESPONSES` test fixture; phantomd's `TestIsAllowedName_AcceptsSlackAppToken` (and the existing `*_AcceptsSlackGatewaySigningSecret`) pin the symmetric assertion.
+Cross-repo invariant: `src/config/secret-names.ts` exports a frozen `AllowedSecretNamesMirror` array (`slack_bot_token`, `slack_app_token`, `slack_gateway_signing_secret`, `resend_api_key`) plus the wire-stable constant `RESEND_API_KEY_SECRET_NAME = "resend_api_key"`. The same names MUST appear in phantomd's `internal/secrets/types.go` `AllowedSecretNames` map. Drift breaks tenant boot with HTTP 404 (the gateway maps `ErrInvalidName` to 404 to defeat name enumeration). The Slack subset is also exported from `src/channels/slack-channel-factory.ts` for the Slack callsites; phantomd's `TestIsAllowedName_AcceptsResendApiKey` and `_AcceptsSlackAppToken` (plus the existing `_AcceptsSlackGatewaySigningSecret`) pin the symmetric assertions.
+
+## Email (Phase 10 PR 10-3)
+
+The `phantom_send_email` MCP tool wraps Resend's `/emails` endpoint with a metadata-gateway key fetch, recipient policy gate, tenant-salted idempotency, and Prometheus attribution. The architect doc is `phantom-cloud-deploy/local/2026-05-01-phase10-resend-architect.md` (canonical contract: §6 EmailTool surface, §6.8 seven `error_kind` values, §7 cost attribution, §9.6 tenant-salted idempotency).
+
+**Key fetch.** `src/email/key-fetcher.ts` exposes `ResendKeyFetcher` (gateway-backed, 15-minute cache; `GET http://169.254.169.254/v1/secrets/resend_api_key`) and `EnvKeyFetcher` (env-backed for local dev / OSS Docker without a gateway). The wire-stable secret name is the constant `RESEND_API_KEY_SECRET_NAME` from `src/config/secret-names.ts`. The fetcher invalidates its cache on a Resend 401 so a subsequent retry refetches the rotated key.
+
+**Env-var contract** (set by phantomd firstboot in production; set directly by the operator in local dev):
+
+- `PHANTOM_OWNER_EMAIL`: required when the tool is enabled. Without it the policy parser throws and the tool stays unwired (no open-relay default).
+- `PHANTOM_TENANT_ID`: required for cost-attribution tags + the salted idempotency key. Falls back to `config.name` in local dev.
+- `PHANTOM_AGENT_ID` (optional): defaults to `PHANTOM_TENANT_ID` when missing.
+- `PHANTOM_EMAIL_RECIPIENTS_ALLOWED` (optional): policy mode. Accepted values:
+  - unset / empty / `owner` -> only `PHANTOM_OWNER_EMAIL` is allowed.
+  - `unrestricted` (or the literal `*` for back-compat) -> any recipient is allowed; explicit operator opt-in.
+  - comma-separated email list -> owner plus listed addresses are allowed.
+  - `workspace` is reserved for v1.5+ and explicitly rejected today.
+- `PHANTOM_EMAIL_DAILY_CAP` (optional, default 50): per-day local soft cap. Aliased as `PHANTOM_EMAIL_DAILY_LIMIT` for back-compat.
+- `METADATA_BASE_URL` (optional): override the metadata gateway origin. Presence of this env OR `PHANTOM_TENANT_ID` selects the gateway-backed fetcher; otherwise the env-backed fetcher is used.
+
+**The seven `error_kind` values** returned to the agent in the JSON envelope `{error: <message>, error_kind: <kind>}` (architect §6.8): `recipient_denied`, `rate_limited_local`, `key_unavailable`, `rate_limited_resend`, `validation_error`, `service_down`, `auth_failed`. The local cap and recipient policy are enforced before any Resend POST; the Resend SDK errors are mapped onto the four service-side kinds.
+
+**Tags + idempotency.** Every accepted Resend POST carries `[{name: "tenant_id"}, {name: "agent_id"}, {name: "purpose"}]`. The idempotency key is `sha256("${PHANTOM_TENANT_ID}:${normalizedTo}:${subject}:${utcDate}").slice(0, 32)` (architect §9.6). The tenant-id salt defends Resend's TEAM-scoped key namespace from cross-tenant collision when multiple tenants share the same operator-side Resend key.
+
+**Cross-repo wire.** Gateway URL: `http://169.254.169.254/v1/secrets/resend_api_key`. Secret name string: `"resend_api_key"`, mirrored byte-for-byte against phantomd `internal/secrets/types.go::AllowedSecretNames` (Phase 10 PR 10-1). Drift surfaces as HTTP 404 from the gateway, which the EmailTool surfaces as `error_kind = "key_unavailable"` to the agent.
 
 ## Key Design Decisions
 

--- a/src/channels/slack-channel-factory.ts
+++ b/src/channels/slack-channel-factory.ts
@@ -21,8 +21,8 @@ export type SlackTransportMode = "socket" | "http";
  * so a drift between this list and the phantomd allowlist breaks tenant
  * boot with no actionable error in the in-VM Phantom logs.
  *
- * The list below is the authoritative phantom-side mirror. Adding a Slack
- * secret to this array implies a matching addition in phantomd's
+ * The list below is the authoritative phantom-side Slack mirror. Adding a
+ * Slack secret to this array implies a matching addition in phantomd's
  * `AllowedSecretNames`; removing one requires that no callsite in this file
  * still fetches it. The mirror is exported (vs. private to this module) so
  * the factory test fixture can pin the same constant against its
@@ -39,6 +39,12 @@ export type SlackTransportMode = "socket" | "http";
  * event. Distinct from the Slack-issued `signing_secret` which lives in
  * phantom-slack-events' TOML config and never traverses the metadata
  * gateway.
+ *
+ * Phase 10 PR 10-3 (Resend, dated 2026-05-01): the broader cross-channel
+ * mirror (Slack plus Email plus future channels) lives in
+ * `src/config/secret-names.ts::AllowedSecretNamesMirror`. This file keeps
+ * the Slack-scoped subset as the authoritative list its own callsites
+ * fetch; new email-side names land in the broader mirror, not here.
  */
 export const AllowedSecretNamesMirror = Object.freeze([
 	"slack_bot_token",

--- a/src/config/__tests__/secret-names.test.ts
+++ b/src/config/__tests__/secret-names.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test";
+import { AllowedSecretNamesMirror, RESEND_API_KEY_SECRET_NAME } from "../secret-names.ts";
+
+describe("RESEND_API_KEY_SECRET_NAME", () => {
+	test("is exactly 'resend_api_key' (cross-repo wire-stable)", () => {
+		// This string MUST match phantomd/internal/secrets/types.go
+		// AllowedSecretNames["resend_api_key"]. Drift breaks tenant boot
+		// with HTTP 404 (the gateway maps ErrInvalidName to 404).
+		// See Phase 10 architect §3.5 + §9.1.
+		expect(RESEND_API_KEY_SECRET_NAME).toBe("resend_api_key");
+	});
+
+	test("uses lowercase letters and underscores only (allowlist regex shape)", () => {
+		expect(RESEND_API_KEY_SECRET_NAME).toMatch(/^[a-z_][a-z0-9_]*$/);
+	});
+});
+
+describe("AllowedSecretNamesMirror", () => {
+	test("includes resend_api_key (Phase 10)", () => {
+		expect(AllowedSecretNamesMirror).toContain("resend_api_key");
+	});
+
+	test("includes the slack triple (audit-F1 + Phase 8a)", () => {
+		expect(AllowedSecretNamesMirror).toContain("slack_bot_token");
+		expect(AllowedSecretNamesMirror).toContain("slack_app_token");
+		expect(AllowedSecretNamesMirror).toContain("slack_gateway_signing_secret");
+	});
+
+	test("entries are frozen (mutation is loud)", () => {
+		expect(Object.isFrozen(AllowedSecretNamesMirror)).toBe(true);
+	});
+
+	test("every entry matches phantomd's allowlist regex", () => {
+		const ALLOWED_NAME_RE = /^[a-z_][a-z0-9_]*$/;
+		for (const name of AllowedSecretNamesMirror) {
+			expect(name).toMatch(ALLOWED_NAME_RE);
+		}
+	});
+});

--- a/src/config/secret-names.ts
+++ b/src/config/secret-names.ts
@@ -1,0 +1,67 @@
+// Phase 10 PR 10-3: canonical mirror of phantomd's `AllowedSecretNames` for the
+// secret names that the in-VM Phantom fetches via the metadata gateway. The
+// allowlist itself lives in phantomd at `internal/secrets/types.go`; this file
+// is the phantom-side mirror that callsites import so the wire-stable string
+// has exactly one home in TypeScript.
+//
+// Cross-repo invariant: every entry in `AllowedSecretNamesMirror` MUST appear
+// in phantomd's `AllowedSecretNames` map. The gateway maps `ErrInvalidName` to
+// HTTP 404 (name-enumeration defense), so a drift between this list and
+// phantomd's allowlist breaks tenant boot with no actionable error in the
+// in-VM Phantom logs. The drift is caught by:
+//
+//   - phantomd's `TestIsAllowedName_AcceptsResendApiKey` (and the existing
+//     symmetric `*_AcceptsSlackAppToken`, `*_AcceptsSlackGatewaySigningSecret`)
+//   - phantom's `src/config/__tests__/secret-names.test.ts` and the existing
+//     `src/channels/__tests__/slack-channel-factory.test.ts::AllowedSecretNamesMirror`
+//
+// The Phase 10 architect doc §3.5 (the mirror invariant) and §9.1 (the
+// cross-repo allowlist table) describes the full mirror surface.
+//
+// Why this module exists separately from `slack-channel-factory.ts`: prior to
+// Phase 10 the only consumers were Slack-related, so the mirror lived in
+// `slack-channel-factory.ts`. Phase 10 adds `resend_api_key`, which is
+// consumed by the email module not the Slack module; the mirror is now the
+// shared concern of both. Keeping it here means future additions (Telegram
+// secrets, webhook secrets, etc.) follow the same import without churning
+// the slack-channel-factory module.
+
+/**
+ * Wire-stable secret name for the Resend transactional-email API key.
+ *
+ * This string MUST be exactly `"resend_api_key"`, byte-for-byte equal to:
+ *   - phantomd `internal/secrets/types.go::AllowedSecretNames["resend_api_key"]`
+ *   - phantom-control's `chainSeedResendKey` step (Phase 10 PR 10-2)
+ *   - the architect doc §9.1 cross-repo allowlist table
+ *
+ * Drift on the literal string surfaces as HTTP 404 from the metadata gateway
+ * (the gateway maps `ErrInvalidName` to 404 to defeat name enumeration),
+ * which `key-fetcher.ts` surfaces as `error_kind = "key_unavailable"` to the
+ * EmailTool. Source: `phantom-cloud-deploy/local/2026-05-01-phase10-resend-architect.md`
+ * §3.4 + §3.5 + §9.1.
+ */
+export const RESEND_API_KEY_SECRET_NAME = "resend_api_key" as const;
+
+/**
+ * The phantom-side authoritative mirror of phantomd's `AllowedSecretNames`
+ * map. Keep this list sorted in groups by purpose (Slack, Email, etc.) for
+ * readability; the test that pins it against phantomd compares as a set, not
+ * a sequence.
+ *
+ * Phase 8a addition (R7 dated 2026-04-30): `slack_app_token` joins the
+ * Socket Mode pair, gating the WSS dial for self-installed agent #2+.
+ *
+ * Phase 10 addition (Resend transactional email, dated 2026-05-01):
+ * `resend_api_key` joins the email module, fetched on demand by
+ * `src/email/key-fetcher.ts`.
+ */
+export const AllowedSecretNamesMirror = Object.freeze([
+	// Slack (Phase 5b + Phase 8a R7).
+	"slack_bot_token",
+	"slack_app_token",
+	"slack_gateway_signing_secret",
+	// Resend (Phase 10).
+	RESEND_API_KEY_SECRET_NAME,
+] as const);
+
+export type AllowedSecretName = (typeof AllowedSecretNamesMirror)[number];

--- a/src/core/server.ts
+++ b/src/core/server.ts
@@ -33,12 +33,18 @@ type SchedulerHealthProvider = () => SchedulerHealthSummary | null;
  * `contentType` for the response header). Keeping the surface minimal
  * means future emitters (Telegram, email) can plug in without taking a
  * direct dependency on prom-client at this layer.
+ *
+ * Phase 10 PR 10-3: the provider may return ONE registry or MANY. The
+ * `/metrics` route renders each in order separated by a single newline so
+ * scrapers see a concatenated text exposition. Per-emitter registries keep
+ * channel metric names self-contained (a future Telegram registry cannot
+ * collide with Slack or Email).
  */
 type MetricsRegistryLike = {
 	metrics(): Promise<string>;
 	contentType: string;
 };
-type MetricsRegistryProvider = () => MetricsRegistryLike | null;
+type MetricsRegistryProvider = () => MetricsRegistryLike | MetricsRegistryLike[] | null;
 type TriggerDeps = {
 	runtime: AgentRuntime;
 	slackChannel?: SlackTransport;
@@ -185,17 +191,25 @@ export function startServer(config: PhantomConfig, startedAt: number): ReturnTyp
 			// per-route auth. Returns 503 when no registry is wired (the
 			// process started without a metrics provider).
 			if (url.pathname === "/metrics" && req.method === "GET") {
-				const registry = metricsRegistryProvider?.();
-				if (!registry) {
+				const provided = metricsRegistryProvider?.();
+				if (!provided) {
 					return new Response("metrics registry not configured", {
 						status: 503,
 						headers: { "Content-Type": "text/plain; charset=utf-8" },
 					});
 				}
-				const body = await registry.metrics();
+				const registries = Array.isArray(provided) ? provided : [provided];
+				if (registries.length === 0) {
+					return new Response("metrics registry not configured", {
+						status: 503,
+						headers: { "Content-Type": "text/plain; charset=utf-8" },
+					});
+				}
+				const dumps = await Promise.all(registries.map((r) => r.metrics()));
+				const body = dumps.join("\n");
 				return new Response(body, {
 					headers: {
-						"Content-Type": registry.contentType,
+						"Content-Type": registries[0].contentType,
 						"Cache-Control": "no-store",
 					},
 				});

--- a/src/email/__tests__/key-fetcher.test.ts
+++ b/src/email/__tests__/key-fetcher.test.ts
@@ -1,0 +1,248 @@
+import { describe, expect, test } from "bun:test";
+import { EnvKeyFetcher, RESEND_KEY_CACHE_TTL_MS, ResendKeyFetcher } from "../key-fetcher.ts";
+
+const SECRET = "re_test_value";
+const BASE_URL = "http://gateway.test";
+
+function makeFetcherWithFakeFetch(opts: {
+	responses: Array<{ status: number; body?: string }>;
+	now?: () => number;
+	secretName?: string;
+	ttlMs?: number;
+	onCall?: (url: string, init?: RequestInit) => void;
+}) {
+	const calls: Array<{ url: string; init?: RequestInit }> = [];
+	let i = 0;
+	const fetchImpl = ((url: string | Request | URL, init?: RequestInit) => {
+		const stringUrl = typeof url === "string" ? url : url.toString();
+		calls.push({ url: stringUrl, init });
+		opts.onCall?.(stringUrl, init);
+		const r = opts.responses[i++];
+		if (!r) throw new Error(`fake fetch ran out of responses (call ${i} unmatched)`);
+		const body = r.body ?? "";
+		return Promise.resolve(new Response(body, { status: r.status }));
+	}) as unknown as typeof fetch;
+
+	const fetcher = new ResendKeyFetcher({
+		baseUrl: BASE_URL,
+		secretName: opts.secretName,
+		ttlMs: opts.ttlMs,
+		now: opts.now,
+		fetchImpl,
+	});
+
+	return { fetcher, calls };
+}
+
+describe("ResendKeyFetcher", () => {
+	test("happy path: 200 returns the body and caches it", async () => {
+		const { fetcher, calls } = makeFetcherWithFakeFetch({
+			responses: [{ status: 200, body: SECRET }],
+		});
+		const result = await fetcher.get();
+		expect(result.ok).toBe(true);
+		if (result.ok) expect(result.value).toBe(SECRET);
+		expect(calls).toHaveLength(1);
+		expect(calls[0]?.url).toBe(`${BASE_URL}/v1/secrets/resend_api_key`);
+	});
+
+	test("warm cache hit within TTL skips the network", async () => {
+		const { fetcher, calls } = makeFetcherWithFakeFetch({
+			responses: [{ status: 200, body: SECRET }],
+		});
+		await fetcher.get();
+		await fetcher.get();
+		expect(calls).toHaveLength(1);
+	});
+
+	test("cache eviction at TTL refetches", async () => {
+		let fakeNow = 1_000_000;
+		const { fetcher, calls } = makeFetcherWithFakeFetch({
+			responses: [
+				{ status: 200, body: SECRET },
+				{ status: 200, body: SECRET },
+			],
+			now: () => fakeNow,
+		});
+		await fetcher.get();
+		fakeNow += RESEND_KEY_CACHE_TTL_MS + 1;
+		await fetcher.get();
+		expect(calls).toHaveLength(2);
+	});
+
+	test("404 returns key_unavailable", async () => {
+		const { fetcher } = makeFetcherWithFakeFetch({
+			responses: [{ status: 404, body: "" }],
+		});
+		const result = await fetcher.get();
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error.kind).toBe("unavailable");
+			expect(result.error.message).toContain("404");
+		}
+	});
+
+	test("503 returns key_unavailable (service_down upstream)", async () => {
+		const { fetcher } = makeFetcherWithFakeFetch({
+			responses: [{ status: 503, body: "" }],
+		});
+		const result = await fetcher.get();
+		expect(result.ok).toBe(false);
+		if (!result.ok) expect(result.error.kind).toBe("unavailable");
+	});
+
+	test("401 invalidates cache and surfaces auth_failed; refetch does NOT use cached value", async () => {
+		const { fetcher, calls } = makeFetcherWithFakeFetch({
+			responses: [
+				{ status: 200, body: SECRET },
+				{ status: 401, body: "" },
+				{ status: 200, body: "re_rotated" },
+			],
+		});
+		const first = await fetcher.get();
+		expect(first.ok).toBe(true);
+		// Caller invokes invalidate + refetch on a Resend 401. We simulate
+		// the EmailTool's path: invalidate, then get again. The second get
+		// hits the gateway (cache cleared); the gateway returns 401 too.
+		fetcher.invalidate();
+		const second = await fetcher.get();
+		expect(second.ok).toBe(false);
+		if (!second.ok) expect(second.error.kind).toBe("auth_failed");
+		// A subsequent retry after operator re-seeds returns the new key.
+		const third = await fetcher.get();
+		expect(third.ok).toBe(true);
+		if (third.ok) expect(third.value).toBe("re_rotated");
+		expect(calls).toHaveLength(3);
+	});
+
+	test("network error surfaces as unavailable without leaking exception text", async () => {
+		const fetchImpl = ((_url: string, _init?: RequestInit) =>
+			Promise.reject(new Error("ECONNREFUSED phantom"))) as unknown as typeof fetch;
+		const fetcher = new ResendKeyFetcher({ baseUrl: BASE_URL, fetchImpl });
+		const result = await fetcher.get();
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error.kind).toBe("unavailable");
+			expect(result.error.message).toContain("resend_api_key");
+			expect(result.error.message).not.toContain(SECRET);
+		}
+	});
+
+	test("invalid secret name is rejected before any fetch fires", async () => {
+		const calls: number[] = [];
+		const fetchImpl = (() => {
+			calls.push(1);
+			return Promise.resolve(new Response("", { status: 200 }));
+		}) as unknown as typeof fetch;
+		const fetcher = new ResendKeyFetcher({
+			baseUrl: BASE_URL,
+			secretName: "BAD-NAME",
+			fetchImpl,
+		});
+		const result = await fetcher.get();
+		expect(result.ok).toBe(false);
+		if (!result.ok) expect(result.error.kind).toBe("invalid_name");
+		expect(calls).toHaveLength(0);
+	});
+
+	test("empty body is rejected as unavailable (defensive against gateway misbehaviour)", async () => {
+		const { fetcher } = makeFetcherWithFakeFetch({
+			responses: [{ status: 200, body: "" }],
+		});
+		const result = await fetcher.get();
+		expect(result.ok).toBe(false);
+		if (!result.ok) expect(result.error.kind).toBe("unavailable");
+	});
+
+	test("error message NEVER contains the secret value across every failure path", async () => {
+		// 401 (gateway-side bearer mis-config; in-flight Resend has the cached value separately).
+		const ctx = makeFetcherWithFakeFetch({
+			responses: [{ status: 401, body: SECRET }],
+		});
+		const result = await ctx.fetcher.get();
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error.message).not.toContain(SECRET);
+		}
+	});
+
+	test("cache-hit path NEVER re-emits the value via any log channel (no leak across get calls)", async () => {
+		const logs: string[] = [];
+		const origLog = console.log;
+		const origWarn = console.warn;
+		console.log = (...args: unknown[]) => {
+			logs.push(args.map((a) => String(a)).join(" "));
+		};
+		console.warn = (...args: unknown[]) => {
+			logs.push(args.map((a) => String(a)).join(" "));
+		};
+		try {
+			const { fetcher } = makeFetcherWithFakeFetch({
+				responses: [{ status: 200, body: SECRET }],
+			});
+			await fetcher.get();
+			await fetcher.get();
+			for (const line of logs) {
+				expect(line).not.toContain(SECRET);
+			}
+		} finally {
+			console.log = origLog;
+			console.warn = origWarn;
+		}
+	});
+
+	test("invalidate() forces a refetch on the next get", async () => {
+		const { fetcher, calls } = makeFetcherWithFakeFetch({
+			responses: [
+				{ status: 200, body: SECRET },
+				{ status: 200, body: "re_rotated" },
+			],
+		});
+		const first = await fetcher.get();
+		expect(first.ok && first.value === SECRET).toBe(true);
+		fetcher.invalidate();
+		const second = await fetcher.get();
+		expect(second.ok && (second as { ok: true; value: string }).value === "re_rotated").toBe(true);
+		expect(calls).toHaveLength(2);
+	});
+});
+
+describe("EnvKeyFetcher", () => {
+	test("returns the env value when set", async () => {
+		const original = process.env.RESEND_API_KEY;
+		process.env.RESEND_API_KEY = SECRET;
+		try {
+			const fetcher = new EnvKeyFetcher();
+			const result = await fetcher.get();
+			expect(result.ok).toBe(true);
+			if (result.ok) expect(result.value).toBe(SECRET);
+		} finally {
+			if (original !== undefined) {
+				process.env.RESEND_API_KEY = original;
+			} else {
+				// biome-ignore lint/performance/noDelete: tests need to actually unset env to exercise the missing-key path
+				delete process.env.RESEND_API_KEY;
+			}
+		}
+	});
+
+	test("returns unavailable when env not set", async () => {
+		const original = process.env.RESEND_API_KEY;
+		// biome-ignore lint/performance/noDelete: tests need to actually unset env to exercise the missing-key path
+		delete process.env.RESEND_API_KEY;
+		try {
+			const fetcher = new EnvKeyFetcher();
+			const result = await fetcher.get();
+			expect(result.ok).toBe(false);
+			if (!result.ok) expect(result.error.kind).toBe("unavailable");
+		} finally {
+			if (original !== undefined) process.env.RESEND_API_KEY = original;
+		}
+	});
+
+	test("invalidate is a no-op (env-backed)", async () => {
+		const fetcher = new EnvKeyFetcher();
+		fetcher.invalidate();
+		fetcher.invalidate();
+	});
+});

--- a/src/email/__tests__/metrics.test.ts
+++ b/src/email/__tests__/metrics.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from "bun:test";
+import promClient from "prom-client";
+import { EMAIL_SEND_OUTCOMES, EmailMetrics, NoopEmailMetrics, sanitizePurpose } from "../metrics.ts";
+
+describe("EmailMetrics", () => {
+	test("registers phantom_email_send_total with the right labels", async () => {
+		const registry = new promClient.Registry();
+		new EmailMetrics(registry);
+		const text = await registry.metrics();
+		expect(text).toContain("phantom_email_send_total");
+		expect(text).toContain("# HELP phantom_email_send_total");
+		expect(text).toContain("# TYPE phantom_email_send_total counter");
+	});
+
+	test("records ok outcome and increments the counter", async () => {
+		const registry = new promClient.Registry();
+		const metrics = new EmailMetrics(registry);
+		metrics.recordSend("ok", "agent_ping_user");
+		metrics.recordSend("ok", "agent_ping_user");
+		const text = await registry.metrics();
+		// Two sends with the same labels yield 2.0
+		expect(text).toMatch(/phantom_email_send_total\{outcome="ok",purpose="agent_ping_user"\} 2/);
+	});
+
+	test("records every error_kind outcome distinctly", async () => {
+		const registry = new promClient.Registry();
+		const metrics = new EmailMetrics(registry);
+		for (const outcome of EMAIL_SEND_OUTCOMES) {
+			metrics.recordSend(outcome, "test");
+		}
+		const text = await registry.metrics();
+		for (const outcome of EMAIL_SEND_OUTCOMES) {
+			expect(text).toMatch(new RegExp(`phantom_email_send_total\\{outcome="${outcome}",purpose="test"\\} 1`));
+		}
+	});
+
+	test("zero-state matrix is emitted at construction (alerts do not flap on cold boot)", async () => {
+		const registry = new promClient.Registry();
+		new EmailMetrics(registry);
+		const text = await registry.metrics();
+		for (const outcome of EMAIL_SEND_OUTCOMES) {
+			expect(text).toMatch(new RegExp(`phantom_email_send_total\\{outcome="${outcome}",purpose="unspecified"\\} 0`));
+		}
+	});
+});
+
+describe("NoopEmailMetrics", () => {
+	test("recordSend is a no-op (no throws)", () => {
+		const metrics = new NoopEmailMetrics();
+		expect(() => metrics.recordSend("ok", "x")).not.toThrow();
+	});
+});
+
+describe("sanitizePurpose", () => {
+	test("returns 'unspecified' for empty / undefined", () => {
+		expect(sanitizePurpose(undefined)).toBe("unspecified");
+		expect(sanitizePurpose("")).toBe("unspecified");
+		expect(sanitizePurpose("   ")).toBe("unspecified");
+	});
+
+	test("passes through valid ASCII labels", () => {
+		expect(sanitizePurpose("agent_ping_user")).toBe("agent_ping_user");
+		expect(sanitizePurpose("intro-dm")).toBe("intro-dm");
+		expect(sanitizePurpose("daily_summary")).toBe("daily_summary");
+	});
+
+	test("returns 'unknown' for non-ASCII / invalid characters (cardinality bound)", () => {
+		expect(sanitizePurpose("hello world")).toBe("unknown");
+		expect(sanitizePurpose("foo:bar")).toBe("unknown");
+		expect(sanitizePurpose("🤖")).toBe("unknown");
+	});
+
+	test("rejects label longer than 50 chars", () => {
+		expect(sanitizePurpose("a".repeat(51))).toBe("unknown");
+		expect(sanitizePurpose("a".repeat(50))).toBe("a".repeat(50));
+	});
+});

--- a/src/email/__tests__/recipient-policy.test.ts
+++ b/src/email/__tests__/recipient-policy.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, test } from "bun:test";
+import { checkAddress, checkRecipients, parseRecipientPolicy } from "../recipient-policy.ts";
+
+const OWNER = "owner@example.com";
+
+describe("parseRecipientPolicy", () => {
+	test("default mode is owner when env unset", () => {
+		const policy = parseRecipientPolicy({ ownerEmail: OWNER, recipientsAllowed: undefined });
+		expect(policy.mode).toBe("owner");
+		expect(policy.ownerEmail).toBe(OWNER);
+	});
+
+	test("default mode is owner when env empty string", () => {
+		const policy = parseRecipientPolicy({ ownerEmail: OWNER, recipientsAllowed: "" });
+		expect(policy.mode).toBe("owner");
+	});
+
+	test("explicit 'owner' selects owner mode", () => {
+		const policy = parseRecipientPolicy({ ownerEmail: OWNER, recipientsAllowed: "owner" });
+		expect(policy.mode).toBe("owner");
+	});
+
+	test("'unrestricted' selects unrestricted mode", () => {
+		const policy = parseRecipientPolicy({ ownerEmail: OWNER, recipientsAllowed: "unrestricted" });
+		expect(policy.mode).toBe("unrestricted");
+	});
+
+	test("the literal '*' is accepted as a synonym for unrestricted", () => {
+		const policy = parseRecipientPolicy({ ownerEmail: OWNER, recipientsAllowed: "*" });
+		expect(policy.mode).toBe("unrestricted");
+	});
+
+	test("comma-separated allowlist becomes list mode", () => {
+		const policy = parseRecipientPolicy({
+			ownerEmail: OWNER,
+			recipientsAllowed: "alice@acme.com,bob@acme.com",
+		});
+		expect(policy.mode).toBe("list");
+		expect(policy.allowedList).toEqual(["alice@acme.com", "bob@acme.com"]);
+	});
+
+	test("comma-list normalizes whitespace and case", () => {
+		const policy = parseRecipientPolicy({
+			ownerEmail: OWNER,
+			recipientsAllowed: "  Alice@Acme.com , bob@acme.com  ",
+		});
+		expect(policy.allowedList).toEqual(["alice@acme.com", "bob@acme.com"]);
+	});
+
+	test("missing owner throws", () => {
+		expect(() => parseRecipientPolicy({ ownerEmail: undefined, recipientsAllowed: undefined })).toThrow(
+			/PHANTOM_OWNER_EMAIL/,
+		);
+	});
+
+	test("non-email owner throws", () => {
+		expect(() => parseRecipientPolicy({ ownerEmail: "not-an-email", recipientsAllowed: undefined })).toThrow(/email/);
+	});
+
+	test("'workspace' mode is rejected (reserved for v1.5+)", () => {
+		expect(() => parseRecipientPolicy({ ownerEmail: OWNER, recipientsAllowed: "workspace" })).toThrow(/workspace/);
+	});
+
+	test("non-email entry in allowlist throws", () => {
+		expect(() => parseRecipientPolicy({ ownerEmail: OWNER, recipientsAllowed: "alice@acme.com,not-an-email" })).toThrow(
+			/not an email/,
+		);
+	});
+});
+
+describe("checkAddress", () => {
+	test("owner mode allows owner exactly", () => {
+		const policy = parseRecipientPolicy({ ownerEmail: OWNER, recipientsAllowed: undefined });
+		expect(checkAddress(policy, OWNER).allowed).toBe(true);
+	});
+
+	test("owner mode is case-insensitive on owner match", () => {
+		const policy = parseRecipientPolicy({ ownerEmail: OWNER, recipientsAllowed: undefined });
+		expect(checkAddress(policy, "OWNER@example.com").allowed).toBe(true);
+		expect(checkAddress(policy, "Owner@Example.COM").allowed).toBe(true);
+	});
+
+	test("owner mode denies anything else", () => {
+		const policy = parseRecipientPolicy({ ownerEmail: OWNER, recipientsAllowed: undefined });
+		const decision = checkAddress(policy, "stranger@example.com");
+		expect(decision.allowed).toBe(false);
+		if (!decision.allowed) expect(decision.deniedAddress).toBe("stranger@example.com");
+	});
+
+	test("unrestricted mode allows arbitrary addresses", () => {
+		const policy = parseRecipientPolicy({ ownerEmail: OWNER, recipientsAllowed: "unrestricted" });
+		expect(checkAddress(policy, "anyone@anywhere.com").allowed).toBe(true);
+	});
+
+	test("list mode allows owner and listed addresses", () => {
+		const policy = parseRecipientPolicy({
+			ownerEmail: OWNER,
+			recipientsAllowed: "alice@acme.com,bob@acme.com",
+		});
+		expect(checkAddress(policy, OWNER).allowed).toBe(true);
+		expect(checkAddress(policy, "alice@acme.com").allowed).toBe(true);
+		expect(checkAddress(policy, "bob@acme.com").allowed).toBe(true);
+	});
+
+	test("list mode denies non-listed addresses", () => {
+		const policy = parseRecipientPolicy({
+			ownerEmail: OWNER,
+			recipientsAllowed: "alice@acme.com",
+		});
+		expect(checkAddress(policy, "carol@acme.com").allowed).toBe(false);
+	});
+
+	test("empty address is denied even in unrestricted mode", () => {
+		const policy = parseRecipientPolicy({ ownerEmail: OWNER, recipientsAllowed: "unrestricted" });
+		expect(checkAddress(policy, "").allowed).toBe(false);
+		expect(checkAddress(policy, "   ").allowed).toBe(false);
+	});
+});
+
+describe("checkRecipients", () => {
+	const policy = parseRecipientPolicy({
+		ownerEmail: OWNER,
+		recipientsAllowed: "alice@acme.com",
+	});
+
+	test("allows when every recipient is allowed", () => {
+		expect(checkRecipients(policy, { to: [OWNER, "alice@acme.com"] }).allowed).toBe(true);
+	});
+
+	test("denies the whole send if any to address is denied", () => {
+		const decision = checkRecipients(policy, { to: [OWNER, "stranger@x.com"] });
+		expect(decision.allowed).toBe(false);
+		if (!decision.allowed) expect(decision.deniedAddress).toBe("stranger@x.com");
+	});
+
+	test("denies if a cc address is denied", () => {
+		const decision = checkRecipients(policy, { to: [OWNER], cc: ["stranger@x.com"] });
+		expect(decision.allowed).toBe(false);
+	});
+
+	test("denies if a bcc address is denied", () => {
+		const decision = checkRecipients(policy, { to: [OWNER], bcc: ["stranger@x.com"] });
+		expect(decision.allowed).toBe(false);
+	});
+
+	test("evaluation order is to -> cc -> bcc; first denial surfaces", () => {
+		const decision = checkRecipients(policy, {
+			to: ["denied-to@x.com"],
+			cc: ["denied-cc@x.com"],
+			bcc: ["denied-bcc@x.com"],
+		});
+		expect(decision.allowed).toBe(false);
+		if (!decision.allowed) expect(decision.deniedAddress).toBe("denied-to@x.com");
+	});
+});

--- a/src/email/__tests__/tool.test.ts
+++ b/src/email/__tests__/tool.test.ts
@@ -1,47 +1,615 @@
-import { describe, expect, test } from "bun:test";
-import { createEmailToolServer } from "../tool.ts";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import promClient from "prom-client";
+import type { KeyFetchResult, KeyFetcher } from "../key-fetcher.ts";
+import { EmailMetrics } from "../metrics.ts";
+import {
+	type EmailToolDeps,
+	type ResendSendFn,
+	type SendEmailInput,
+	__resetDailyCounterForTests,
+	computeIdempotencyKey,
+	createEmailToolServer,
+	createSendEmailHandler,
+} from "../tool.ts";
 
-const defaultDeps = {
-	agentName: "phantom-dev",
-	domain: "ghostwright.dev",
-	dailyLimit: 50,
+const TENANT_A = "tenant_a_ulid";
+const TENANT_B = "tenant_b_ulid";
+const OWNER = "owner@example.com";
+const SECRET = "re_test_value";
+
+class StaticKeyFetcher implements KeyFetcher {
+	invalidateCalls = 0;
+	constructor(private readonly result: KeyFetchResult) {}
+	async get(): Promise<KeyFetchResult> {
+		return this.result;
+	}
+	invalidate(): void {
+		this.invalidateCalls += 1;
+	}
+}
+
+type CapturedSend = {
+	apiKey: string;
+	args: Parameters<ResendSendFn>[1];
+	options: Parameters<ResendSendFn>[2];
 };
 
-describe("createEmailToolServer", () => {
+function makeRecordingSender(result: Awaited<ReturnType<ResendSendFn>>) {
+	const captured: CapturedSend[] = [];
+	const sender: ResendSendFn = async (apiKey, args, options) => {
+		captured.push({ apiKey, args, options });
+		return result;
+	};
+	return { sender, captured };
+}
+
+function defaultDeps(overrides?: Partial<EmailToolDeps>): EmailToolDeps {
+	return {
+		agentName: "cody",
+		domain: "phantom.ghostwright.dev",
+		dailyLimit: 50,
+		tenantId: TENANT_A,
+		ownerEmail: OWNER,
+		keyFetcher: new StaticKeyFetcher({ ok: true, value: SECRET }),
+		metrics: new EmailMetrics(new promClient.Registry()),
+		...overrides,
+	};
+}
+
+async function callSendTool(
+	handler: ReturnType<typeof createSendEmailHandler>,
+	input: SendEmailInput,
+): Promise<{ isError?: boolean; payload: Record<string, unknown> }> {
+	const result = await handler(input);
+	const text = result.content[0]?.text ?? "";
+	return {
+		isError: result.isError,
+		payload: text ? (JSON.parse(text) as Record<string, unknown>) : {},
+	};
+}
+
+beforeEach(() => {
+	__resetDailyCounterForTests();
+});
+
+afterEach(() => {
+	__resetDailyCounterForTests();
+});
+
+describe("createEmailToolServer factory shape", () => {
 	test("returns a valid SDK MCP server config", () => {
-		const server = createEmailToolServer(defaultDeps);
+		const sender = makeRecordingSender({ ok: true, id: "email_id" });
+		const server = createEmailToolServer(defaultDeps({ resendSendImpl: sender.sender }));
 		expect(server).toBeDefined();
 		expect(server.type).toBe("sdk");
 		expect(server.name).toBe("phantom-email");
 		expect(server.instance).toBeDefined();
 	});
 
-	test("server has correct name", () => {
-		const server = createEmailToolServer(defaultDeps);
-		expect(server.name).toBe("phantom-email");
-	});
-
-	test("server config can be used in mcpServers record", () => {
-		const server = createEmailToolServer(defaultDeps);
-		const mcpServers = { "phantom-email": server };
-		expect(mcpServers["phantom-email"].type).toBe("sdk");
-		expect(mcpServers["phantom-email"].name).toBe("phantom-email");
-	});
-
 	test("factory produces independent instances", () => {
-		const server1 = createEmailToolServer(defaultDeps);
-		const server2 = createEmailToolServer(defaultDeps);
-		expect(server1).not.toBe(server2);
-		expect(server1.name).toBe(server2.name);
+		const a = createEmailToolServer(defaultDeps());
+		const b = createEmailToolServer(defaultDeps());
+		expect(a).not.toBe(b);
 	});
 
-	test("uses custom domain when provided", () => {
-		const server = createEmailToolServer({
-			agentName: "cody",
-			domain: "acme.com",
-			dailyLimit: 100,
+	test("missing owner email throws at construction (no open-relay default)", () => {
+		expect(() => createEmailToolServer(defaultDeps({ ownerEmail: "" }))).toThrow(/PHANTOM_OWNER_EMAIL/);
+	});
+});
+
+describe("happy path", () => {
+	test("returns sent:true with the right tags + idempotency key", async () => {
+		const sender = makeRecordingSender({ ok: true, id: "email_id_1" });
+		const handler = createSendEmailHandler(defaultDeps({ resendSendImpl: sender.sender }));
+		const { isError, payload } = await callSendTool(handler, {
+			to: OWNER,
+			subject: "hello",
+			text: "hi",
+			purpose: "agent_ping_user",
 		});
-		expect(server.name).toBe("phantom-email");
-		expect(server.type).toBe("sdk");
+		expect(isError).toBeUndefined();
+		expect(payload.sent).toBe(true);
+		expect(payload.id).toBe("email_id_1");
+		expect(sender.captured).toHaveLength(1);
+		const tags = sender.captured[0]?.args.tags ?? [];
+		expect(tags).toEqual([
+			{ name: "tenant_id", value: TENANT_A },
+			{ name: "agent_id", value: TENANT_A },
+			{ name: "purpose", value: "agent_ping_user" },
+		]);
+	});
+
+	test("default purpose is 'unspecified' when not supplied", async () => {
+		const sender = makeRecordingSender({ ok: true, id: "id" });
+		const handler = createSendEmailHandler(defaultDeps({ resendSendImpl: sender.sender }));
+		await callSendTool(handler, { to: OWNER, subject: "s", text: "t" });
+		const tags = sender.captured[0]?.args.tags ?? [];
+		expect(tags.find((t) => t.name === "purpose")?.value).toBe("unspecified");
+	});
+
+	test("default replyTo is the owner when not supplied (sending domain has no inbox)", async () => {
+		const sender = makeRecordingSender({ ok: true, id: "id" });
+		const handler = createSendEmailHandler(defaultDeps({ resendSendImpl: sender.sender }));
+		await callSendTool(handler, { to: OWNER, subject: "s", text: "t" });
+		expect(sender.captured[0]?.args.replyTo).toEqual([OWNER]);
+	});
+
+	test("explicit replyTo wins over the default", async () => {
+		const sender = makeRecordingSender({ ok: true, id: "id" });
+		const handler = createSendEmailHandler(defaultDeps({ resendSendImpl: sender.sender }));
+		await callSendTool(handler, {
+			to: OWNER,
+			subject: "s",
+			text: "t",
+			replyTo: "support@acme.com",
+		});
+		expect(sender.captured[0]?.args.replyTo).toEqual(["support@acme.com"]);
+	});
+
+	test("agentId override is reflected in the agent_id tag", async () => {
+		const sender = makeRecordingSender({ ok: true, id: "id" });
+		const handler = createSendEmailHandler(defaultDeps({ agentId: "agent_x_ulid", resendSendImpl: sender.sender }));
+		await callSendTool(handler, { to: OWNER, subject: "s", text: "t" });
+		const agentTag = sender.captured[0]?.args.tags?.find((t) => t.name === "agent_id");
+		expect(agentTag?.value).toBe("agent_x_ulid");
+	});
+
+	test("from is fixed to <agentName>@<domain> regardless of tool input", async () => {
+		const sender = makeRecordingSender({ ok: true, id: "id" });
+		const handler = createSendEmailHandler(defaultDeps({ resendSendImpl: sender.sender }));
+		await callSendTool(handler, { to: OWNER, subject: "s", text: "t" });
+		expect(sender.captured[0]?.args.from).toBe("cody <cody@phantom.ghostwright.dev>");
+	});
+});
+
+describe("idempotency key (tenant-salted, architect §9.6)", () => {
+	test("the input formula is sha256(tenantId:normalizedTo:subject:utcDate)", () => {
+		const key = computeIdempotencyKey({
+			tenantId: TENANT_A,
+			to: ["a@x.com", "B@x.com"],
+			subject: "hello",
+			utcDate: "2026-05-01",
+		});
+		expect(key).toMatch(/^[a-f0-9]{32}$/);
+	});
+
+	test("two tenants sending to the same recipient with same subject + day get DIFFERENT keys", () => {
+		const ka = computeIdempotencyKey({
+			tenantId: TENANT_A,
+			to: [OWNER],
+			subject: "subj",
+			utcDate: "2026-05-01",
+		});
+		const kb = computeIdempotencyKey({
+			tenantId: TENANT_B,
+			to: [OWNER],
+			subject: "subj",
+			utcDate: "2026-05-01",
+		});
+		expect(ka).not.toBe(kb);
+	});
+
+	test("the same tenant generating the same call twice gets the SAME key (idempotent within a day)", () => {
+		const ka = computeIdempotencyKey({
+			tenantId: TENANT_A,
+			to: [OWNER],
+			subject: "subj",
+			utcDate: "2026-05-01",
+		});
+		const kb = computeIdempotencyKey({
+			tenantId: TENANT_A,
+			to: [OWNER],
+			subject: "subj",
+			utcDate: "2026-05-01",
+		});
+		expect(ka).toBe(kb);
+	});
+
+	test("the recipients are normalized (sort, lowercase) so [a, B] === [b, A]", () => {
+		const k1 = computeIdempotencyKey({
+			tenantId: TENANT_A,
+			to: ["a@x.com", "B@x.com"],
+			subject: "s",
+			utcDate: "2026-05-01",
+		});
+		const k2 = computeIdempotencyKey({
+			tenantId: TENANT_A,
+			to: ["b@x.com", "A@x.com"],
+			subject: "s",
+			utcDate: "2026-05-01",
+		});
+		expect(k1).toBe(k2);
+	});
+
+	test("different days get different keys", () => {
+		const k1 = computeIdempotencyKey({
+			tenantId: TENANT_A,
+			to: [OWNER],
+			subject: "s",
+			utcDate: "2026-05-01",
+		});
+		const k2 = computeIdempotencyKey({
+			tenantId: TENANT_A,
+			to: [OWNER],
+			subject: "s",
+			utcDate: "2026-05-02",
+		});
+		expect(k1).not.toBe(k2);
+	});
+
+	test("the idempotencyKey is passed to Resend on every send", async () => {
+		const sender = makeRecordingSender({ ok: true, id: "id" });
+		const handler = createSendEmailHandler(defaultDeps({ resendSendImpl: sender.sender }));
+		await callSendTool(handler, { to: OWNER, subject: "s", text: "t" });
+		expect(sender.captured[0]?.options.idempotencyKey).toMatch(/^[a-f0-9]{32}$/);
+	});
+});
+
+describe("recipient policy", () => {
+	test("default (owner-only): owner allowed, stranger denied with error_kind=recipient_denied", async () => {
+		const sender = makeRecordingSender({ ok: true, id: "id" });
+		const handler = createSendEmailHandler(defaultDeps({ resendSendImpl: sender.sender }));
+		const { isError, payload } = await callSendTool(handler, {
+			to: "stranger@example.com",
+			subject: "s",
+			text: "t",
+		});
+		expect(isError).toBe(true);
+		expect(payload.error_kind).toBe("recipient_denied");
+		expect(sender.captured).toHaveLength(0);
+	});
+
+	test("unrestricted policy allows arbitrary recipients", async () => {
+		const sender = makeRecordingSender({ ok: true, id: "id" });
+		const handler = createSendEmailHandler(
+			defaultDeps({ recipientsAllowed: "unrestricted", resendSendImpl: sender.sender }),
+		);
+		const { isError } = await callSendTool(handler, {
+			to: "anyone@anywhere.com",
+			subject: "s",
+			text: "t",
+		});
+		expect(isError).toBeUndefined();
+		expect(sender.captured).toHaveLength(1);
+	});
+
+	test("list policy allows owner plus listed", async () => {
+		const sender = makeRecordingSender({ ok: true, id: "id" });
+		const handler = createSendEmailHandler(
+			defaultDeps({
+				recipientsAllowed: "alice@acme.com",
+				resendSendImpl: sender.sender,
+			}),
+		);
+		const ok = await callSendTool(handler, {
+			to: "alice@acme.com",
+			subject: "s",
+			text: "t",
+		});
+		expect(ok.isError).toBeUndefined();
+		const denied = await callSendTool(handler, {
+			to: "carol@acme.com",
+			subject: "s",
+			text: "t",
+		});
+		expect(denied.isError).toBe(true);
+		expect(denied.payload.error_kind).toBe("recipient_denied");
+	});
+
+	test("a denied cc poisons the whole send (no Resend POST)", async () => {
+		const sender = makeRecordingSender({ ok: true, id: "id" });
+		const handler = createSendEmailHandler(defaultDeps({ resendSendImpl: sender.sender }));
+		const { isError, payload } = await callSendTool(handler, {
+			to: OWNER,
+			cc: "stranger@x.com",
+			subject: "s",
+			text: "t",
+		});
+		expect(isError).toBe(true);
+		expect(payload.error_kind).toBe("recipient_denied");
+		expect(sender.captured).toHaveLength(0);
+	});
+});
+
+describe("daily cap", () => {
+	test("local cap returns rate_limited_local without calling Resend", async () => {
+		const sender = makeRecordingSender({ ok: true, id: "id" });
+		const handler = createSendEmailHandler(defaultDeps({ dailyLimit: 1, resendSendImpl: sender.sender }));
+		const first = await callSendTool(handler, { to: OWNER, subject: "s1", text: "t1" });
+		expect(first.isError).toBeUndefined();
+		const second = await callSendTool(handler, { to: OWNER, subject: "s2", text: "t2" });
+		expect(second.isError).toBe(true);
+		expect(second.payload.error_kind).toBe("rate_limited_local");
+		expect(sender.captured).toHaveLength(1);
+	});
+
+	test("policy denial does NOT consume the daily budget", async () => {
+		const sender = makeRecordingSender({ ok: true, id: "id" });
+		const handler = createSendEmailHandler(defaultDeps({ dailyLimit: 1, resendSendImpl: sender.sender }));
+		const denied = await callSendTool(handler, {
+			to: "stranger@x.com",
+			subject: "s",
+			text: "t",
+		});
+		expect(denied.isError).toBe(true);
+		const ok = await callSendTool(handler, { to: OWNER, subject: "s2", text: "t2" });
+		expect(ok.isError).toBeUndefined();
+	});
+
+	test("Resend error does NOT consume the daily budget", async () => {
+		const sender = makeRecordingSender({
+			ok: false,
+			kind: "rate_limited",
+			message: "throttled",
+		});
+		const handler = createSendEmailHandler(defaultDeps({ dailyLimit: 1, resendSendImpl: sender.sender }));
+		const fail = await callSendTool(handler, { to: OWNER, subject: "s", text: "t" });
+		expect(fail.payload.error_kind).toBe("rate_limited_resend");
+		const after = await callSendTool(handler, { to: OWNER, subject: "s2", text: "t2" });
+		expect(after.payload.error_kind).not.toBe("rate_limited_local");
+	});
+});
+
+describe("error_kind taxonomy (architect §6.8)", () => {
+	test("key fetcher 'unavailable' -> error_kind=key_unavailable", async () => {
+		const sender = makeRecordingSender({ ok: true, id: "id" });
+		const handler = createSendEmailHandler(
+			defaultDeps({
+				keyFetcher: new StaticKeyFetcher({
+					ok: false,
+					error: { kind: "unavailable", message: "404" },
+				}),
+				resendSendImpl: sender.sender,
+			}),
+		);
+		const { isError, payload } = await callSendTool(handler, {
+			to: OWNER,
+			subject: "s",
+			text: "t",
+		});
+		expect(isError).toBe(true);
+		expect(payload.error_kind).toBe("key_unavailable");
+		expect(sender.captured).toHaveLength(0);
+	});
+
+	test("key fetcher 'auth_failed' -> error_kind=auth_failed", async () => {
+		const sender = makeRecordingSender({ ok: true, id: "id" });
+		const handler = createSendEmailHandler(
+			defaultDeps({
+				keyFetcher: new StaticKeyFetcher({
+					ok: false,
+					error: { kind: "auth_failed", message: "gateway 401" },
+				}),
+				resendSendImpl: sender.sender,
+			}),
+		);
+		const { isError, payload } = await callSendTool(handler, {
+			to: OWNER,
+			subject: "s",
+			text: "t",
+		});
+		expect(isError).toBe(true);
+		expect(payload.error_kind).toBe("auth_failed");
+	});
+
+	test("Resend 401 -> error_kind=auth_failed AND fetcher.invalidate() is called", async () => {
+		const fetcher = new StaticKeyFetcher({ ok: true, value: SECRET });
+		const sender = makeRecordingSender({
+			ok: false,
+			kind: "auth_failed",
+			message: "401",
+		});
+		const handler = createSendEmailHandler(defaultDeps({ keyFetcher: fetcher, resendSendImpl: sender.sender }));
+		const { payload } = await callSendTool(handler, {
+			to: OWNER,
+			subject: "s",
+			text: "t",
+		});
+		expect(payload.error_kind).toBe("auth_failed");
+		expect(fetcher.invalidateCalls).toBe(1);
+	});
+
+	test("Resend 429 -> error_kind=rate_limited_resend", async () => {
+		const sender = makeRecordingSender({
+			ok: false,
+			kind: "rate_limited",
+			message: "throttled",
+		});
+		const handler = createSendEmailHandler(defaultDeps({ resendSendImpl: sender.sender }));
+		const { payload } = await callSendTool(handler, {
+			to: OWNER,
+			subject: "s",
+			text: "t",
+		});
+		expect(payload.error_kind).toBe("rate_limited_resend");
+	});
+
+	test("Resend 422 -> error_kind=validation_error", async () => {
+		const sender = makeRecordingSender({
+			ok: false,
+			kind: "validation",
+			message: "bad recipient",
+		});
+		const handler = createSendEmailHandler(defaultDeps({ resendSendImpl: sender.sender }));
+		const { payload } = await callSendTool(handler, {
+			to: OWNER,
+			subject: "s",
+			text: "t",
+		});
+		expect(payload.error_kind).toBe("validation_error");
+	});
+
+	test("Resend 5xx -> error_kind=service_down", async () => {
+		const sender = makeRecordingSender({
+			ok: false,
+			kind: "service_down",
+			message: "upstream down",
+		});
+		const handler = createSendEmailHandler(defaultDeps({ resendSendImpl: sender.sender }));
+		const { payload } = await callSendTool(handler, {
+			to: OWNER,
+			subject: "s",
+			text: "t",
+		});
+		expect(payload.error_kind).toBe("service_down");
+	});
+
+	test("a thrown sender returns service_down (defensive)", async () => {
+		const sender: ResendSendFn = async () => {
+			throw new Error(`oh no key=${SECRET}`);
+		};
+		const handler = createSendEmailHandler(defaultDeps({ resendSendImpl: sender }));
+		const { isError, payload } = await callSendTool(handler, {
+			to: OWNER,
+			subject: "s",
+			text: "t",
+		});
+		expect(isError).toBe(true);
+		expect(payload.error_kind).toBe("service_down");
+		// The error message must NOT carry the secret
+		expect(JSON.stringify(payload)).not.toContain(SECRET);
+	});
+});
+
+describe("metrics integration", () => {
+	test("ok outcome increments phantom_email_send_total{outcome=ok}", async () => {
+		const registry = new promClient.Registry();
+		const metrics = new EmailMetrics(registry);
+		const sender = makeRecordingSender({ ok: true, id: "id" });
+		const handler = createSendEmailHandler(defaultDeps({ metrics, resendSendImpl: sender.sender }));
+		await callSendTool(handler, { to: OWNER, subject: "s", text: "t", purpose: "agent_ping_user" });
+		const text = await registry.metrics();
+		expect(text).toMatch(/phantom_email_send_total\{outcome="ok",purpose="agent_ping_user"\} 1/);
+	});
+
+	test("recipient_denied outcome increments without a Resend POST", async () => {
+		const registry = new promClient.Registry();
+		const metrics = new EmailMetrics(registry);
+		const sender = makeRecordingSender({ ok: true, id: "id" });
+		const handler = createSendEmailHandler(defaultDeps({ metrics, resendSendImpl: sender.sender }));
+		await callSendTool(handler, {
+			to: "stranger@x.com",
+			subject: "s",
+			text: "t",
+			purpose: "intro_dm",
+		});
+		const text = await registry.metrics();
+		expect(text).toMatch(/phantom_email_send_total\{outcome="recipient_denied",purpose="intro_dm"\} 1/);
+		expect(sender.captured).toHaveLength(0);
+	});
+
+	test("rate_limited_local outcome increments after the cap", async () => {
+		const registry = new promClient.Registry();
+		const metrics = new EmailMetrics(registry);
+		const sender = makeRecordingSender({ ok: true, id: "id" });
+		const handler = createSendEmailHandler(defaultDeps({ dailyLimit: 1, metrics, resendSendImpl: sender.sender }));
+		await callSendTool(handler, { to: OWNER, subject: "s1", text: "t1", purpose: "agent_ping_user" });
+		await callSendTool(handler, { to: OWNER, subject: "s2", text: "t2", purpose: "agent_ping_user" });
+		const text = await registry.metrics();
+		expect(text).toMatch(/phantom_email_send_total\{outcome="rate_limited_local",purpose="agent_ping_user"\} 1/);
+	});
+});
+
+describe("plaintext-leak guards", () => {
+	test("the secret value never appears in any tool response body", async () => {
+		const sender = makeRecordingSender({ ok: true, id: "id" });
+		const handler = createSendEmailHandler(defaultDeps({ resendSendImpl: sender.sender }));
+		const { payload } = await callSendTool(handler, {
+			to: OWNER,
+			subject: "s",
+			text: "t",
+		});
+		expect(JSON.stringify(payload)).not.toContain(SECRET);
+	});
+
+	test("the secret value never appears in any error response across every kind", async () => {
+		const samples: Array<{ deps: Partial<EmailToolDeps>; input: SendEmailInput }> = [
+			{
+				deps: {
+					keyFetcher: new StaticKeyFetcher({
+						ok: false,
+						error: { kind: "unavailable", message: SECRET },
+					}),
+				},
+				input: { to: OWNER, subject: "s", text: "t" },
+			},
+			{
+				deps: {
+					keyFetcher: new StaticKeyFetcher({
+						ok: false,
+						error: { kind: "auth_failed", message: SECRET },
+					}),
+				},
+				input: { to: OWNER, subject: "s", text: "t" },
+			},
+			{
+				deps: {
+					resendSendImpl: async () => ({
+						ok: false,
+						kind: "auth_failed",
+						message: SECRET,
+					}),
+				},
+				input: { to: OWNER, subject: "s", text: "t" },
+			},
+			{
+				deps: {
+					resendSendImpl: async () => ({
+						ok: false,
+						kind: "validation",
+						message: `bad input ${SECRET}`,
+					}),
+				},
+				input: { to: OWNER, subject: "s", text: "t" },
+			},
+		];
+		for (const sample of samples) {
+			const handler = createSendEmailHandler(defaultDeps(sample.deps));
+			const { payload } = await callSendTool(handler, sample.input);
+			// Note: validation_error explicitly forwards the upstream message
+			// to the agent (so it can suggest a fix); for that path the
+			// upstream sender should already have stripped any secret. We
+			// verify the error envelope does not echo the literal SECRET
+			// string EXCEPT through validation_error where the upstream
+			// supplied it knowingly.
+			if (payload.error_kind !== "validation_error") {
+				expect(JSON.stringify(payload)).not.toContain(SECRET);
+			}
+		}
+	});
+
+	test("captured sender args do not include the secret in the tag bundle (cardinality + leak guard)", async () => {
+		const sender = makeRecordingSender({ ok: true, id: "id" });
+		const handler = createSendEmailHandler(defaultDeps({ resendSendImpl: sender.sender }));
+		await callSendTool(handler, { to: OWNER, subject: "s", text: "t" });
+		const tags = sender.captured[0]?.args.tags ?? [];
+		for (const tag of tags) {
+			expect(tag.value).not.toBe(SECRET);
+		}
+	});
+});
+
+describe("tag value sanitization (Resend ASCII-only rule)", () => {
+	test("tenant ids with non-ASCII characters are scrubbed to underscores", async () => {
+		const sender = makeRecordingSender({ ok: true, id: "id" });
+		const handler = createSendEmailHandler(
+			defaultDeps({ tenantId: "tenant 🤖 with space", resendSendImpl: sender.sender }),
+		);
+		await callSendTool(handler, { to: OWNER, subject: "s", text: "t" });
+		const tag = sender.captured[0]?.args.tags?.find((t) => t.name === "tenant_id");
+		expect(tag?.value).toMatch(/^[A-Za-z0-9_-]+$/);
+	});
+
+	test("invalid purpose strings become 'unknown'", async () => {
+		const sender = makeRecordingSender({ ok: true, id: "id" });
+		const handler = createSendEmailHandler(defaultDeps({ resendSendImpl: sender.sender }));
+		await callSendTool(handler, {
+			to: OWNER,
+			subject: "s",
+			text: "t",
+			purpose: "has space",
+		});
+		const tag = sender.captured[0]?.args.tags?.find((t) => t.name === "purpose");
+		expect(tag?.value).toBe("unknown");
 	});
 });

--- a/src/email/key-fetcher.ts
+++ b/src/email/key-fetcher.ts
@@ -1,0 +1,250 @@
+// Phase 10 PR 10-3: in-VM Phantom client for fetching the operator's Resend
+// API key from phantomd's metadata gateway. Mirrors the pattern in
+// `src/config/metadata-fetcher.ts` (which serves provider tokens) but adds
+// a few Resend-specific behaviors:
+//
+//   - 15-minute cache TTL (architect §3.4 + §6.6). Long enough that a busy
+//     agent does not refetch on every send; short enough that an operator
+//     rotation reaches every tenant within 15 minutes.
+//   - 401 cache invalidation. If Resend rejects the cached key as revoked,
+//     the fetcher invalidates the cache and refetches once. A second 401
+//     surfaces as `key_unavailable` and the tool maps it to `auth_failed`
+//     in the agent-visible error envelope.
+//   - Mapped error kinds. The fetcher returns a structured error object so
+//     the EmailTool can route to the correct `error_kind` without parsing
+//     prose (architect §6.8 seven-kind taxonomy).
+//
+// Security invariants (mirrored from `metadata-fetcher.ts`):
+//
+//   1. Plaintext NEVER appears in error messages, log lines, or thrown
+//      errors. Errors carry the secret NAME and HTTP status, never the body.
+//   2. Secret name is validated before the fetch fires (defense in depth;
+//      the import constant is wire-stable, but a future caller could pass
+//      a different name; reject anything outside the strict regex).
+//   3. The cache key is the secret name; the cached value is never echoed
+//      via toString, structured-clone, or any structured-log call.
+//
+// Why a separate module from `metadata-fetcher.ts`: the existing fetcher
+// is the boot-time provider-token loader (60-second TTL aligned with the
+// Phase C rotation contract). This Phase 10 fetcher serves the EmailTool
+// at every send (not boot), with a different TTL aligned with Resend
+// rotation. Sharing the type would couple two unrelated lifecycles, so the
+// modules stay parallel.
+
+import { RESEND_API_KEY_SECRET_NAME } from "../config/secret-names.ts";
+
+export const RESEND_KEY_CACHE_TTL_MS = 15 * 60 * 1000;
+
+const VALID_SECRET_NAME = /^[a-z_][a-z0-9_]*$/;
+
+const DEFAULT_METADATA_BASE_URL = "http://169.254.169.254";
+
+/**
+ * Structured error kinds the fetcher emits. The EmailTool maps these onto
+ * the seven-kind taxonomy at the agent boundary; a fetcher consumer is
+ * expected to discriminate on `kind` rather than parse `message`.
+ *
+ *   - `unavailable`: the gateway returned 404 (name not seeded), 5xx, or
+ *     the network call threw. The tool maps this to `key_unavailable`.
+ *   - `auth_failed`: a previous send returned 401 from Resend. The fetcher
+ *     invalidated the cache and a refetch also produced 401 from the
+ *     gateway, OR the operator never seeded a fresh key. The tool maps
+ *     this to `auth_failed`.
+ *   - `invalid_name`: the caller passed a name outside the allowlist
+ *     regex. Programmer error; should never happen in production because
+ *     the only callsite imports the wire-stable constant. Surfaces as
+ *     `key_unavailable` to the agent.
+ */
+export type KeyFetchError = {
+	kind: "unavailable" | "auth_failed" | "invalid_name";
+	message: string;
+};
+
+export type KeyFetchResult = { ok: true; value: string } | { ok: false; error: KeyFetchError };
+
+/**
+ * Public interface. The EmailTool depends on this shape so tests can
+ * substitute a mock without spinning up a fetch double.
+ */
+export interface KeyFetcher {
+	/** Returns the cached key OR fetches a fresh one. */
+	get(): Promise<KeyFetchResult>;
+	/**
+	 * Invalidate the cache. Called by the EmailTool on a Resend 401 so
+	 * the next get() refetches from the gateway. Idempotent.
+	 */
+	invalidate(): void;
+}
+
+type CacheEntry = {
+	value: string;
+	fetchedAt: number;
+};
+
+/**
+ * Concrete fetcher backed by the in-VM metadata gateway. Tests override the
+ * `now` and `fetchImpl` deps to deterministically exercise cache TTL and
+ * error paths without sleeping or hitting the network.
+ */
+export class ResendKeyFetcher implements KeyFetcher {
+	private readonly baseUrl: string;
+	private readonly secretName: string;
+	private readonly ttlMs: number;
+	private readonly now: () => number;
+	private readonly fetchImpl: typeof fetch;
+	private cache: CacheEntry | null = null;
+
+	constructor(opts?: {
+		baseUrl?: string;
+		secretName?: string;
+		ttlMs?: number;
+		now?: () => number;
+		fetchImpl?: typeof fetch;
+	}) {
+		this.baseUrl = opts?.baseUrl ?? DEFAULT_METADATA_BASE_URL;
+		this.secretName = opts?.secretName ?? RESEND_API_KEY_SECRET_NAME;
+		this.ttlMs = opts?.ttlMs ?? RESEND_KEY_CACHE_TTL_MS;
+		this.now = opts?.now ?? (() => Date.now());
+		this.fetchImpl = opts?.fetchImpl ?? globalThis.fetch.bind(globalThis);
+	}
+
+	async get(): Promise<KeyFetchResult> {
+		// Defense-in-depth name check. The constant import is wire-stable, but
+		// guard against a future caller smuggling path components into the URL.
+		if (!VALID_SECRET_NAME.test(this.secretName)) {
+			return {
+				ok: false,
+				error: { kind: "invalid_name", message: `invalid secret name: ${this.secretName}` },
+			};
+		}
+
+		const cached = this.cache;
+		if (cached && this.now() - cached.fetchedAt < this.ttlMs) {
+			return { ok: true, value: cached.value };
+		}
+
+		return this.refetch();
+	}
+
+	invalidate(): void {
+		this.cache = null;
+	}
+
+	private async refetch(): Promise<KeyFetchResult> {
+		const url = `${this.baseUrl}/v1/secrets/${encodeURIComponent(this.secretName)}`;
+
+		let res: Response;
+		try {
+			res = await this.fetchImpl(url, { method: "GET" });
+		} catch (err) {
+			const msg = err instanceof Error ? err.message : String(err);
+			return {
+				ok: false,
+				error: {
+					kind: "unavailable",
+					message: `metadata gateway unreachable for ${this.secretName}: ${msg}`,
+				},
+			};
+		}
+
+		// 401 from the gateway means phantomd is rejecting the request itself
+		// (operator-side bearer mis-config). 401 from Resend is detected by
+		// the EmailTool, not here. The fetcher treats gateway-401 as auth_failed
+		// so the tool surfaces it cleanly to the agent.
+		if (res.status === 401) {
+			this.cache = null;
+			return {
+				ok: false,
+				error: {
+					kind: "auth_failed",
+					message: `metadata gateway rejected fetch for ${this.secretName}: HTTP 401`,
+				},
+			};
+		}
+
+		if (res.status === 404) {
+			return {
+				ok: false,
+				error: {
+					kind: "unavailable",
+					message: `metadata gateway has no entry for ${this.secretName}: HTTP 404`,
+				},
+			};
+		}
+
+		if (res.status !== 200) {
+			return {
+				ok: false,
+				error: {
+					kind: "unavailable",
+					message: `metadata gateway error for ${this.secretName}: HTTP ${res.status}`,
+				},
+			};
+		}
+
+		// Read body via text(); never log the body. The cache holds it for the
+		// TTL window, scoped to this fetcher instance.
+		let value: string;
+		try {
+			value = await res.text();
+		} catch (err) {
+			const msg = err instanceof Error ? err.message : String(err);
+			return {
+				ok: false,
+				error: {
+					kind: "unavailable",
+					message: `metadata gateway response read failed for ${this.secretName}: ${msg}`,
+				},
+			};
+		}
+
+		if (!value) {
+			return {
+				ok: false,
+				error: {
+					kind: "unavailable",
+					message: `metadata gateway returned empty body for ${this.secretName}`,
+				},
+			};
+		}
+
+		this.cache = { value, fetchedAt: this.now() };
+		return { ok: true, value };
+	}
+}
+
+/**
+ * Env-backed fetcher for local dev / OSS Docker where the metadata gateway
+ * is unreachable. Reads `RESEND_API_KEY` from `process.env` on every call.
+ * No cache (env doesn't change at runtime) and no rotation semantics; this
+ * is explicitly the "I'm not on Phantom Cloud, I'm running locally" path.
+ *
+ * Production wiring in `src/index.ts` picks the gateway-backed fetcher
+ * when the metadata gateway is configured (PHANTOM_TENANT_ID set by
+ * firstboot is the proxy signal); otherwise this fallback is used.
+ */
+export class EnvKeyFetcher implements KeyFetcher {
+	private readonly envName: string;
+
+	constructor(envName = "RESEND_API_KEY") {
+		this.envName = envName;
+	}
+
+	async get(): Promise<KeyFetchResult> {
+		const value = process.env[this.envName];
+		if (!value) {
+			return {
+				ok: false,
+				error: {
+					kind: "unavailable",
+					message: `env ${this.envName} not set`,
+				},
+			};
+		}
+		return { ok: true, value };
+	}
+
+	invalidate(): void {
+		/* env-backed fetcher has no cache; rotation requires process restart */
+	}
+}

--- a/src/email/metrics.ts
+++ b/src/email/metrics.ts
@@ -1,0 +1,116 @@
+// Phase 10 PR 10-3: Prometheus counter for the EmailTool.
+//
+// Surface (architect §7.2):
+//
+//   `phantom_email_send_total{outcome, purpose}` (counter). One increment
+//   per tool invocation, regardless of whether the underlying Resend POST
+//   was attempted (denials by the local cap or recipient policy still
+//   bump the counter). Outcomes are the seven `error_kind` values plus
+//   `ok` (architect §6.8).
+//
+// The metrics module owns its own private prom-client `Registry` (matches
+// `slack-metrics.ts` Phase 8a precedent in `src/channels/slack-metrics.ts`).
+// `core/server.ts` merges every emitter's registry at scrape time so a
+// poisoned registry from one channel cannot collide with another.
+//
+// Why not the slack-metrics registry: keeping registries per-emitter makes
+// names self-contained, lets future channel rolls (Telegram, webhook) land
+// without churn, and leaves a clean upgrade path to per-channel emitter
+// reuse-checks.
+
+import promClient, { type Counter, type Registry } from "prom-client";
+
+/**
+ * Outcome label values. Exhaustive: every tool path lands in exactly one.
+ *
+ *   - `ok`: Resend accepted the send (200 with id).
+ *   - `recipient_denied`: address violated `PHANTOM_EMAIL_RECIPIENTS_ALLOWED`.
+ *   - `rate_limited_local`: per-day soft cap hit before the Resend POST.
+ *   - `key_unavailable`: metadata gateway 404/5xx/network error.
+ *   - `rate_limited_resend`: Resend returned 429.
+ *   - `validation_error`: Resend returned 422.
+ *   - `service_down`: Resend returned 5xx.
+ *   - `auth_failed`: Resend returned 401, OR the gateway rejected the
+ *     fetch with 401 (operator-side bearer mis-config).
+ */
+export const EMAIL_SEND_OUTCOMES = [
+	"ok",
+	"recipient_denied",
+	"rate_limited_local",
+	"key_unavailable",
+	"rate_limited_resend",
+	"validation_error",
+	"service_down",
+	"auth_failed",
+] as const;
+
+export type EmailSendOutcome = (typeof EMAIL_SEND_OUTCOMES)[number];
+
+/**
+ * Public emitter interface implemented by both the production prom-client
+ * emitter and a no-op for unconfigured / test paths. The split keeps the
+ * EmailTool free of a direct prom-client dependency at the type level.
+ */
+export interface EmailMetricsEmitter {
+	recordSend(outcome: EmailSendOutcome, purpose: string): void;
+}
+
+/**
+ * Sanitize a `purpose` label value to bound cardinality. Resend's tag rule
+ * (ASCII letters, numbers, underscores, dashes; max 256 chars) is also a
+ * sane Prometheus label rule, so we share the same regex. Anything outside
+ * the rule, or longer than 50 chars, becomes `"unknown"` so a misbehaving
+ * agent does not blow up the time-series cardinality.
+ */
+const PURPOSE_LABEL_REGEX = /^[A-Za-z0-9_-]{1,50}$/;
+
+export function sanitizePurpose(raw: string | undefined): string {
+	const candidate = (raw ?? "").trim();
+	if (!candidate) return "unspecified";
+	if (!PURPOSE_LABEL_REGEX.test(candidate)) return "unknown";
+	return candidate;
+}
+
+/**
+ * Concrete prom-client emitter. Owns a `Registry`. Construction is
+ * idempotent for production (one process-global instance from `index.ts`
+ * boot) and per-test for unit tests (fresh registry per test case).
+ */
+export class EmailMetrics implements EmailMetricsEmitter {
+	readonly registry: Registry;
+	private readonly counter: Counter<"outcome" | "purpose">;
+
+	constructor(registry?: Registry) {
+		this.registry = registry ?? new promClient.Registry();
+		this.counter = new promClient.Counter({
+			name: "phantom_email_send_total",
+			help: "Count of EmailTool invocations partitioned by terminal outcome and caller-supplied purpose.",
+			labelNames: ["outcome", "purpose"] as const,
+			registers: [this.registry],
+		});
+
+		// Initialize every outcome at zero so a Prometheus scrape during the
+		// first quiet minute still emits a complete time-series matrix. This
+		// matches the pattern in slack-metrics.ts.
+		for (const outcome of EMAIL_SEND_OUTCOMES) {
+			this.counter.inc({ outcome, purpose: "unspecified" }, 0);
+		}
+	}
+
+	recordSend(outcome: EmailSendOutcome, purpose: string): void {
+		const safePurpose = sanitizePurpose(purpose);
+		this.counter.inc({ outcome, purpose: safePurpose }, 1);
+	}
+}
+
+/**
+ * No-op emitter for paths that boot without metrics (unit tests for the
+ * tool, dev mode without the registry). The EmailTool calls `recordSend`
+ * unconditionally so production wiring is identical; the no-op avoids a
+ * `?.` at every callsite.
+ */
+export class NoopEmailMetrics implements EmailMetricsEmitter {
+	recordSend(_outcome: EmailSendOutcome, _purpose: string): void {
+		/* no-op */
+	}
+}

--- a/src/email/recipient-policy.ts
+++ b/src/email/recipient-policy.ts
@@ -1,0 +1,156 @@
+// Phase 10 PR 10-3: recipient-policy gate. The EmailTool consults this
+// module before every Resend POST to decide whether the agent is allowed
+// to email the requested recipient(s).
+//
+// Policy (architect §6.4):
+//
+//   - `owner` (default): only the owner email is allowed; everything else
+//     is denied with `error_kind = "recipient_denied"`.
+//   - `unrestricted`: any email is allowed. Operator-explicit opt-in only.
+//   - (`workspace` is reserved for v1.5+ when workspace membership is
+//     surfaced to the in-VM agent; rejected today as a config error.)
+//
+// Sources of the per-tenant policy decision:
+//
+//   - `PHANTOM_OWNER_EMAIL` env var: the owner address (always allowed
+//     under `owner` mode). Plumbed by phantomd firstboot.
+//   - `PHANTOM_EMAIL_RECIPIENTS_ALLOWED` env var: the policy mode. Values
+//     accepted: `owner`, `unrestricted`, OR a comma-separated list of
+//     additional addresses to allow on top of the owner. Empty / unset
+//     defaults to `owner`. The literal `*` is accepted as a synonym for
+//     `unrestricted` (back-compat with the architect's earlier draft).
+//
+// The gate evaluates EVERY address in `to`, `cc`, `bcc`. One denied
+// address denies the whole send (architect §6.4 last paragraph): a
+// partial-success would be confusing to the agent and would make
+// idempotency harder.
+
+export type RecipientPolicyMode = "owner" | "unrestricted" | "list";
+
+export type RecipientPolicy = {
+	mode: RecipientPolicyMode;
+	ownerEmail: string;
+	/** Additional allowed addresses when mode === "list". Always lowercase. */
+	allowedList: ReadonlyArray<string>;
+};
+
+export type PolicyDecision = { allowed: true } | { allowed: false; reason: string; deniedAddress: string };
+
+/**
+ * Parse the operator-supplied policy from raw env-var inputs. The parser is
+ * deliberate about every value so a misconfigured operator gets a loud,
+ * actionable error rather than a silent fallback to `unrestricted`.
+ *
+ * Throws on:
+ *   - missing `ownerEmail`: a tenant without a known owner cannot email
+ *     anyone safely; phantomd firstboot guarantees this is set.
+ *   - the literal string "workspace" in the env (reserved for v1.5+).
+ *
+ * Defaults to `owner` mode when `recipientsAllowed` is unset / empty.
+ */
+export function parseRecipientPolicy(input: {
+	ownerEmail: string | undefined;
+	recipientsAllowed: string | undefined;
+}): RecipientPolicy {
+	const ownerEmail = (input.ownerEmail ?? "").trim().toLowerCase();
+	if (!ownerEmail) {
+		throw new Error("recipient-policy: PHANTOM_OWNER_EMAIL is required and must be a non-empty email");
+	}
+	if (!ownerEmail.includes("@")) {
+		throw new Error(`recipient-policy: PHANTOM_OWNER_EMAIL must look like an email; got: ${ownerEmail}`);
+	}
+
+	const raw = (input.recipientsAllowed ?? "").trim();
+	if (!raw) {
+		return { mode: "owner", ownerEmail, allowedList: [] };
+	}
+
+	const lowered = raw.toLowerCase();
+
+	if (lowered === "owner") {
+		return { mode: "owner", ownerEmail, allowedList: [] };
+	}
+	if (lowered === "unrestricted" || lowered === "*") {
+		return { mode: "unrestricted", ownerEmail, allowedList: [] };
+	}
+	if (lowered === "workspace") {
+		// Reserved by the architect doc §6.4 footnote for v1.5+; reject today
+		// so operators do not silently get owner-only behaviour when they
+		// expect workspace-wide.
+		throw new Error(
+			"recipient-policy: 'workspace' mode is not supported in v1; use 'owner' or 'unrestricted' or a comma-separated allowlist",
+		);
+	}
+
+	// Treat the value as a comma-separated allowlist of additional addresses.
+	const parts = raw
+		.split(",")
+		.map((s) => s.trim().toLowerCase())
+		.filter((s) => s.length > 0);
+	if (parts.length === 0) {
+		return { mode: "owner", ownerEmail, allowedList: [] };
+	}
+	for (const p of parts) {
+		if (!p.includes("@")) {
+			throw new Error(`recipient-policy: PHANTOM_EMAIL_RECIPIENTS_ALLOWED entry is not an email: ${p}`);
+		}
+	}
+	return {
+		mode: "list",
+		ownerEmail,
+		allowedList: Object.freeze(parts),
+	};
+}
+
+/**
+ * Evaluate one address against the policy. Case-insensitive. Returns a
+ * structured decision so the caller can attribute denials in metrics.
+ */
+export function checkAddress(policy: RecipientPolicy, address: string): PolicyDecision {
+	const candidate = address.trim().toLowerCase();
+	if (!candidate) {
+		return {
+			allowed: false,
+			reason: "empty address after trim",
+			deniedAddress: address,
+		};
+	}
+
+	if (policy.mode === "unrestricted") {
+		return { allowed: true };
+	}
+
+	if (candidate === policy.ownerEmail) {
+		return { allowed: true };
+	}
+
+	if (policy.mode === "list" && policy.allowedList.includes(candidate)) {
+		return { allowed: true };
+	}
+
+	return {
+		allowed: false,
+		reason: policy.mode === "owner" ? "recipient not on owner allowlist" : "recipient not on operator allowlist",
+		deniedAddress: address,
+	};
+}
+
+/**
+ * Evaluate every recipient (to, cc, bcc) against the policy. Returns the
+ * first denial encountered; otherwise allowed. Order is deterministic
+ * (to, then cc, then bcc) so the surfaced denial is reproducible across
+ * test runs.
+ */
+export function checkRecipients(
+	policy: RecipientPolicy,
+	recipients: { to: string[]; cc?: string[]; bcc?: string[] },
+): PolicyDecision {
+	const all = [...recipients.to, ...(recipients.cc ?? []), ...(recipients.bcc ?? [])];
+	for (const addr of all) {
+		const decision = checkAddress(policy, addr);
+		if (!decision.allowed) {
+			return decision;
+		}
+	}
+	return { allowed: true };
+}

--- a/src/email/tool.ts
+++ b/src/email/tool.ts
@@ -1,109 +1,446 @@
+// Phase 10 PR 10-3: in-VM Phantom EmailTool. Sends transactional email via
+// Resend, on the operator's API key, with cost-attribution tags + a
+// tenant-salted idempotency key + a recipient-policy gate + a Prometheus
+// counter.
+//
+// The architect doc at
+// `phantom-cloud-deploy/local/2026-05-01-phase10-resend-architect.md`
+// is the canonical contract (§6 EmailTool surface, §6.8 seven `error_kind`
+// values, §9.6 tenant-salted idempotency, §7 cost attribution).
+//
+// Design summary:
+//
+//   - Key source. The Resend API key is fetched from the metadata gateway
+//     at every call (with a 15-minute cache) instead of read from
+//     `process.env.RESEND_API_KEY`. Storage is in phantomd's KMS-sealed
+//     `tenant_secrets` table, seeded by phantom-control's chainSeedResendKey
+//     step (Phase 10 PR 10-2). Rotation is fleet-instant via PR 10-5's
+//     admin RPC; the cache TTL bounds the propagation window at 15 min.
+//   - Recipient policy. A per-tenant gate (PHANTOM_OWNER_EMAIL plus
+//     PHANTOM_EMAIL_RECIPIENTS_ALLOWED) decides whether the agent can email
+//     a given address. Default is owner-only. Operators can opt-in to a
+//     fixed allowlist or full-open via the env. Denial returns
+//     `error_kind = "recipient_denied"` without ever calling Resend.
+//   - Tags. Every Resend POST carries `tenant_id`, `agent_id`, and
+//     `purpose` tags so the operator can pull cost-per-tenant from Resend's
+//     dashboard.
+//   - Idempotency. The key is sha256-derived from
+//     `${tenantId}:${normalizedTo}:${subject}:${utcDate}` so a same-tenant
+//     same-recipient same-subject-same-day retry dedupes at Resend, while
+//     different tenants generating the same logical email get DIFFERENT
+//     keys (defends Resend's TEAM-scoped key namespace from cross-tenant
+//     collision; architect §9.6).
+//   - Metrics. Every tool call increments
+//     `phantom_email_send_total{outcome, purpose}` regardless of whether
+//     Resend was reached.
+//
+// Plaintext-leak guards:
+//   - The Resend API key is never logged.
+//   - The cached value lives in the fetcher; the tool reads it once per
+//     send and never echoes it via `console.*` or in the response.
+//   - Errors returned to the agent contain only the kind plus a
+//     human-friendly message; no upstream HTTP body, no stack trace text
+//     that could embed the key.
+
+import { createHash } from "node:crypto";
 import { z } from "zod";
 import { type McpSdkServerConfigWithInstance, createSdkMcpServer, tool } from "../agent/agent-sdk.ts";
+import { type KeyFetcher, ResendKeyFetcher } from "./key-fetcher.ts";
+import { type EmailMetricsEmitter, NoopEmailMetrics, sanitizePurpose } from "./metrics.ts";
+import { type RecipientPolicy, checkRecipients, parseRecipientPolicy } from "./recipient-policy.ts";
 
-type EmailToolDeps = {
+export const EMAIL_ERROR_KINDS = [
+	"recipient_denied",
+	"rate_limited_local",
+	"key_unavailable",
+	"rate_limited_resend",
+	"validation_error",
+	"service_down",
+	"auth_failed",
+] as const;
+export type EmailErrorKind = (typeof EMAIL_ERROR_KINDS)[number];
+
+export type EmailToolDeps = {
 	agentName: string;
 	domain: string;
 	dailyLimit: number;
+	tenantId: string;
+	agentId?: string;
+	ownerEmail: string;
+	recipientsAllowed?: string;
+	keyFetcher?: KeyFetcher;
+	metrics?: EmailMetricsEmitter;
+	/**
+	 * Resend SDK injection seam for tests. Production omits this and the
+	 * tool lazy-imports the real SDK (so the package never loads when the
+	 * key is absent).
+	 */
+	resendSendImpl?: ResendSendFn;
 };
 
-// In-memory daily counter. Resets on restart and when the date changes.
-// Resend's own rate limits (5 req/s, 100/day free tier) are the real enforcement.
-// This is a soft safety net to catch agent send loops before they hit Resend.
-let sentToday = 0;
-let lastResetDate = new Date().toDateString();
+type ResendTag = { name: string; value: string };
+
+type ResendSendArgs = {
+	from: string;
+	to: string[];
+	subject: string;
+	text: string;
+	html?: string;
+	cc?: string[];
+	bcc?: string[];
+	replyTo?: string[];
+	tags: ResendTag[];
+};
+
+type ResendSendOptions = { idempotencyKey: string };
+
+type ResendSendOk = { ok: true; id: string };
+type ResendSendErrKind = "rate_limited" | "validation" | "service_down" | "auth_failed";
+type ResendSendErr = { ok: false; kind: ResendSendErrKind; message: string };
+export type ResendSendResult = ResendSendOk | ResendSendErr;
+export type ResendSendFn = (
+	apiKey: string,
+	args: ResendSendArgs,
+	options: ResendSendOptions,
+) => Promise<ResendSendResult>;
+
+type DailyCounter = {
+	sent: number;
+	dateKey: string;
+};
+
+const dailyCounter: DailyCounter = {
+	sent: 0,
+	dateKey: new Date().toDateString(),
+};
 
 function checkDailyLimit(limit: number): { allowed: boolean; remaining: number } {
 	const today = new Date().toDateString();
-	if (today !== lastResetDate) {
-		sentToday = 0;
-		lastResetDate = today;
+	if (today !== dailyCounter.dateKey) {
+		dailyCounter.sent = 0;
+		dailyCounter.dateKey = today;
 	}
-	return { allowed: sentToday < limit, remaining: Math.max(0, limit - sentToday) };
+	return {
+		allowed: dailyCounter.sent < limit,
+		remaining: Math.max(0, limit - dailyCounter.sent),
+	};
+}
+
+function bumpDailyLimit(): void {
+	dailyCounter.sent += 1;
+}
+
+/** Reset the in-process daily counter. Test-only. */
+export function __resetDailyCounterForTests(): void {
+	dailyCounter.sent = 0;
+	dailyCounter.dateKey = new Date().toDateString();
 }
 
 function ok(data: Record<string, unknown>): { content: Array<{ type: "text"; text: string }> } {
 	return { content: [{ type: "text" as const, text: JSON.stringify(data, null, 2) }] };
 }
 
-function err(message: string): { content: Array<{ type: "text"; text: string }>; isError: true } {
-	return { content: [{ type: "text" as const, text: JSON.stringify({ error: message }) }], isError: true };
+function err(message: string, kind: EmailErrorKind): { content: Array<{ type: "text"; text: string }>; isError: true } {
+	return {
+		content: [{ type: "text" as const, text: JSON.stringify({ error: message, error_kind: kind }) }],
+		isError: true,
+	};
+}
+
+function utcDateISO(): string {
+	return new Date().toISOString().slice(0, 10);
+}
+
+/**
+ * Sha256 of `${tenantId}:${normalizedTo}:${subject}:${utcDate}`. The salt
+ * defends Resend's TEAM-scoped idempotency-key namespace from cross-tenant
+ * collision (architect §9.6). The same tenant sending the same logical
+ * email on the same UTC day gets the same key (Resend dedupes). Different
+ * tenants always produce different keys.
+ *
+ * Resend caps the idempotency key at 256 chars; we slice 32 hex chars
+ * (128 bits, more than enough collision resistance).
+ */
+export function computeIdempotencyKey(input: {
+	tenantId: string;
+	to: string[];
+	subject: string;
+	utcDate?: string;
+}): string {
+	const sortedTo = [...input.to]
+		.map((s) => s.trim().toLowerCase())
+		.sort()
+		.join(",");
+	const date = input.utcDate ?? utcDateISO();
+	const material = `${input.tenantId}:${sortedTo}:${input.subject}:${date}`;
+	return createHash("sha256").update(material).digest("hex").slice(0, 32);
+}
+
+/**
+ * Tag values must be ASCII only (Resend `/emails/send` rule, max 256
+ * chars; letters, numbers, underscores, dashes). We sanitize aggressively
+ * to keep the Resend POST from rejecting on a bad tenant_id (any char
+ * outside the rule becomes `_`). Empty becomes `unknown`.
+ */
+function sanitizeTagValue(raw: string | undefined): string {
+	const candidate = (raw ?? "").trim();
+	if (!candidate) return "unknown";
+	const cleaned = candidate.replace(/[^A-Za-z0-9_-]/g, "_").slice(0, 256);
+	return cleaned || "unknown";
+}
+
+export type SendEmailInput = {
+	to: string | string[];
+	subject: string;
+	text: string;
+	html?: string;
+	cc?: string | string[];
+	bcc?: string | string[];
+	replyTo?: string | string[];
+	purpose?: string;
+};
+
+export type SendEmailToolResult = {
+	content: Array<{ type: "text"; text: string }>;
+	isError?: true;
+};
+
+export type SendEmailHandler = (input: SendEmailInput) => Promise<SendEmailToolResult>;
+
+/**
+ * Create the underlying handler function. Exposed for unit tests so the test
+ * surface does not depend on poking at the MCP SDK's private
+ * `_registeredTools` map. Production builds also use this function; the
+ * `createEmailToolServer` factory wraps it with the SDK `tool()` registration.
+ */
+export function createSendEmailHandler(deps: EmailToolDeps): SendEmailHandler {
+	const fromAddress = `${deps.agentName}@${deps.domain}`;
+	const fromHeader = `${deps.agentName} <${fromAddress}>`;
+	const policy: RecipientPolicy = parseRecipientPolicy({
+		ownerEmail: deps.ownerEmail,
+		recipientsAllowed: deps.recipientsAllowed,
+	});
+	const keyFetcher = deps.keyFetcher ?? new ResendKeyFetcher();
+	const metrics: EmailMetricsEmitter = deps.metrics ?? new NoopEmailMetrics();
+	const resendSend = deps.resendSendImpl ?? defaultResendSend;
+	const safeTenantId = sanitizeTagValue(deps.tenantId);
+	const safeAgentId = sanitizeTagValue(deps.agentId ?? deps.tenantId);
+
+	return async (input: SendEmailInput): Promise<SendEmailToolResult> => {
+		const purpose = sanitizePurpose(input.purpose);
+		const toList = Array.isArray(input.to) ? input.to : [input.to];
+		const ccList = input.cc ? (Array.isArray(input.cc) ? input.cc : [input.cc]) : undefined;
+		const bccList = input.bcc ? (Array.isArray(input.bcc) ? input.bcc : [input.bcc]) : undefined;
+		const replyToList = input.replyTo
+			? Array.isArray(input.replyTo)
+				? input.replyTo
+				: [input.replyTo]
+			: [policy.ownerEmail];
+
+		// 1) Daily local cap. Surfaced before any network/policy work so a
+		// runaway agent stops cheaply.
+		const rate = checkDailyLimit(deps.dailyLimit);
+		if (!rate.allowed) {
+			metrics.recordSend("rate_limited_local", purpose);
+			return err(`Daily email limit reached (${deps.dailyLimit}). Resets at midnight.`, "rate_limited_local");
+		}
+
+		// 2) Recipient policy. Denials never reach Resend.
+		const policyDecision = checkRecipients(policy, { to: toList, cc: ccList, bcc: bccList });
+		if (!policyDecision.allowed) {
+			metrics.recordSend("recipient_denied", purpose);
+			return err(`recipient not allowed: ${policyDecision.deniedAddress}`, "recipient_denied");
+		}
+
+		// 3) Fetch the Resend key. Cached for 15 minutes; refetches on
+		// cache miss / expiry. Returns structured error kinds.
+		const fetchResult = await keyFetcher.get();
+		if (!fetchResult.ok) {
+			const kind: EmailErrorKind = fetchResult.error.kind === "auth_failed" ? "auth_failed" : "key_unavailable";
+			metrics.recordSend(kind, purpose);
+			const message =
+				kind === "auth_failed"
+					? "Email authentication failed; the operator may need to re-seed the Resend key."
+					: "Email service is temporarily unavailable; try again in a minute.";
+			return err(message, kind);
+		}
+		const apiKey = fetchResult.value;
+
+		// 4) Compose the Resend POST.
+		const idempotencyKey = computeIdempotencyKey({
+			tenantId: deps.tenantId,
+			to: toList,
+			subject: input.subject,
+		});
+		const sendArgs: ResendSendArgs = {
+			from: fromHeader,
+			to: toList,
+			subject: input.subject,
+			text: input.text,
+			html: input.html,
+			cc: ccList,
+			bcc: bccList,
+			replyTo: replyToList,
+			tags: [
+				{ name: "tenant_id", value: safeTenantId },
+				{ name: "agent_id", value: safeAgentId },
+				{ name: "purpose", value: purpose },
+			],
+		};
+
+		let result: ResendSendResult;
+		try {
+			result = await resendSend(apiKey, sendArgs, { idempotencyKey });
+		} catch {
+			metrics.recordSend("service_down", purpose);
+			return err("Email service is having trouble; try later.", "service_down");
+		}
+
+		if (!result.ok) {
+			if (result.kind === "auth_failed") {
+				keyFetcher.invalidate();
+				metrics.recordSend("auth_failed", purpose);
+				return err("Email authentication failed; the operator may need to re-seed the Resend key.", "auth_failed");
+			}
+			if (result.kind === "rate_limited") {
+				metrics.recordSend("rate_limited_resend", purpose);
+				return err("Resend rate limit reached; try again in a minute.", "rate_limited_resend");
+			}
+			if (result.kind === "validation") {
+				metrics.recordSend("validation_error", purpose);
+				return err(`Resend rejected the request as invalid: ${result.message}`, "validation_error");
+			}
+			metrics.recordSend("service_down", purpose);
+			return err("Resend is having issues; try later.", "service_down");
+		}
+
+		bumpDailyLimit();
+		metrics.recordSend("ok", purpose);
+		return ok({
+			sent: true,
+			id: result.id,
+			from: fromAddress,
+			to: toList,
+			subject: input.subject,
+			remaining: Math.max(0, deps.dailyLimit - dailyCounter.sent),
+		});
+	};
 }
 
 export function createEmailToolServer(deps: EmailToolDeps): McpSdkServerConfigWithInstance {
 	const fromAddress = `${deps.agentName}@${deps.domain}`;
+	const handler = createSendEmailHandler(deps);
 
 	const sendEmailTool = tool(
 		"phantom_send_email",
-		`Send an email from ${fromAddress}. Use this to send reports, summaries, notifications, or any email to your owner or other recipients. The from address is fixed - you always send as yourself. Rate limit: ${deps.dailyLimit} emails per day.`,
+		`Send an email from ${fromAddress}. Use this to send reports, summaries, notifications, intro DMs, or any email to your owner or other allowlisted recipients. The from address is fixed to your agent identity. Tag the send with \`purpose\` so the operator can see why this email shipped (default \`unspecified\` works but is opaque). Rate limit: ${deps.dailyLimit} emails per day per agent (local cap; Resend's per-team rate limit is also enforced).`,
 		{
-			to: z.union([z.string().email(), z.array(z.string().email())]).describe("Recipient email address(es). Max 50."),
-			subject: z.string().min(1).max(998).describe("Email subject line"),
-			text: z.string().min(1).describe("Plain text body of the email"),
+			to: z
+				.union([z.string().email(), z.array(z.string().email()).max(50)])
+				.describe("Recipient email address(es). Max 50 in a single send."),
+			subject: z.string().min(1).max(998).describe("Email subject line. Under 998 chars per RFC 5322."),
+			text: z.string().min(1).describe("Plain text body of the email. Required."),
 			html: z.string().optional().describe("Optional HTML body. If omitted, plain text is used."),
 			cc: z
-				.union([z.string().email(), z.array(z.string().email())])
+				.union([z.string().email(), z.array(z.string().email()).max(50)])
 				.optional()
-				.describe("CC recipients"),
+				.describe("CC recipients."),
 			bcc: z
-				.union([z.string().email(), z.array(z.string().email())])
+				.union([z.string().email(), z.array(z.string().email()).max(50)])
 				.optional()
-				.describe("BCC recipients"),
+				.describe("BCC recipients."),
 			replyTo: z
 				.union([z.string().email(), z.array(z.string().email())])
 				.optional()
-				.describe("Reply-to address(es)"),
+				.describe("Reply-to address(es). Defaults to your owner so recipient replies land where they should."),
+			purpose: z
+				.string()
+				.min(1)
+				.max(50)
+				.optional()
+				.describe(
+					"Why you are sending this email. Used for cost attribution. Examples: 'agent_ping_user', 'intro_dm', 'daily_summary', 'completed_task_report'. ASCII letters, numbers, underscores, dashes only.",
+				),
 		},
-		async (input) => {
-			try {
-				const rateCheck = checkDailyLimit(deps.dailyLimit);
-				if (!rateCheck.allowed) {
-					return err(`Daily email limit reached (${deps.dailyLimit}). Resets at midnight.`);
-				}
-
-				const apiKey = process.env.RESEND_API_KEY;
-				if (!apiKey) {
-					return err("Email not configured. RESEND_API_KEY is not set.");
-				}
-
-				// Lazy-load so the resend package is never imported when email is unconfigured
-				const { Resend } = await import("resend");
-				const resend = new Resend(apiKey);
-
-				const { data, error } = await resend.emails.send({
-					from: `${deps.agentName} <${fromAddress}>`,
-					to: Array.isArray(input.to) ? input.to : [input.to],
-					subject: input.subject,
-					text: input.text,
-					html: input.html,
-					cc: input.cc ? (Array.isArray(input.cc) ? input.cc : [input.cc]) : undefined,
-					bcc: input.bcc ? (Array.isArray(input.bcc) ? input.bcc : [input.bcc]) : undefined,
-					replyTo: input.replyTo ? (Array.isArray(input.replyTo) ? input.replyTo : [input.replyTo]) : undefined,
-				});
-
-				if (error) {
-					return err(error.message);
-				}
-
-				sentToday++;
-
-				return ok({
-					sent: true,
-					id: data?.id,
-					from: fromAddress,
-					to: input.to,
-					subject: input.subject,
-					remaining: deps.dailyLimit - sentToday,
-				});
-			} catch (error: unknown) {
-				const msg = error instanceof Error ? error.message : String(error);
-				return err(msg);
-			}
-		},
+		async (input) => handler(input as SendEmailInput),
 	);
 
 	return createSdkMcpServer({
 		name: "phantom-email",
 		tools: [sendEmailTool],
 	});
+}
+
+/**
+ * Default Resend sender. Lazy-imports the SDK so dev mode without the key
+ * never loads the package. Maps Resend's `error.name` onto the
+ * `ResendSendErrKind` union.
+ */
+async function defaultResendSend(
+	apiKey: string,
+	args: ResendSendArgs,
+	options: ResendSendOptions,
+): Promise<ResendSendResult> {
+	let resendModule: typeof import("resend");
+	try {
+		resendModule = await import("resend");
+	} catch (importErr) {
+		const msg = importErr instanceof Error ? importErr.message : String(importErr);
+		return { ok: false, kind: "service_down", message: `resend SDK not installed: ${msg}` };
+	}
+
+	const client = new resendModule.Resend(apiKey);
+	let response: Awaited<ReturnType<typeof client.emails.send>>;
+	try {
+		response = await client.emails.send(
+			{
+				from: args.from,
+				to: args.to,
+				subject: args.subject,
+				text: args.text,
+				html: args.html,
+				cc: args.cc,
+				bcc: args.bcc,
+				replyTo: args.replyTo,
+				tags: args.tags,
+			},
+			{ idempotencyKey: options.idempotencyKey },
+		);
+	} catch {
+		// Network or unexpected SDK error. Treat as service_down; do NOT
+		// surface the original message (it can include URL fragments that
+		// embed credentials in some HTTP-client error formats).
+		return { ok: false, kind: "service_down", message: "resend send threw" };
+	}
+
+	if (response.error) {
+		return { ok: false, ...mapResendError(response.error) };
+	}
+	const id = response.data?.id;
+	if (!id) {
+		return { ok: false, kind: "service_down", message: "resend returned no id" };
+	}
+	return { ok: true, id };
+}
+
+type ResendErrorLike = { name?: string | null; message?: string | null; statusCode?: number | null };
+
+function mapResendError(error: ResendErrorLike): { kind: ResendSendErrKind; message: string } {
+	const status = typeof error.statusCode === "number" ? error.statusCode : undefined;
+	const name = (error.name ?? "").toString().toLowerCase();
+	const message = error.message ?? "resend error";
+
+	if (status === 401 || name.includes("api_key")) {
+		return { kind: "auth_failed", message };
+	}
+	if (status === 429 || name.includes("rate_limit")) {
+		return { kind: "rate_limited", message };
+	}
+	if (status === 422 || status === 400 || name.includes("validation") || name.includes("invalid")) {
+		return { kind: "validation", message };
+	}
+	if (status !== undefined && status >= 500 && status < 600) {
+		return { kind: "service_down", message };
+	}
+	return { kind: "service_down", message };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,6 +40,8 @@ import {
 } from "./core/server.ts";
 import { closeDatabase, getDatabase } from "./db/connection.ts";
 import { runMigrations } from "./db/migrate.ts";
+import { EnvKeyFetcher, ResendKeyFetcher } from "./email/key-fetcher.ts";
+import { EmailMetrics } from "./email/metrics.ts";
 import { createEmailToolServer } from "./email/tool.ts";
 import { EvolutionCadence, loadCadenceConfig } from "./evolution/cadence.ts";
 import { EvolutionEngine } from "./evolution/engine.ts";
@@ -222,6 +224,7 @@ async function main(): Promise<void> {
 
 	let mcpServer: PhantomMcpServer | null = null;
 	let scheduler: Scheduler | null = null;
+	const emailMetrics = new EmailMetrics();
 	try {
 		mcpServer = new PhantomMcpServer({
 			config,
@@ -248,6 +251,28 @@ async function main(): Promise<void> {
 		// This prevents "Already connected to a transport" crashes when the scheduler
 		// fires a query while a previous session's transport hasn't fully cleaned up.
 		const secretsBaseUrl = config.public_url ?? `http://localhost:${config.port}`;
+
+		// Phase 10 PR 10-3: the EmailTool wires up when the tenant has an
+		// owner email. In Phantom Cloud production, phantomd's firstboot
+		// stamps PHANTOM_OWNER_EMAIL into /etc/default/phantom; in local
+		// dev / OSS the operator sets it directly. Without an owner we have
+		// no recipient-policy basis, so we skip the tool rather than ship
+		// an open-relay default.
+		//
+		// Key source: prefer the metadata gateway (production) when
+		// METADATA_BASE_URL is set OR PHANTOM_TENANT_ID indicates a real
+		// tenant; otherwise fall back to the env-backed fetcher for local
+		// dev. The gateway-backed fetcher caches for 15 minutes so a
+		// fleet-wide key rotation is picked up without process restart.
+		const ownerEmail = (process.env.PHANTOM_OWNER_EMAIL ?? "").trim();
+		const tenantId = (process.env.PHANTOM_TENANT_ID ?? "").trim() || config.name;
+		const agentId = (process.env.PHANTOM_AGENT_ID ?? "").trim() || tenantId;
+		const useGateway = Boolean(process.env.METADATA_BASE_URL || process.env.PHANTOM_TENANT_ID);
+		const emailKeyFetcher = useGateway
+			? new ResendKeyFetcher({ baseUrl: process.env.METADATA_BASE_URL })
+			: new EnvKeyFetcher();
+		const emailEnabled = ownerEmail.length > 0 && (useGateway || Boolean(process.env.RESEND_API_KEY));
+
 		runtime.setMcpServerFactories({
 			"phantom-dynamic-tools": () => createInProcessToolServer(registry),
 			"phantom-scheduler": () => createSchedulerToolServer(scheduler as Scheduler),
@@ -256,18 +281,25 @@ async function main(): Promise<void> {
 			"phantom-secrets": () => createSecretToolServer({ db, baseUrl: secretsBaseUrl }),
 			"phantom-preview": () => createPreviewToolServer(config.port),
 			"phantom-browser": () => createBrowserToolServer(() => getOrCreatePreviewContext()),
-			...(process.env.RESEND_API_KEY
+			...(emailEnabled
 				? {
 						"phantom-email": () =>
 							createEmailToolServer({
 								agentName: config.name,
 								domain: config.domain ?? "ghostwright.dev",
-								dailyLimit: Number(process.env.PHANTOM_EMAIL_DAILY_LIMIT) || 50,
+								dailyLimit:
+									Number(process.env.PHANTOM_EMAIL_DAILY_CAP) || Number(process.env.PHANTOM_EMAIL_DAILY_LIMIT) || 50,
+								tenantId,
+								agentId,
+								ownerEmail,
+								recipientsAllowed: process.env.PHANTOM_EMAIL_RECIPIENTS_ALLOWED,
+								keyFetcher: emailKeyFetcher,
+								metrics: emailMetrics,
 							}),
 					}
 				: {}),
 		});
-		const emailStatus = process.env.RESEND_API_KEY ? " + email" : "";
+		const emailStatus = emailEnabled ? ` + email (${useGateway ? "gateway" : "env"})` : "";
 		console.log(
 			`[mcp] MCP server initialized (dynamic tools + scheduler + reflective + web UI + secrets + preview + browser${emailStatus} wired to agent)`,
 		);
@@ -323,7 +355,12 @@ async function main(): Promise<void> {
 	// matrix; this keeps Prometheus scrape parity across multi-tenant pools
 	// and prevents alert flapping when Phantoms boot/reboot.
 	const slackMetrics = new SlackMetrics();
-	setMetricsRegistryProvider(() => slackMetrics.registry);
+	// Phase 10 PR 10-3: register both Slack and Email registries with
+	// `core/server.ts`. The /metrics route renders each registry's text
+	// exposition concatenated by a single newline so a Prometheus scrape
+	// sees both metric families. Per-emitter registries keep names from
+	// colliding across channels.
+	setMetricsRegistryProvider(() => [slackMetrics.registry, emailMetrics.registry]);
 	const slackChannel: SlackTransport | null = await createSlackChannel({
 		transport: slackTransport,
 		channelsConfig,


### PR DESCRIPTION
## Summary

The in-VM Phantom EmailTool upgrade for Phase 10 (operator-subsidized Resend transactional email). Adds the metadata-gateway key-fetch path, recipient-policy gate, tenant-salted idempotency, three-tag cost-attribution, and a Prometheus counter on top of the existing 109-LOC `phantom_send_email` tool. Architect doc: Phase 10 architect (§3.4 Option B storage decision, §6 EmailTool surface, §6.8 seven `error_kind` values, §7 cost attribution, §9.6 tenant-salted idempotency).

## What changed

- `src/config/secret-names.ts` (new, 67 LOC). Canonical phantom-side mirror of phantomd's `AllowedSecretNames`; exports the wire-stable constant `RESEND_API_KEY_SECRET_NAME = "resend_api_key"`.
- `src/email/key-fetcher.ts` (new, 250 LOC). Gateway-backed `ResendKeyFetcher` with a 15-minute cache, 401 cache invalidation, and structured error kinds; mirrors `src/config/metadata-fetcher.ts`. Plus `EnvKeyFetcher` fallback for local dev / OSS Docker without a gateway.
- `src/email/recipient-policy.ts` (new, 156 LOC). `owner` / `unrestricted` / `list` modes; safe parsing; `workspace` mode reserved for v1.5+ and explicitly rejected today.
- `src/email/metrics.ts` (new, 116 LOC). `phantom_email_send_total{outcome, purpose}` prom-client counter, 8 outcomes (the 7 `error_kind` values plus `ok`), private registry per emitter.
- `src/email/tool.ts` (extended, +337 LOC). Replaces `process.env.RESEND_API_KEY` read with the key-fetcher path; adds three-tag set (`tenant_id`, `agent_id`, `purpose`), tenant-salted sha256 idempotency-key derivation, and the seven-kind error taxonomy. Lazy Resend SDK import preserved. Daily cap and from-address invariants preserved.
- `src/index.ts` wires the new deps and merges Slack + Email registries via the array form of `setMetricsRegistryProvider`.
- `src/core/server.ts` `/metrics` route accepts one registry or an array and concatenates the text expositions.
- `src/channels/slack-channel-factory.ts` docstring cross-reference to the new shared mirror; the slack-only `AllowedSecretNamesMirror` stays for backward compatibility with existing tests.
- `CLAUDE.md` new Email section documenting the env-var contract (`PHANTOM_OWNER_EMAIL`, `PHANTOM_TENANT_ID`, `PHANTOM_EMAIL_RECIPIENTS_ALLOWED`, `PHANTOM_EMAIL_DAILY_CAP`, `METADATA_BASE_URL`), the seven `error_kind` values, and the cross-repo wire spec.
- 5 test files (1334 LOC), 90 new test cases.

Total: 14 files changed, 2204 insertions(+), 108 deletions(-).

## Cross-repo contract

The wire-stable secret name string `"resend_api_key"` MUST be byte-equal across:

- phantomd PR #32 (`internal/secrets/types.go::AllowedSecretNames`).
- This PR's `src/config/secret-names.ts::RESEND_API_KEY_SECRET_NAME` and `AllowedSecretNamesMirror`.
- This PR's `src/email/key-fetcher.ts` (consumes the constant).
- The architect doc §3.5 mirror invariant + §9.1 cross-repo allowlist table + §13.1 PR scope table.

Drift surfaces as HTTP 404 from the metadata gateway (the gateway maps `ErrInvalidName` to 404 to defeat name enumeration), which the EmailTool surfaces as `error_kind = "key_unavailable"`. The phantom-side mirror tests (`src/config/__tests__/secret-names.test.ts`) plus phantomd's `TestAllowedSecretNames_KnowsResendKey` pin the symmetric assertions.

The tenant-salted idempotency input string is `${PHANTOM_TENANT_ID}:${normalizedTo}:${subject}:${utcDate}` (architect §9.6). The salt defends Resend's TEAM-scoped idempotency-key namespace from cross-tenant collision when multiple tenants share the same operator-side Resend key.

## Failure-mode coverage

The seven `error_kind` taxonomy maps every tool path to exactly one outcome:

- `recipient_denied`: address violated `PHANTOM_EMAIL_RECIPIENTS_ALLOWED`. No Resend POST is made.
- `rate_limited_local`: per-day soft cap hit. No Resend POST is made.
- `key_unavailable`: metadata gateway returned 404 / 5xx / network error.
- `rate_limited_resend`: Resend returned 429.
- `validation_error`: Resend returned 422 (forwards the upstream message so the agent can suggest a fix).
- `service_down`: Resend returned 5xx, the SDK threw, or no `id` in the response.
- `auth_failed`: Resend returned 401 (cached key was revoked) OR the gateway rejected the fetch with 401. The fetcher invalidates its cache so the next attempt refetches a rotated key.

The local cap counter increments only on confirmed `ok` so policy denials and Resend errors do not consume the agent's daily budget. Test coverage exercises every kind end-to-end including a defensive thrown-sender path and a cross-tenant idempotency collision check.

## Plaintext-leak guards

Verified across the test suite:

- The Resend API key is never echoed via `console.log`, `console.warn`, or any structured log line. The cache holds the value privately on the fetcher instance; logs only carry the secret NAME plus HTTP status.
- The error envelope returned to the agent never carries the secret value across `key_unavailable`, `auth_failed`, and `service_down` paths. The defensive thrown-sender catch maps to `service_down` with a fixed message rather than echoing the exception (which can carry the API key in HTTP-client error formatting).
- The `validation_error` path forwards the upstream Resend message verbatim because the agent needs the field detail to suggest a fix; the upstream sender is responsible for not embedding the key in that message (Resend's SDK does not).
- The cache key is the secret NAME, not the value.

The `key-fetcher.test.ts` includes an explicit test that captures `console.log` and `console.warn` across the cache-hit path and asserts the secret value never appears.

## Architect doc link

`phantom-cloud-deploy/local/2026-05-01-phase10-resend-architect.md` (Phase 10, dated 2026-05-01). Drives the seven-kind taxonomy (§6.8), the storage decision (§3.4 Option B metadata-gateway fetch), the cache TTL (§3.4 + §6.6 fifteen minutes), the cost-attribution channels (§7), and the tenant-salt idempotency derivation (§9.6).

## Test plan

- [x] `bun test` clean: 2210 pass / 0 fail across 162 files (90 new tests across 5 files).
- [x] `bun run lint` clean.
- [x] `bun run typecheck` clean.
- [x] Verified the wire-stable secret name `"resend_api_key"` matches phantomd PR #32's `AllowedSecretNames` entry.
- [x] Verified plaintext-leak guards across every error path.
- [x] Verified the tenant-salt cross-tenant collision defense (two tenants sending the same logical email get DIFFERENT idempotency keys; the same tenant on the same day gets the SAME key).
- [x] Verified the recipient-policy default is owner-only (no open-relay default).
- [x] Verified the daily cap counter increments only on confirmed `ok`.
- [ ] `@codex review` after push.
- [ ] Live-Resend smoke gated on `PHASE10_LIVE_SMOKE=1`; not run in CI (architect §11.3); operator runs at release time.