### PR TITLE
Phase 18 PR-6: /health/build-info endpoint + migration-safety CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,15 @@ jobs:
       - name: Typecheck
         run: bun run typecheck
 
+      # Phase 18 PR-6: enforce the additive + idempotent migration contract on
+      # every PR. Phantom tenants survive a snapshot-replace upgrade by
+      # rsyncing /app/data/ from the old clone to the new clone, so a
+      # destructive migration here would corrupt every live tenant on the
+      # next upgrade. The gate walks src/db/schema.ts and rejects DROP
+      # TABLE / DROP COLUMN / RENAME / non-idempotent CREATE statements.
+      - name: Migration safety gate
+        run: bun run src/db/check-migrations.ts
+
       - name: Test
         run: bun test
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,9 +134,12 @@ src/
     tools.ts            # phantom_create_page, phantom_generate_login
     login-page.ts       # Login page HTML
   core/
-    server.ts           # Bun.serve() HTTP server, /health, /metrics, /trigger, /webhook, /ui
+    server.ts           # Bun.serve() HTTP server, /health, /health/build-info, /metrics, /trigger, /webhook, /ui
+    build-info.ts       # Reads /etc/phantom-build-info at request-time (Phase 18 PR-6)
   db/
-    schema.ts           # SQLite migrations (7 total)
+    schema.ts           # SQLite migrations (51 total; additive + idempotent contract)
+    migration-safety.ts # CI gate that walks schema.ts (Phase 18 PR-6)
+    check-migrations.ts # Entry point for the migration-safety gate
     connection.ts       # Database connection
 config/                 # YAML configs (phantom.yaml, channels.yaml, mcp.yaml, roles/)
 phantom-config/         # Evolved agent config (constitution, persona, domain knowledge)
@@ -273,6 +276,20 @@ Cross-repo invariants (byte-equality with neighbouring repos):
 - Status mapping (200 -> success, 404 -> expired/consumed/unknown, 400 -> bad shape, 403 -> cross-tenant, 429 -> rate limit, 5xx -> validator unavailable) mirrors the phantomd proxy at `magic_link_proxy.go::handleMagicLinkValidate`.
 
 Tests: `src/ui/__tests__/auth-magic.test.ts` (45 cases) covers happy path, every failure mode, every plaintext-leak guard, the full rate-limit semantics, the cross-tenant + owner-email gates, the open-redirect defense, and refresh survival. The route-wiring smoke is at `src/core/__tests__/server.test.ts::"GET /auth/magic"`.
+
+## Build identity (Phase 18 PR-6)
+
+Every phantom-rootfs image carries `/etc/phantom-build-info`, a small JSON file recording which phantom commit, which requested ref, when the rootfs was built, and adjacent provenance (full schema in `phantom-rootfs/Dockerfile` section 10b). The in-VM phantom exposes the file's contents at `GET /health/build-info` so an operator can verify what phantom version is actually running in a tenant VM:
+
+```
+curl https://<slug>.phantom.ghostwright.dev/health/build-info
+```
+
+Returns the JSON file verbatim. Schema fields: `schema_version` (currently `1`), `phantom_sha` (40-char hex), `phantom_ref_requested`, `phantom_ref_resolved`, `phantom_built_at`, `rootfs_image_name`, plus `murph_*` and `dockerfile_sha` provenance. Reconcile the response's `phantom_sha` against `phantomctl tenant get`'s `image_tag` field; mismatch indicates an upgrade in flight, a corrupted clone, or the daemon hasn't been restarted after a swap. Returns 404 with `error: "build_info_unavailable"` when the file is absent (a misconfigured dev container; production never sees this). The endpoint is unauthenticated, matching the `/health` precedent: per-tenant isolation comes from the per-tenant URL behind Caddy.
+
+The file is read at request-time and never cached in process memory, so an in-place upgrade that overwrites the file is reflected on the next request. Tests override the path via `PHANTOM_BUILD_INFO_PATH`.
+
+**Migration-safety CI gate.** Phantom tenants survive a snapshot-replace upgrade by rsyncing `/app/data/` (which contains `phantom.sqlite`) from the old ZFS clone to the new clone. Migrations therefore must be **additive** (no `DROP TABLE`, `DROP COLUMN`, `DROP CONSTRAINT`, `DROP INDEX`, no `RENAME`) and **idempotent** (`CREATE TABLE IF NOT EXISTS`, `CREATE INDEX IF NOT EXISTS`). `ALTER TABLE ... ADD COLUMN` is allowed because the runner's `_migrations` index gates re-execution. The gate runs in CI on every PR via `bun run src/db/check-migrations.ts`, fails closed on any violation, and rejects the PR. The full architectural argument lives in the Phase 18 architect doc §5.2.
 
 ## Key Design Decisions
 

--- a/src/core/__tests__/build-info.test.ts
+++ b/src/core/__tests__/build-info.test.ts
@@ -1,0 +1,174 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import YAML from "yaml";
+import { hashTokenSync } from "../../mcp/config.ts";
+import type { McpConfig } from "../../mcp/types.ts";
+import { readBuildInfo } from "../build-info.ts";
+import { startServer } from "../server.ts";
+
+/**
+ * Phase 18 PR-6: end-to-end coverage for the /health/build-info surface.
+ *
+ * The endpoint reads a JSON file at `/etc/phantom-build-info` (or whatever
+ * `PHANTOM_BUILD_INFO_PATH` points at). Tests redirect the path at a tmp
+ * file so they never touch /etc.
+ */
+describe("readBuildInfo", () => {
+	let tmpDir: string;
+	let path: string;
+
+	beforeEach(() => {
+		tmpDir = mkdtempSync(join(tmpdir(), "phantom-build-info-"));
+		path = join(tmpDir, "build-info");
+	});
+
+	afterEach(() => {
+		rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	test("returns parsed JSON when the file exists", async () => {
+		const payload = {
+			schema_version: 1,
+			phantom_ref_requested: "main",
+			phantom_ref_resolved: "abc1234",
+			phantom_sha: "abc1234deadbeef0000000000000000000000ff",
+			phantom_built_at: "2026-05-01T12:00:00Z",
+			rootfs_image_name: "phantom-rootfs",
+		};
+		writeFileSync(path, JSON.stringify(payload), "utf-8");
+
+		const result = await readBuildInfo(path);
+		expect(result.kind).toBe("ok");
+		if (result.kind !== "ok") return;
+		expect(result.parsed).toEqual(payload);
+		expect(result.raw).toBe(JSON.stringify(payload));
+	});
+
+	test("returns missing when the file is absent", async () => {
+		const result = await readBuildInfo(join(tmpDir, "does-not-exist"));
+		expect(result.kind).toBe("missing");
+	});
+
+	test("returns malformed when the file is not JSON", async () => {
+		writeFileSync(path, "not json{", "utf-8");
+		const result = await readBuildInfo(path);
+		expect(result.kind).toBe("malformed");
+	});
+
+	test("returns malformed when the file is JSON but not an object", async () => {
+		writeFileSync(path, JSON.stringify(["array", "instead"]), "utf-8");
+		const result = await readBuildInfo(path);
+		expect(result.kind).toBe("malformed");
+	});
+});
+
+describe("GET /health/build-info", () => {
+	const mcpConfigPath = "config/mcp.yaml";
+	let originalMcpYaml: string | null = null;
+	let server: ReturnType<typeof Bun.serve>;
+	let baseUrl: string;
+	let tmpDir: string;
+	let path: string;
+	let originalEnv: string | undefined;
+
+	beforeAll(() => {
+		if (existsSync(mcpConfigPath)) {
+			originalMcpYaml = readFileSync(mcpConfigPath, "utf-8");
+		}
+		const mcpConfig: McpConfig = {
+			tokens: [{ name: "admin", hash: hashTokenSync("test-admin"), scopes: ["read", "operator", "admin"] }],
+			rate_limit: { requests_per_minute: 60, burst: 10 },
+		};
+		mkdirSync("config", { recursive: true });
+		writeFileSync(mcpConfigPath, YAML.stringify(mcpConfig), "utf-8");
+
+		server = startServer({ name: "phantom", port: 0, role: "base" } as never, Date.now());
+		baseUrl = `http://localhost:${server.port}`;
+	});
+
+	afterAll(() => {
+		server?.stop(true);
+		if (originalMcpYaml !== null) {
+			writeFileSync(mcpConfigPath, originalMcpYaml, "utf-8");
+		}
+	});
+
+	beforeEach(() => {
+		tmpDir = mkdtempSync(join(tmpdir(), "phantom-build-info-route-"));
+		path = join(tmpDir, "build-info");
+		originalEnv = process.env.PHANTOM_BUILD_INFO_PATH;
+		process.env.PHANTOM_BUILD_INFO_PATH = path;
+	});
+
+	afterEach(() => {
+		if (originalEnv === undefined) {
+			// biome-ignore lint/performance/noDelete: tests must actually unset the env to exercise the default-path branch
+			delete process.env.PHANTOM_BUILD_INFO_PATH;
+		} else {
+			process.env.PHANTOM_BUILD_INFO_PATH = originalEnv;
+		}
+		rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	test("200 with the file's JSON when build-info exists", async () => {
+		const payload = {
+			schema_version: 1,
+			phantom_ref_requested: "v0.20.2",
+			phantom_ref_resolved: "abc1234",
+			phantom_sha: "abc1234deadbeef0000000000000000000000ff",
+			phantom_built_at: "2026-05-01T12:00:00Z",
+			murph_ref_requested: "main",
+			murph_ref_resolved: "def5678",
+			murph_sha: "def5678cafef00d00000000000000000000baad",
+			rootfs_image_name: "phantom-rootfs",
+			dockerfile_sha: "fedcba0987654321",
+		};
+		writeFileSync(path, JSON.stringify(payload), "utf-8");
+
+		const res = await fetch(`${baseUrl}/health/build-info`);
+		expect(res.status).toBe(200);
+		expect(res.headers.get("Content-Type")).toContain("application/json");
+		expect(res.headers.get("Cache-Control")).toBe("no-store");
+		const body = (await res.json()) as Record<string, unknown>;
+		expect(body).toEqual(payload);
+		expect(body.schema_version).toBe(1);
+		expect(typeof body.schema_version).toBe("number");
+	});
+
+	test("404 with a clean error when the file is missing", async () => {
+		const res = await fetch(`${baseUrl}/health/build-info`);
+		expect(res.status).toBe(404);
+		const body = (await res.json()) as { error: string };
+		expect(body.error).toBe("build_info_unavailable");
+	});
+
+	test("500 when the file is present but malformed", async () => {
+		writeFileSync(path, "{not json", "utf-8");
+		const res = await fetch(`${baseUrl}/health/build-info`);
+		expect(res.status).toBe(500);
+		const body = (await res.json()) as { error: string };
+		expect(body.error).toBe("build_info_malformed");
+	});
+
+	test("reads at request-time so an in-place file overwrite is reflected on the next request", async () => {
+		writeFileSync(path, JSON.stringify({ schema_version: 1, phantom_sha: "first" }), "utf-8");
+		let res = await fetch(`${baseUrl}/health/build-info`);
+		expect(res.status).toBe(200);
+		let body = (await res.json()) as { phantom_sha: string };
+		expect(body.phantom_sha).toBe("first");
+
+		writeFileSync(path, JSON.stringify({ schema_version: 1, phantom_sha: "second" }), "utf-8");
+		res = await fetch(`${baseUrl}/health/build-info`);
+		expect(res.status).toBe(200);
+		body = (await res.json()) as { phantom_sha: string };
+		expect(body.phantom_sha).toBe("second");
+	});
+
+	test("POST /health/build-info returns 404 (read-only contract)", async () => {
+		writeFileSync(path, JSON.stringify({ schema_version: 1 }), "utf-8");
+		const res = await fetch(`${baseUrl}/health/build-info`, { method: "POST" });
+		expect(res.status).toBe(404);
+	});
+});

--- a/src/core/build-info.ts
+++ b/src/core/build-info.ts
@@ -1,0 +1,68 @@
+import { readFile } from "node:fs/promises";
+
+/**
+ * Phase 18 PR-6: build-identity surface for the in-VM phantom.
+ *
+ * `/etc/phantom-build-info` is embedded into every phantom-rootfs image at
+ * Docker build time (see phantom-rootfs/Dockerfile section 10b). The file is
+ * a small JSON blob recording the resolved phantom commit SHA, the requested
+ * ref, the build wall-clock, and adjacent provenance. The host bare-metal
+ * `60-install-rootfs.sh` validates the same shape on every install.
+ *
+ * Operators query this endpoint to verify "what phantom version is actually
+ * running in this VM" and reconcile against `phantomctl tenant get`'s
+ * `image_tag`. Drift between the two means an upgrade is in flight, the
+ * clone is corrupt, or the daemon hasn't been restarted after a swap (see
+ * Phase 18 architect §7.4).
+ *
+ * The file is read at request-time, not cached in process memory. PR-2 and
+ * PR-4 of the Phase 18 plan preserve `/etc/phantom-build-info` across the
+ * snapshot-replace upgrade path; reading at request-time means an in-place
+ * upgrade that overwrites the file is reflected on the next request without
+ * a phantom restart.
+ */
+
+const DEFAULT_BUILD_INFO_PATH = "/etc/phantom-build-info";
+
+/**
+ * Resolve the build-info file path. Tests + dev containers override via the
+ * `PHANTOM_BUILD_INFO_PATH` env var. Production reads the baked-in default.
+ */
+export function buildInfoPath(): string {
+	return process.env.PHANTOM_BUILD_INFO_PATH ?? DEFAULT_BUILD_INFO_PATH;
+}
+
+export type BuildInfoReadResult =
+	| { kind: "ok"; raw: string; parsed: Record<string, unknown> }
+	| { kind: "missing" }
+	| { kind: "malformed"; error: string };
+
+/**
+ * Read and parse the build-info JSON. Pure file IO + JSON parse; no
+ * side-effects, no caching. The caller decides how to surface each result
+ * kind to the operator.
+ */
+export async function readBuildInfo(path: string = buildInfoPath()): Promise<BuildInfoReadResult> {
+	let raw: string;
+	try {
+		raw = await readFile(path, "utf-8");
+	} catch (err) {
+		const code = (err as NodeJS.ErrnoException).code;
+		if (code === "ENOENT") return { kind: "missing" };
+		// Other IO errors (EACCES, EISDIR) are also operator-fixable; surface as
+		// missing so the endpoint returns 404 with a clean error rather than
+		// crashing the request handler.
+		return { kind: "missing" };
+	}
+
+	try {
+		const parsed = JSON.parse(raw) as Record<string, unknown>;
+		if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+			return { kind: "malformed", error: "build-info is not a JSON object" };
+		}
+		return { kind: "ok", raw, parsed };
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		return { kind: "malformed", error: `build-info JSON parse error: ${message}` };
+	}
+}

--- a/src/core/server.ts
+++ b/src/core/server.ts
@@ -12,6 +12,7 @@ import type { SchedulerHealthSummary } from "../scheduler/health.ts";
 import { avatarUrlIfPresent, handleAvatarGet } from "../ui/api/identity.ts";
 import { handleAuthMagic } from "../ui/auth-magic.ts";
 import { getPublicDir, handleUiRequest } from "../ui/serve.ts";
+import { readBuildInfo } from "./build-info.ts";
 import { type HealthPayload, renderHealthHtml } from "./health-page.ts";
 
 const VERSION = "0.20.2";
@@ -184,6 +185,39 @@ export function startServer(config: PhantomConfig, startedAt: number): ReturnTyp
 				}
 
 				return Response.json(payload);
+			}
+
+			// Phase 18 PR-6: build-identity surface. Reads /etc/phantom-build-info
+			// at request-time (no in-process cache) and returns the JSON contents
+			// verbatim. Operators reconcile the response's `phantom_sha` against
+			// `phantomctl tenant get`'s `image_tag` to detect drift between what
+			// the host thinks is running and what the in-VM phantom actually
+			// loaded. Unauthenticated, matching the `/health` precedent: the
+			// build SHA is a public-repo value, and per-tenant isolation comes
+			// from the per-tenant URL behind Caddy. 404 when the file is absent
+			// so a misconfigured dev container surfaces a clean error rather
+			// than leaking other process state.
+			if (url.pathname === "/health/build-info" && req.method === "GET") {
+				const result = await readBuildInfo();
+				if (result.kind === "missing") {
+					return Response.json(
+						{
+							error: "build_info_unavailable",
+							message:
+								"phantom build-info file is not present on this filesystem; expected at /etc/phantom-build-info (set PHANTOM_BUILD_INFO_PATH to override)",
+						},
+						{ status: 404, headers: { "Cache-Control": "no-store" } },
+					);
+				}
+				if (result.kind === "malformed") {
+					return Response.json(
+						{ error: "build_info_malformed", message: result.error },
+						{ status: 500, headers: { "Cache-Control": "no-store" } },
+					);
+				}
+				return new Response(result.raw, {
+					headers: { "Content-Type": "application/json; charset=utf-8", "Cache-Control": "no-store" },
+				});
 			}
 
 			// Phase 8a: Prometheus metrics surface. Unauthenticated by design,

--- a/src/db/__tests__/migration-safety.test.ts
+++ b/src/db/__tests__/migration-safety.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, test } from "bun:test";
+import { checkMigrations, formatViolations, validateMigration } from "../migration-safety.ts";
+import { MIGRATIONS } from "../schema.ts";
+
+/**
+ * Phase 18 PR-6: migration-safety gate coverage.
+ *
+ * The gate enforces the additive + idempotent contract documented in
+ * `migration-safety.ts`. Coverage proves the rules fire on bad migrations,
+ * pass on good ones, and that the live `MIGRATIONS` array in `schema.ts`
+ * is currently clean.
+ */
+describe("validateMigration", () => {
+	test("flags DROP TABLE", () => {
+		const v = validateMigration("DROP TABLE legacy_tenants", 0);
+		expect(v.length).toBe(1);
+		expect(v[0].rule).toBe("no_drop_table");
+	});
+
+	test("flags lowercase drop table", () => {
+		const v = validateMigration("drop table legacy_tenants", 0);
+		expect(v.length).toBe(1);
+		expect(v[0].rule).toBe("no_drop_table");
+	});
+
+	test("flags ALTER TABLE ... DROP COLUMN", () => {
+		const v = validateMigration("ALTER TABLE sessions DROP COLUMN legacy_field", 0);
+		expect(v.length).toBe(1);
+		expect(v[0].rule).toBe("no_drop_column");
+	});
+
+	test("flags DROP CONSTRAINT", () => {
+		const v = validateMigration("ALTER TABLE sessions DROP CONSTRAINT pk_sessions", 0);
+		expect(v.length).toBe(1);
+		expect(v[0].rule).toBe("no_drop_constraint");
+	});
+
+	test("flags DROP INDEX", () => {
+		const v = validateMigration("DROP INDEX idx_sessions_key", 0);
+		expect(v.length).toBe(1);
+		expect(v[0].rule).toBe("no_drop_index");
+	});
+
+	test("flags ALTER TABLE ... RENAME COLUMN", () => {
+		const v = validateMigration("ALTER TABLE sessions RENAME COLUMN old_name TO new_name", 0);
+		expect(v.length).toBeGreaterThanOrEqual(1);
+		expect(v.some((x) => x.rule === "no_rename_column")).toBe(true);
+	});
+
+	test("flags ALTER TABLE ... RENAME TO", () => {
+		const v = validateMigration("ALTER TABLE sessions RENAME TO sessions_legacy", 0);
+		expect(v.some((x) => x.rule === "no_rename_table")).toBe(true);
+	});
+
+	test("flags CREATE TABLE without IF NOT EXISTS", () => {
+		const v = validateMigration("CREATE TABLE foo (id INTEGER PRIMARY KEY)", 0);
+		expect(v.length).toBe(1);
+		expect(v[0].rule).toBe("create_table_must_be_idempotent");
+	});
+
+	test("flags CREATE INDEX without IF NOT EXISTS", () => {
+		const v = validateMigration("CREATE INDEX idx_foo_id ON foo(id)", 0);
+		expect(v.length).toBe(1);
+		expect(v[0].rule).toBe("create_index_must_be_idempotent");
+	});
+
+	test("flags CREATE UNIQUE INDEX without IF NOT EXISTS", () => {
+		const v = validateMigration("CREATE UNIQUE INDEX idx_foo_id ON foo(id)", 0);
+		expect(v.length).toBe(1);
+		expect(v[0].rule).toBe("create_index_must_be_idempotent");
+	});
+
+	test("passes a clean CREATE TABLE IF NOT EXISTS", () => {
+		const v = validateMigration("CREATE TABLE IF NOT EXISTS foo (id INTEGER PRIMARY KEY)", 0);
+		expect(v.length).toBe(0);
+	});
+
+	test("passes CREATE INDEX IF NOT EXISTS", () => {
+		const v = validateMigration("CREATE INDEX IF NOT EXISTS idx_foo_id ON foo(id)", 0);
+		expect(v.length).toBe(0);
+	});
+
+	test("passes ALTER TABLE ADD COLUMN (idempotency comes from _migrations gate)", () => {
+		const v = validateMigration("ALTER TABLE sessions ADD COLUMN new_field TEXT", 0);
+		expect(v.length).toBe(0);
+	});
+
+	test("passes DELETE FROM data cleanup (no schema change)", () => {
+		const v = validateMigration("DELETE FROM dynamic_tools WHERE handler_type = 'inline'", 0);
+		expect(v.length).toBe(0);
+	});
+
+	test("ignores forbidden tokens that appear inside SQL line comments", () => {
+		const v = validateMigration(
+			"-- DROP TABLE was considered but rejected\nCREATE TABLE IF NOT EXISTS foo (id INTEGER PRIMARY KEY)",
+			0,
+		);
+		expect(v.length).toBe(0);
+	});
+});
+
+describe("checkMigrations", () => {
+	test("the live MIGRATIONS array passes the gate", () => {
+		const violations = checkMigrations();
+		expect(violations).toEqual([]);
+	});
+
+	test("MIGRATIONS array contains the expected count of statements (regression: schema.ts size)", () => {
+		// 51 entries as of Phase 10 PR 10-3. New entries push this number up;
+		// the test exists to flag accidental truncation, not to gate growth.
+		expect(MIGRATIONS.length).toBeGreaterThanOrEqual(51);
+	});
+
+	test("returns every violation across multiple bad statements", () => {
+		const fixture = [
+			"CREATE TABLE IF NOT EXISTS good (id INTEGER PRIMARY KEY)",
+			"DROP TABLE bad_one",
+			"CREATE TABLE bad_two (id INTEGER)",
+			"ALTER TABLE good DROP COLUMN id",
+		];
+		const violations = checkMigrations(fixture);
+		expect(violations.length).toBe(3);
+		expect(violations.map((v) => v.rule).sort()).toEqual([
+			"create_table_must_be_idempotent",
+			"no_drop_column",
+			"no_drop_table",
+		]);
+		expect(violations.find((v) => v.rule === "no_drop_table")?.index).toBe(1);
+		expect(violations.find((v) => v.rule === "create_table_must_be_idempotent")?.index).toBe(2);
+		expect(violations.find((v) => v.rule === "no_drop_column")?.index).toBe(3);
+	});
+});
+
+describe("formatViolations", () => {
+	test("returns empty string for an empty list", () => {
+		expect(formatViolations([])).toBe("");
+	});
+
+	test("includes rule names, indices, and detail text in the output", () => {
+		const formatted = formatViolations([
+			{ index: 7, statement: "DROP TABLE foo", rule: "no_drop_table", detail: "reason here" },
+		]);
+		expect(formatted).toContain("migration[7]");
+		expect(formatted).toContain("rule=no_drop_table");
+		expect(formatted).toContain("DROP TABLE foo");
+		expect(formatted).toContain("reason here");
+	});
+});

--- a/src/db/check-migrations.ts
+++ b/src/db/check-migrations.ts
@@ -1,0 +1,27 @@
+/**
+ * Phase 18 PR-6: migration-safety CI gate entry point.
+ *
+ * Run via `bun run src/db/check-migrations.ts`. Walks every migration string
+ * in `src/db/schema.ts` and checks each against the additive + idempotent
+ * contract. Exits non-zero with a human-readable violation list if any
+ * migration breaks the contract; exits 0 silently otherwise.
+ *
+ * The contract and rationale live in `migration-safety.ts`. The full
+ * architectural argument is in
+ * `phantom-cloud-deploy/local/2026-05-01-phase18-phantom-updates-flow-architect.md`
+ * §5.2 (the Phase 18 architect doc, private).
+ */
+
+import { checkMigrations, formatViolations } from "./migration-safety.ts";
+
+function main(): void {
+	const violations = checkMigrations();
+	if (violations.length === 0) {
+		console.log("migration-safety: ok");
+		return;
+	}
+	console.error(formatViolations(violations));
+	process.exit(1);
+}
+
+main();

--- a/src/db/migration-safety.ts
+++ b/src/db/migration-safety.ts
@@ -1,0 +1,181 @@
+import { MIGRATIONS } from "./schema.ts";
+
+/**
+ * Phase 18 PR-6: migration-safety gate.
+ *
+ * Phantom's tenants survive an upgrade by having their `/app/data/`
+ * directory rsynced from the old ZFS clone to the new clone (Phase 18
+ * architect §5.1). The SQLite file at `/app/data/phantom.sqlite` carries
+ * forward, including the `_migrations` index table. When the new phantom
+ * code boots in the new clone, `runMigrations` runs only the new entries.
+ *
+ * For this to be safe, every migration MUST be:
+ *
+ * 1. **Additive.** No `DROP TABLE`, no `DROP COLUMN`, no
+ *    `ALTER TABLE ... DROP CONSTRAINT`, no column renames. Removing or
+ *    renaming columns breaks the previous version's reads of the existing
+ *    data, which breaks the rollback-safety invariant (architect §5.2).
+ * 2. **Idempotent.** Running the same migration twice is the same as
+ *    running it once. New tables and indexes use `CREATE ... IF NOT
+ *    EXISTS`. SQLite's `ALTER TABLE ... ADD COLUMN` does not have an
+ *    `IF NOT EXISTS` clause, but the `_migrations` table makes the step
+ *    idempotent at the runner level (an already-applied index_num is
+ *    skipped).
+ *
+ * The contract is enforced as a CI gate. The gate walks the `MIGRATIONS`
+ * array, parses each statement, and rejects the PR if any violation is
+ * found. Invoke from CI via `bun run scripts/check-migrations.ts`.
+ *
+ * The gate is intentionally conservative: it blocks the patterns that
+ * have known-bad outcomes for the upgrade flow. It does not attempt to
+ * be a SQL parser. False positives are a feature, not a bug; an operator
+ * who needs a forbidden pattern must explicitly opt in (architect §5.2).
+ */
+
+export type MigrationViolation = {
+	index: number;
+	statement: string;
+	rule: string;
+	detail: string;
+};
+
+const FORBIDDEN_PATTERNS: ReadonlyArray<{ rule: string; pattern: RegExp; detail: string }> = [
+	{
+		rule: "no_drop_table",
+		pattern: /\bDROP\s+TABLE\b/i,
+		detail:
+			"DROP TABLE is forbidden because it deletes data the previous phantom version may still read, breaking rollback safety. To deprecate a table, leave it and mark it unused in code.",
+	},
+	{
+		rule: "no_drop_column",
+		pattern: /\bDROP\s+COLUMN\b/i,
+		detail:
+			"DROP COLUMN is forbidden because the previous phantom version's SELECTs against the column would fail after rollback. Leave the column in place and stop writing to it in code.",
+	},
+	{
+		rule: "no_drop_constraint",
+		pattern: /\bDROP\s+CONSTRAINT\b/i,
+		detail:
+			"ALTER TABLE ... DROP CONSTRAINT is forbidden because it changes the data shape in a way the previous phantom version cannot recover from after rollback.",
+	},
+	{
+		rule: "no_drop_index",
+		pattern: /\bDROP\s+INDEX\b/i,
+		detail:
+			"DROP INDEX is forbidden because it can change query plans in ways the previous version did not anticipate. Leave the index in place; if it is unused, the cost is negligible.",
+	},
+	{
+		rule: "no_rename_column",
+		pattern: /\bRENAME\s+COLUMN\b/i,
+		detail:
+			"RENAME COLUMN is forbidden because it breaks the previous phantom version's column references. Add a new column with the desired name, write to both, and remove the old column reads in a later version.",
+	},
+	{
+		rule: "no_rename_table",
+		pattern: /\bRENAME\s+TO\b/i,
+		detail:
+			"ALTER TABLE ... RENAME TO is forbidden for the same reason as RENAME COLUMN. Keep the original name; create a new table if the schema needs to evolve.",
+	},
+];
+
+/**
+ * Strip SQL line comments (`-- ...`) so they do not trigger pattern matches.
+ * Block comments are not used in phantom's migrations today; if introduced
+ * later, extend this stripper accordingly.
+ */
+function stripComments(statement: string): string {
+	return statement
+		.split("\n")
+		.map((line) => {
+			const idx = line.indexOf("--");
+			return idx >= 0 ? line.slice(0, idx) : line;
+		})
+		.join("\n");
+}
+
+/**
+ * Detect patterns that indicate non-idempotent statements. SQLite's only
+ * idempotent forms for table/index creation are CREATE ... IF NOT EXISTS.
+ * ALTER TABLE ADD COLUMN is allowed without IF NOT EXISTS because the
+ * `_migrations` table gates re-execution at the runner level.
+ */
+function checkIdempotency(statement: string, index: number): MigrationViolation[] {
+	const cleaned = stripComments(statement).trim();
+	const upper = cleaned.toUpperCase();
+	const violations: MigrationViolation[] = [];
+
+	if (/\bCREATE\s+TABLE\b/.test(upper) && !/\bCREATE\s+TABLE\s+IF\s+NOT\s+EXISTS\b/.test(upper)) {
+		violations.push({
+			index,
+			statement,
+			rule: "create_table_must_be_idempotent",
+			detail:
+				"CREATE TABLE must use IF NOT EXISTS so the migration step can run on a database that already has the table (e.g. the runner's _migrations gate is bypassed during recovery).",
+		});
+	}
+
+	if (/\bCREATE\b/.test(upper) && /\bINDEX\b/.test(upper) && !/\bIF\s+NOT\s+EXISTS\b/.test(upper)) {
+		violations.push({
+			index,
+			statement,
+			rule: "create_index_must_be_idempotent",
+			detail: "CREATE INDEX (and CREATE UNIQUE INDEX) must use IF NOT EXISTS for the same reason as CREATE TABLE.",
+		});
+	}
+
+	return violations;
+}
+
+/**
+ * Validate a single migration statement against the additive + idempotent
+ * contract. Returns an empty array if the statement is clean.
+ */
+export function validateMigration(statement: string, index: number): MigrationViolation[] {
+	const violations: MigrationViolation[] = [];
+	const cleaned = stripComments(statement);
+
+	for (const { rule, pattern, detail } of FORBIDDEN_PATTERNS) {
+		if (pattern.test(cleaned)) {
+			violations.push({ index, statement, rule, detail });
+		}
+	}
+
+	violations.push(...checkIdempotency(statement, index));
+
+	return violations;
+}
+
+/**
+ * Walk every migration string in `MIGRATIONS` and collect every violation.
+ * The CI gate fails the build if the returned array is non-empty.
+ */
+export function checkMigrations(statements: ReadonlyArray<string> = MIGRATIONS): MigrationViolation[] {
+	const violations: MigrationViolation[] = [];
+	for (let i = 0; i < statements.length; i++) {
+		violations.push(...validateMigration(statements[i], i));
+	}
+	return violations;
+}
+
+/**
+ * Format a violation list as a human-readable error block for the CI log.
+ */
+export function formatViolations(violations: ReadonlyArray<MigrationViolation>): string {
+	if (violations.length === 0) {
+		return "";
+	}
+
+	const lines: string[] = [`Migration-safety gate found ${violations.length} violation(s):`, ""];
+	for (const v of violations) {
+		const preview = v.statement.replace(/\s+/g, " ").trim().slice(0, 160);
+		lines.push(`- migration[${v.index}] rule=${v.rule}`);
+		lines.push(`  statement: ${preview}${preview.length === 160 ? "..." : ""}`);
+		lines.push(`  detail:    ${v.detail}`);
+		lines.push("");
+	}
+	lines.push("All phantom migrations must be additive (no DROP, no RENAME) and idempotent (CREATE ... IF NOT EXISTS).");
+	lines.push(
+		"See phantom-cloud-deploy/local/2026-05-01-phase18-phantom-updates-flow-architect.md §5.2 for the full contract.",
+	);
+	return lines.join("\n");
+}


### PR DESCRIPTION
## Summary

- Adds `GET /health/build-info` to the in-VM phantom HTTP server. Reads `/etc/phantom-build-info` (the JSON file embedded in every phantom-rootfs image at Docker build time) and returns it verbatim so operators can verify what phantom version is actually running inside a tenant VM.
- Adds a migration-safety CI gate at `src/db/check-migrations.ts` that walks `src/db/schema.ts` and rejects any non-additive or non-idempotent migration. Wired into `.github/workflows/ci.yml` as a fail-closed step.
- Adds a "Build identity" subsection to `CLAUDE.md` covering both surfaces.

## Why this matters

This is part 6 of the Phase 18 phantom-updates flow. PR-1 (content-addressable snapshots) and PR-7 (operations runbook) are already merged in adjacent repos. The Phase 18 model is per-tenant snapshot-replace upgrades: each tenant pins a phantom version via `tenants.image_tag = "phantom-rootfs:<sha7>"`, and an operator-driven upgrade swaps the tenant's ZFS clone to a new base while rsyncing `/app/data/` (which contains `phantom.sqlite`) from the old clone to the new one.

Two truth-source gaps that this PR closes:

1. **Operators have no in-VM truth-source for "what code is actually running."** `phantomctl tenant get` returns `image_tag` from the host's SQLite, but that is the operator's intended state, not the in-VM observed state. The new endpoint returns the JSON file phantom-rootfs's Dockerfile section 10b bakes in, with the resolved 40-char `phantom_sha`, the requested ref, the build wall-clock, the rootfs image name, and adjacent provenance. An operator reconciles the response against `image_tag` to detect drift (upgrade in flight, corrupted clone, or daemon not restarted after a swap).

2. **A destructive migration would corrupt every live tenant.** Because `/app/data/phantom.sqlite` rsyncs forward across an upgrade, any `DROP TABLE` / `DROP COLUMN` / `RENAME` migration would break the previous version's reads and break rollback safety. The CI gate enforces the contract on every PR before it can land.

## What ships

- `src/core/build-info.ts`: read-and-parse helper. Returns `{kind: "ok" | "missing" | "malformed"}`. Pure file IO, no caching.
- `src/core/server.ts`: new route handler at `GET /health/build-info`. 200 with the file contents, 404 with `error: "build_info_unavailable"` when missing, 500 with `error: "build_info_malformed"` when present-but-bad JSON. `Cache-Control: no-store` so the request-time read is honored end to end.
- `src/db/migration-safety.ts`: the gate library. Forbids `DROP TABLE`, `DROP COLUMN`, `DROP CONSTRAINT`, `DROP INDEX`, `RENAME COLUMN`, `RENAME TO`. Requires `CREATE TABLE IF NOT EXISTS` and `CREATE INDEX IF NOT EXISTS`. `ALTER TABLE ADD COLUMN` is allowed because the runner's `_migrations` index makes it idempotent at the runner level. Strips SQL line comments before pattern matching so commented-out forbidden tokens do not trigger false positives.
- `src/db/check-migrations.ts`: thin CLI runner. Exits 0 on clean, exits 1 with a human-readable violation list otherwise.
- `.github/workflows/ci.yml`: new "Migration safety gate" step between Typecheck and Test.
- `CLAUDE.md`: new "Build identity (Phase 18 PR-6)" section documenting both surfaces and the operator workflow.

## Architectural invariants

- **Read at request-time, never cached.** A future in-place upgrade that overwrites `/etc/phantom-build-info` is reflected on the next request without a phantom restart. Verified by an end-to-end test that overwrites the file mid-flight.
- **Read-only contract.** `Cache-Control: no-store`, GET-only. POSTs return 404. No side-effects.
- **Unauthenticated by design.** Matches the `/health` and `/metrics` precedent. Per-tenant isolation comes from the per-tenant URL behind Caddy. The build SHA is a public-repo value.
- **Schema version 1.** Locked. Future schema changes bump the integer; the test pins it as a number, not a string.
- **Path overridable via `PHANTOM_BUILD_INFO_PATH`.** Production reads the baked-in `/etc/phantom-build-info`; tests redirect at a tmp file.
- **Migration-safety gate is fail-closed.** Any violation fails CI and blocks the merge.

## Pre-existing migration audit

Walked all 51 entries in `src/db/schema.ts` against the new gate. Zero pre-existing violations. The gate passes cleanly on `main` today; this is the foundation for keeping it that way.

## Test plan

- [x] `bun typecheck` clean
- [x] `bun run lint` clean
- [x] `bun test` clean: 2337 pass / 0 fail / 10 skip / 1 todo (was 2308 pass before this PR; +29 new tests)
- [x] `bun run src/db/check-migrations.ts` reports `migration-safety: ok` on the live `MIGRATIONS` array
- [ ] Manual smoke against a real rootfs (deferred to Cheema's pre-merge check; the unit + integration tests cover the path that matters)

## Authority

Ships to `ghostwright/phantom` (PUBLIC). Per repo rules, this PR is operator-merge-only. The orchestrator pushes the branch and opens the PR; Cheema reviews and merges.

## Authoritative context

- Phase 18 architect doc: `phantom-cloud-deploy/local/2026-05-01-phase18-phantom-updates-flow-architect.md` §5.2 (migration contract), §7.4 (build-info endpoint), §11.6 (this PR's spec).
- `phantom-rootfs/Dockerfile` section 10b for the source of truth on the JSON shape.