### PR TITLE
ux(intro): co-worker-voiced first DM with morning-brief commitment + button confirmation

### DIFF
--- a/src/channels/__tests__/slack-http-receiver.test.ts
+++ b/src/channels/__tests__/slack-http-receiver.test.ts
@@ -726,18 +726,34 @@ describe("lifecycle and bot user discovery", () => {
 // ----- synthetic first DM on connect ---------------------------------------
 
 describe("synthetic first DM on connect", () => {
-	test("opens a DM with the installer and posts the introduction text", async () => {
+	test("opens a DM with the installer and posts the co-worker introduction text + Block Kit blocks", async () => {
 		const channel = new SlackHttpChannel(baseConfig);
 		channel.setPhantomName("Maple");
 		await channel.connect();
 
 		expect(mockConversationsOpen).toHaveBeenCalledWith({ users: "U_INSTALLER" });
-		const calls = mockPostMessage.mock.calls as unknown as Array<[{ channel?: string; text?: string }]>;
+		// The intro DM is now co-worker-voiced: "Hi there. I'm in. ... as
+		// Maple from now on." plus a Block Kit payload carrying the three
+		// morning-brief buttons. We pin both the phantom name in the text
+		// fallback AND the actions block_id so a regression that drops
+		// either fails loudly.
+		const calls = mockPostMessage.mock.calls as unknown as Array<
+			[{ channel?: string; text?: string; blocks?: Array<{ type: string; block_id?: string }> }]
+		>;
 		const introCall = calls.find((c) => {
 			const arg = c[0];
-			return arg.channel === "D_DM_OPEN" && typeof arg.text === "string" && arg.text.includes("I'm Maple");
+			return (
+				arg.channel === "D_DM_OPEN" &&
+				typeof arg.text === "string" &&
+				arg.text.includes("co-worker") &&
+				arg.text.includes("Maple")
+			);
 		});
 		expect(introCall).toBeDefined();
+		const blocks = introCall?.[0].blocks;
+		expect(Array.isArray(blocks)).toBe(true);
+		const actionsBlock = blocks?.find((b) => b.block_id === "phantom_morning_brief");
+		expect(actionsBlock).toBeDefined();
 	});
 
 	test("does not re-introduce on a reconnect after disconnect (firstDmSent gates)", async () => {

--- a/src/channels/__tests__/slack-introduction.test.ts
+++ b/src/channels/__tests__/slack-introduction.test.ts
@@ -1,5 +1,13 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import { composeIntroductionText, sendIntroductionDm } from "../slack-introduction.ts";
+import type { SlackBlock } from "../feedback.ts";
+import {
+	MORNING_BRIEF_LOCK_ACTION_ID,
+	MORNING_BRIEF_RETIME_ACTION_ID,
+	MORNING_BRIEF_SKIP_ACTION_ID,
+	composeIntroductionBlocks,
+	composeIntroductionText,
+	sendIntroductionDm,
+} from "../slack-introduction.ts";
 
 // Module-mock the heartbeat dependency before importing slack-introduction
 // so its `await reportFirstDmSent(...)` call lands on our recorder. This
@@ -24,6 +32,9 @@ mock.module("../../tenancy/heartbeat.ts", () => ({
 const ORIGINAL_METADATA = process.env.METADATA_BASE_URL;
 const ORIGINAL_TRANSPORT = process.env.SLACK_TRANSPORT;
 const ORIGINAL_DASHBOARD = process.env.PHANTOM_DASHBOARD_URL;
+const ORIGINAL_OWNER_NAME = process.env.PHANTOM_OWNER_NAME;
+const ORIGINAL_DOMAIN = process.env.PHANTOM_DOMAIN;
+const ORIGINAL_TENANT_SLUG = process.env.PHANTOM_TENANT_SLUG;
 
 beforeEach(() => {
 	heartbeatCalls.length = 0;
@@ -31,6 +42,9 @@ beforeEach(() => {
 	process.env.METADATA_BASE_URL = "http://169.254.169.254";
 	process.env.SLACK_TRANSPORT = "http";
 	process.env.PHANTOM_DASHBOARD_URL = undefined;
+	process.env.PHANTOM_OWNER_NAME = undefined;
+	process.env.PHANTOM_DOMAIN = undefined;
+	process.env.PHANTOM_TENANT_SLUG = undefined;
 });
 
 afterEach(() => {
@@ -49,37 +63,177 @@ afterEach(() => {
 	} else {
 		process.env.PHANTOM_DASHBOARD_URL = ORIGINAL_DASHBOARD;
 	}
+	if (ORIGINAL_OWNER_NAME === undefined) {
+		process.env.PHANTOM_OWNER_NAME = undefined;
+	} else {
+		process.env.PHANTOM_OWNER_NAME = ORIGINAL_OWNER_NAME;
+	}
+	if (ORIGINAL_DOMAIN === undefined) {
+		process.env.PHANTOM_DOMAIN = undefined;
+	} else {
+		process.env.PHANTOM_DOMAIN = ORIGINAL_DOMAIN;
+	}
+	if (ORIGINAL_TENANT_SLUG === undefined) {
+		process.env.PHANTOM_TENANT_SLUG = undefined;
+	} else {
+		process.env.PHANTOM_TENANT_SLUG = ORIGINAL_TENANT_SLUG;
+	}
 });
 
 describe("composeIntroductionText", () => {
-	test("includes the phantom name and team name in the greeting", () => {
-		const text = composeIntroductionText("Maple", "Acme Corp");
-		expect(text).toContain("Hi! I'm Maple.");
-		expect(text).toContain("connected to Acme Corp");
+	test("greets the owner by name when PHANTOM_OWNER_NAME is provided", () => {
+		const text = composeIntroductionText("Phantom", "Cheema", "https://gilded-hearth.phantom.ghostwright.dev");
+		expect(text.startsWith("Hi Cheema. I'm in.")).toBe(true);
 	});
 
-	test("instructs the user how to interact with the agent", () => {
-		const text = composeIntroductionText("Phantom", "Workspace");
-		expect(text).toContain("Reply to this DM");
-		expect(text).toContain("@-mention me");
+	test("falls back to 'Hi there' when no owner name is provided", () => {
+		const text = composeIntroductionText("Phantom", undefined, "https://gilded-hearth.phantom.ghostwright.dev");
+		expect(text.startsWith("Hi there. I'm in.")).toBe(true);
 	});
 
-	test("omits the manage-me line when no dashboard URL is provided", () => {
-		const text = composeIntroductionText("Phantom", "Workspace");
-		expect(text).not.toContain("manage me");
+	test("identifies the agent as a co-worker, not a chatbot or assistant", () => {
+		const text = composeIntroductionText("Phantom", "Cheema");
+		expect(text).toContain("co-worker");
+		expect(text).not.toContain("AI assistant");
+		expect(text).not.toContain("I can help you with");
+		expect(text).not.toContain("What would you like");
+		expect(text).not.toContain("What can you do");
 	});
 
-	test("includes the dashboard URL in the manage-me line when provided", () => {
-		const text = composeIntroductionText("Phantom", "Workspace", "https://example.test/dashboard");
-		expect(text).toContain("You can manage me at https://example.test/dashboard.");
+	test("commits to the 8am morning brief as the proactive first action", () => {
+		const text = composeIntroductionText("Phantom", "Cheema");
+		expect(text).toContain("Tomorrow at 8am");
+		expect(text).toContain("what changed overnight");
+		// The text fallback nudges the user to the buttons rendered in
+		// the Block Kit payload above it, so a screen reader does not
+		// dead-end on the question.
+		expect(text).toContain("Lock it in");
+		expect(text).toContain("buttons below");
+	});
+
+	test("offers the user a way to start work right now if they prefer", () => {
+		const text = composeIntroductionText("Phantom", "Cheema");
+		expect(text).toContain("If you want me to start on something now, just tell me what.");
+	});
+
+	test("includes the home URL in the intro line when provided", () => {
+		const text = composeIntroductionText("Phantom", "Cheema", "https://gilded-hearth.phantom.ghostwright.dev");
+		expect(text).toContain("I live at https://gilded-hearth.phantom.ghostwright.dev");
+	});
+
+	test("omits the 'I live at' phrase when no home URL is provided", () => {
+		const text = composeIntroductionText("Phantom", "Cheema");
+		expect(text).not.toContain("I live at");
+	});
+
+	test("includes the dashboard URL footer when provided", () => {
+		const text = composeIntroductionText(
+			"Phantom",
+			"Cheema",
+			"https://gilded-hearth.phantom.ghostwright.dev",
+			"https://app.ghostwright.dev",
+		);
+		expect(text).toContain("If you want to change anything about me, I live at https://app.ghostwright.dev.");
+	});
+
+	test("omits the dashboard footer when no dashboard URL is provided", () => {
+		const text = composeIntroductionText("Phantom", "Cheema", "https://gilded-hearth.phantom.ghostwright.dev");
+		expect(text).not.toContain("change anything about me");
+	});
+
+	test("never contains an em dash anywhere in the copy", () => {
+		// Voice contract: em dashes are banned by the cardinal style rule.
+		// Both U+2014 (em dash) and U+2013 (en dash) are flagged because
+		// either reads as the same chatbot-formal voice we are leaving
+		// behind.
+		const variants = [
+			composeIntroductionText("Phantom", "Cheema"),
+			composeIntroductionText("Phantom", undefined, "https://example.test"),
+			composeIntroductionText("Phantom", "Cheema", "https://example.test", "https://app.example.test"),
+		];
+		for (const text of variants) {
+			expect(text).not.toContain("—");
+			expect(text).not.toContain("–");
+		}
+	});
+
+	test("never contains an emoji or marketing-voice phrase", () => {
+		const text = composeIntroductionText(
+			"Phantom",
+			"Cheema",
+			"https://gilded-hearth.phantom.ghostwright.dev",
+			"https://app.ghostwright.dev",
+		);
+		expect(text).not.toContain("✨");
+		expect(text).not.toContain("\u{1F44B}");
+		expect(text).not.toContain("\u{1F680}");
+		expect(text).not.toContain("Maximize");
+		expect(text).not.toContain("blazing");
+		expect(text).not.toContain("Welcome to the future");
+	});
+});
+
+describe("composeIntroductionBlocks", () => {
+	test("renders a header, body section, actions row, and offer section", () => {
+		const blocks = composeIntroductionBlocks("Phantom", "Cheema", "https://gilded-hearth.phantom.ghostwright.dev");
+		const header = blocks.find((b) => b.type === "header");
+		const sections = blocks.filter((b) => b.type === "section");
+		const actions = blocks.find((b) => b.type === "actions");
+		expect(header).toBeDefined();
+		expect(sections.length).toBeGreaterThanOrEqual(2);
+		expect(actions).toBeDefined();
+		expect(actions?.block_id).toBe("phantom_morning_brief");
+	});
+
+	test("the actions row carries exactly three buttons in lock-retime-skip order", () => {
+		const blocks = composeIntroductionBlocks("Phantom", "Cheema", "https://example.test");
+		const actions = blocks.find((b) => b.type === "actions") as SlackBlock & {
+			elements?: Array<{ action_id?: string; text?: { text?: string }; style?: string; value?: string }>;
+		};
+		expect(actions?.elements?.length).toBe(3);
+		const ids = actions?.elements?.map((e) => e.action_id);
+		expect(ids).toEqual([MORNING_BRIEF_LOCK_ACTION_ID, MORNING_BRIEF_RETIME_ACTION_ID, MORNING_BRIEF_SKIP_ACTION_ID]);
+		expect(actions?.elements?.[0]?.text?.text).toBe("Lock 8am");
+		expect(actions?.elements?.[0]?.style).toBe("primary");
+		expect(actions?.elements?.[1]?.text?.text).toBe("Pick another time");
+		expect(actions?.elements?.[2]?.text?.text).toBe("Skip mornings");
+	});
+
+	test("the dashboard context block appears only when a dashboard URL is set", () => {
+		const without = composeIntroductionBlocks("Phantom", "Cheema", "https://example.test");
+		const withDash = composeIntroductionBlocks("Phantom", "Cheema", "https://example.test", "https://app.example.test");
+		expect(without.some((b) => b.type === "context")).toBe(false);
+		expect(withDash.some((b) => b.type === "context")).toBe(true);
+	});
+
+	test("the body section uses the named greeting when an owner name is provided", () => {
+		const blocks = composeIntroductionBlocks("Phantom", "Cheema", "https://example.test");
+		const bodySection = blocks.find((b) => b.type === "section" && (b.text?.text ?? "").includes("co-worker"));
+		expect(bodySection?.text?.text).toContain("Hi Cheema.");
+	});
+
+	test("the body section falls back to 'Hi there' when no owner name is provided", () => {
+		const blocks = composeIntroductionBlocks("Phantom", undefined, "https://example.test");
+		const bodySection = blocks.find((b) => b.type === "section" && (b.text?.text ?? "").includes("co-worker"));
+		expect(bodySection?.text?.text).toContain("Hi there.");
+	});
+
+	test("the header uses the agent's name", () => {
+		const blocks = composeIntroductionBlocks("Maple", "Cheema", "https://example.test");
+		const header = blocks.find((b) => b.type === "header");
+		expect(header?.text?.text).toBe("Maple is in.");
 	});
 });
 
 describe("sendIntroductionDm", () => {
-	test("calls sendDm with the installer user id and the composed text", async () => {
-		const sendDm = mock(async (_userId: string, _text: string) => "1715000000.000123" as string | null);
+	test("calls sendDm with the installer user id, text fallback, and Block Kit blocks", async () => {
+		process.env.PHANTOM_OWNER_NAME = "Cheema";
+		process.env.PHANTOM_DOMAIN = "gilded-hearth.phantom.ghostwright.dev";
+		const sendDm = mock(
+			async (_userId: string, _text: string, _blocks?: SlackBlock[]) => "1715000000.000123" as string | null,
+		);
 		const result = await sendIntroductionDm({
-			phantomName: "Maple",
+			phantomName: "Phantom",
 			teamName: "Acme Corp",
 			installerUserId: "U_INSTALLER",
 			sendDm,
@@ -89,62 +243,117 @@ describe("sendIntroductionDm", () => {
 		const args = sendDm.mock.calls[0];
 		if (!args) throw new Error("no call");
 		expect(args[0]).toBe("U_INSTALLER");
-		expect(args[1]).toContain("I'm Maple");
+		expect(args[1]).toContain("Hi Cheema.");
+		expect(args[1]).toContain("co-worker");
+		const blocks = args[2] as SlackBlock[] | undefined;
+		expect(Array.isArray(blocks)).toBe(true);
+		const actions = blocks?.find((b) => b.type === "actions");
+		expect(actions?.block_id).toBe("phantom_morning_brief");
 		expect(result.sent).toBe(true);
 		expect(result.messageTs).toBe("1715000000.000123");
 	});
 
-	test("includes the dashboard URL when PHANTOM_DASHBOARD_URL is set to a valid URL", async () => {
-		process.env.PHANTOM_DASHBOARD_URL = "https://example.test/manage";
+	test("derives the home URL from PHANTOM_DOMAIN when set", async () => {
+		process.env.PHANTOM_OWNER_NAME = "Cheema";
+		process.env.PHANTOM_DOMAIN = "gilded-hearth.phantom.ghostwright.dev";
 		let captured = "";
 		const sendDm = mock(async (_u: string, text: string) => {
 			captured = text;
 			return "1715000000.000111" as string | null;
 		});
 		await sendIntroductionDm({
-			phantomName: "Maple",
+			phantomName: "Phantom",
 			teamName: "Acme",
 			installerUserId: "U_INSTALLER",
 			sendDm,
 		});
-		expect(captured).toContain("You can manage me at https://example.test/manage.");
+		expect(captured).toContain("I live at https://gilded-hearth.phantom.ghostwright.dev");
 	});
 
-	test("omits the manage-me line when PHANTOM_DASHBOARD_URL is unset (self-host)", async () => {
+	test("derives the home URL from PHANTOM_TENANT_SLUG when PHANTOM_DOMAIN is unset", async () => {
+		process.env.PHANTOM_TENANT_SLUG = "gilded-hearth";
 		let captured = "";
 		const sendDm = mock(async (_u: string, text: string) => {
 			captured = text;
 			return "1715000000.000222" as string | null;
 		});
 		await sendIntroductionDm({
-			phantomName: "Maple",
+			phantomName: "Phantom",
 			teamName: "Acme",
 			installerUserId: "U_INSTALLER",
 			sendDm,
 		});
-		expect(captured).not.toContain("manage me");
+		expect(captured).toContain("I live at https://gilded-hearth.phantom.ghostwright.dev");
 	});
 
-	test("omits the manage-me line when PHANTOM_DASHBOARD_URL is malformed", async () => {
-		process.env.PHANTOM_DASHBOARD_URL = "not a url";
+	test("strips a leading https:// from PHANTOM_DOMAIN before building the URL", async () => {
+		process.env.PHANTOM_DOMAIN = "https://gilded-hearth.phantom.ghostwright.dev/";
 		let captured = "";
 		const sendDm = mock(async (_u: string, text: string) => {
 			captured = text;
 			return "1715000000.000333" as string | null;
 		});
 		await sendIntroductionDm({
-			phantomName: "Maple",
+			phantomName: "Phantom",
 			teamName: "Acme",
 			installerUserId: "U_INSTALLER",
 			sendDm,
 		});
-		expect(captured).not.toContain("manage me");
+		expect(captured).not.toContain("https://https://");
+		expect(captured).toContain("I live at https://gilded-hearth.phantom.ghostwright.dev");
+	});
+
+	test("includes the dashboard URL footer when PHANTOM_DASHBOARD_URL is set", async () => {
+		process.env.PHANTOM_DASHBOARD_URL = "https://app.ghostwright.dev";
+		let captured = "";
+		const sendDm = mock(async (_u: string, text: string) => {
+			captured = text;
+			return "1715000000.000444" as string | null;
+		});
+		await sendIntroductionDm({
+			phantomName: "Phantom",
+			teamName: "Acme",
+			installerUserId: "U_INSTALLER",
+			sendDm,
+		});
+		expect(captured).toContain("If you want to change anything about me, I live at https://app.ghostwright.dev.");
+	});
+
+	test("omits the dashboard footer when PHANTOM_DASHBOARD_URL is malformed", async () => {
+		process.env.PHANTOM_DASHBOARD_URL = "not a url";
+		let captured = "";
+		const sendDm = mock(async (_u: string, text: string) => {
+			captured = text;
+			return "1715000000.000555" as string | null;
+		});
+		await sendIntroductionDm({
+			phantomName: "Phantom",
+			teamName: "Acme",
+			installerUserId: "U_INSTALLER",
+			sendDm,
+		});
+		expect(captured).not.toContain("change anything about me");
+	});
+
+	test("omits the dashboard footer when PHANTOM_DASHBOARD_URL is unset (self-host)", async () => {
+		let captured = "";
+		const sendDm = mock(async (_u: string, text: string) => {
+			captured = text;
+			return "1715000000.000666" as string | null;
+		});
+		await sendIntroductionDm({
+			phantomName: "Phantom",
+			teamName: "Acme",
+			installerUserId: "U_INSTALLER",
+			sendDm,
+		});
+		expect(captured).not.toContain("change anything about me");
 	});
 
 	test("acks first_dm_sent with the returned message_ts when SLACK_TRANSPORT=http", async () => {
 		const sendDm = mock(async () => "1715000000.000456" as string | null);
 		const result = await sendIntroductionDm({
-			phantomName: "Maple",
+			phantomName: "Phantom",
 			teamName: "Acme",
 			installerUserId: "U_INSTALLER",
 			sendDm,
@@ -167,7 +376,7 @@ describe("sendIntroductionDm", () => {
 		process.env.METADATA_BASE_URL = undefined;
 		const sendDm = mock(async () => "1715000000.000789" as string | null);
 		const result = await sendIntroductionDm({
-			phantomName: "Maple",
+			phantomName: "Phantom",
 			teamName: "Acme",
 			installerUserId: "U_INSTALLER",
 			sendDm,
@@ -184,7 +393,7 @@ describe("sendIntroductionDm", () => {
 		process.env.SLACK_TRANSPORT = undefined;
 		const sendDm = mock(async () => "1715000000.000900" as string | null);
 		const result = await sendIntroductionDm({
-			phantomName: "Maple",
+			phantomName: "Phantom",
 			teamName: "Acme",
 			installerUserId: "U_INSTALLER",
 			sendDm,
@@ -201,7 +410,7 @@ describe("sendIntroductionDm", () => {
 		process.env.SLACK_TRANSPORT = "socket";
 		const sendDm = mock(async () => "1715000000.000901" as string | null);
 		const result = await sendIntroductionDm({
-			phantomName: "Maple",
+			phantomName: "Phantom",
 			teamName: "Acme",
 			installerUserId: "U_INSTALLER",
 			sendDm,
@@ -219,7 +428,7 @@ describe("sendIntroductionDm", () => {
 		process.env.SLACK_TRANSPORT = "  http  ";
 		const sendDm = mock(async () => "1715000000.000902" as string | null);
 		const result = await sendIntroductionDm({
-			phantomName: "Maple",
+			phantomName: "Phantom",
 			teamName: "Acme",
 			installerUserId: "U_INSTALLER",
 			sendDm,
@@ -236,7 +445,7 @@ describe("sendIntroductionDm", () => {
 		process.env.SLACK_TRANSPORT = "";
 		const sendDm = mock(async () => "1715000000.000903" as string | null);
 		const result = await sendIntroductionDm({
-			phantomName: "Maple",
+			phantomName: "Phantom",
 			teamName: "Acme",
 			installerUserId: "U_INSTALLER",
 			sendDm,
@@ -249,7 +458,7 @@ describe("sendIntroductionDm", () => {
 	test("returns sent:false and skips heartbeat when sendDm returns null (Slack rate limit)", async () => {
 		const sendDm = mock(async () => null);
 		const result = await sendIntroductionDm({
-			phantomName: "Maple",
+			phantomName: "Phantom",
 			teamName: "Acme",
 			installerUserId: "U_INSTALLER",
 			sendDm,
@@ -268,7 +477,7 @@ describe("sendIntroductionDm", () => {
 			throw new Error("ECONNREFUSED");
 		});
 		const result = await sendIntroductionDm({
-			phantomName: "Maple",
+			phantomName: "Phantom",
 			teamName: "Acme",
 			installerUserId: "U_INSTALLER",
 			sendDm,
@@ -291,7 +500,7 @@ describe("sendIntroductionDm", () => {
 		};
 		try {
 			await sendIntroductionDm({
-				phantomName: "Maple",
+				phantomName: "Phantom",
 				teamName: "Acme",
 				installerUserId: "U_INSTALLER",
 				sendDm,

--- a/src/channels/slack-actions.ts
+++ b/src/channels/slack-actions.ts
@@ -1,11 +1,18 @@
 /**
- * Slack interactive action handlers: feedback buttons and agent-suggested actions.
- * Registers Bolt action handlers that route button clicks to the appropriate
- * subsystems (feedback -> evolution, actions -> agent follow-up).
+ * Slack interactive action handlers: feedback buttons, agent-suggested
+ * actions, and the morning-brief confirmation buttons emitted by the
+ * synthetic introduction DM. Registers Bolt action handlers that route
+ * button clicks to the appropriate subsystems (feedback -> evolution,
+ * actions -> agent follow-up, morning-brief -> preference recorder).
  */
 
 import type { App } from "@slack/bolt";
 import { FEEDBACK_ACTION_IDS, buildFeedbackAckBlocks, emitFeedback, parseFeedbackAction } from "./feedback.ts";
+import {
+	MORNING_BRIEF_LOCK_ACTION_ID,
+	MORNING_BRIEF_RETIME_ACTION_ID,
+	MORNING_BRIEF_SKIP_ACTION_ID,
+} from "./slack-introduction.ts";
 
 type ActionFollowUpHandler = (params: {
 	userId: string;
@@ -20,6 +27,29 @@ let actionFollowUpHandler: ActionFollowUpHandler | null = null;
 
 export function setActionFollowUpHandler(handler: ActionFollowUpHandler): void {
 	actionFollowUpHandler = handler;
+}
+
+/**
+ * Morning-brief preference recorder. Three states: lock the default 8am
+ * slot, retime (the user wants a different hour and will reply with it),
+ * skip mornings entirely. Slice 15 wires the SQLite table that backs
+ * `MorningBriefPreference`; until then the recorder defaults to a
+ * structured log line so the choice is visible in production logs and
+ * the wire shape is locked.
+ */
+export type MorningBriefChoice = "lock_8am" | "retime" | "skip";
+
+export type MorningBriefPreferenceRecorder = (params: {
+	userId: string;
+	channel: string;
+	choice: MorningBriefChoice;
+	clickedAt: number;
+}) => Promise<void> | void;
+
+let morningBriefRecorder: MorningBriefPreferenceRecorder | null = null;
+
+export function setMorningBriefPreferenceRecorder(recorder: MorningBriefPreferenceRecorder): void {
+	morningBriefRecorder = recorder;
 }
 
 /** Extract a typed value from the Bolt body object */
@@ -152,4 +182,77 @@ export function registerSlackActions(app: App): void {
 			});
 		}
 	});
+
+	// Morning-brief confirmation handlers. Each registered separately so
+	// Bolt can route the click without our own switch-on-action_id; the
+	// shared body lifts the click target, swaps the actions block for a
+	// confirmation context block, and forwards to the preference
+	// recorder. The brief itself does not run yet (slice 15); this PR
+	// captures the choice so the brief lands with the user's
+	// already-recorded preference on day one.
+	for (const meta of [
+		{ id: MORNING_BRIEF_LOCK_ACTION_ID, choice: "lock_8am" as const, ack: "Locked. Tomorrow at 8am your time." },
+		{
+			id: MORNING_BRIEF_RETIME_ACTION_ID,
+			choice: "retime" as const,
+			ack: "Got it. Reply with the time you want, like '7am' or '9:30am', and I'll match it.",
+		},
+		{
+			id: MORNING_BRIEF_SKIP_ACTION_ID,
+			choice: "skip" as const,
+			ack: "No morning brief. I'll wait for you to ping me.",
+		},
+	]) {
+		app.action(meta.id, async ({ ack, body, client }) => {
+			await ack();
+
+			const b = body as unknown as Record<string, unknown>;
+			const channelId = bodyField<string>(b, "channel", "id");
+			const messageTs = bodyField<string>(b, "message", "ts");
+			const userId = bodyField<string>(b, "user", "id");
+			const messageText = bodyField<string>(b, "message", "text") ?? "";
+			const existingBlocks = bodyField<Array<{ type: string; block_id?: string }>>(b, "message", "blocks") ?? [];
+
+			if (!channelId || !messageTs || !userId) return;
+
+			// Swap the actions row for a context block recording the
+			// click. Mirrors the existing phantom:action handler shape so
+			// the user gets the same "click landed" feeling across every
+			// button surface in the product.
+			const filtered = existingBlocks.filter((block) => block.block_id !== "phantom_morning_brief");
+			try {
+				await client.chat.update({
+					channel: channelId,
+					ts: messageTs,
+					text: messageText,
+					blocks: [
+						...filtered,
+						{
+							type: "context",
+							elements: [{ type: "mrkdwn", text: `_${meta.ack}_` }],
+						},
+					],
+				} as unknown as Parameters<typeof client.chat.update>[0]);
+			} catch (err) {
+				const msg = err instanceof Error ? err.message : String(err);
+				console.warn(`[slack] Failed to update morning-brief buttons: ${msg}`);
+			}
+
+			if (morningBriefRecorder) {
+				try {
+					await morningBriefRecorder({ userId, channel: channelId, choice: meta.choice, clickedAt: Date.now() });
+				} catch (err) {
+					const msg = err instanceof Error ? err.message : String(err);
+					console.warn(`[slack] morning-brief recorder failed: ${msg}`);
+				}
+			} else {
+				// Until slice 15 wires the persistent recorder, surface the
+				// choice in logs so operators can confirm the wire shape
+				// end-to-end against production traffic.
+				console.log(
+					`[slack] morning_brief_choice user=${userId} channel=${channelId} choice=${meta.choice} ts=${messageTs}`,
+				);
+			}
+		});
+	}
 }

--- a/src/channels/slack-egress.ts
+++ b/src/channels/slack-egress.ts
@@ -65,7 +65,21 @@ export async function egressPostToChannel(ctx: EgressContext, channelId: string,
 	return lastTs;
 }
 
-export async function egressSendDm(ctx: EgressContext, userId: string, text: string): Promise<string | null> {
+// egressSendDm opens a DM channel and posts the message. When `blocks`
+// is provided, the message ships as a Block Kit payload with `text` as
+// the screen-reader and notification fallback (Slack truncates long
+// fallbacks; the caller is expected to keep the fallback under 3000
+// chars). The blocks payload bypasses splitMessage chunking because
+// blocks must travel as a single chat.postMessage; if the blocks shape
+// is too large for Slack the API returns an error which we log and
+// return null. When `blocks` is omitted the helper falls back to the
+// text-chunked path through egressPostToChannel.
+export async function egressSendDm(
+	ctx: EgressContext,
+	userId: string,
+	text: string,
+	blocks?: SlackBlock[],
+): Promise<string | null> {
 	try {
 		const openResult = await ctx.client.conversations.open({ users: userId });
 		const dmChannelId = openResult.channel?.id;
@@ -73,7 +87,20 @@ export async function egressSendDm(ctx: EgressContext, userId: string, text: str
 			console.error(`[${ctx.logTag}] Failed to open DM with user ${userId}: no channel returned`);
 			return null;
 		}
-		return egressPostToChannel(ctx, dmChannelId, text);
+		if (!blocks || blocks.length === 0) {
+			return egressPostToChannel(ctx, dmChannelId, text);
+		}
+		try {
+			const postArgs: Record<string, unknown> = { channel: dmChannelId, text, blocks };
+			const result = await ctx.client.chat.postMessage(
+				postArgs as unknown as Parameters<typeof ctx.client.chat.postMessage>[0],
+			);
+			return result.ts ?? null;
+		} catch (err: unknown) {
+			const msg = err instanceof Error ? err.message : String(err);
+			console.error(`[${ctx.logTag}] Failed to post DM blocks to user ${userId}: ${msg}`);
+			return null;
+		}
 	} catch (err: unknown) {
 		const msg = err instanceof Error ? err.message : String(err);
 		console.error(`[${ctx.logTag}] Failed to send DM to user ${userId}: ${msg}`);

--- a/src/channels/slack-http-receiver.ts
+++ b/src/channels/slack-http-receiver.ts
@@ -255,7 +255,7 @@ export class SlackHttpChannel implements Channel, EventDispatchHost {
 			phantomName: this.phantomName,
 			teamName: this.teamName,
 			installerUserId: this.installerUserId,
-			sendDm: (userId, text) => this.sendDm(userId, text),
+			sendDm: (userId, text, blocks) => this.sendDm(userId, text, blocks),
 		});
 		if (result.sent) {
 			this.firstDmSent = true;
@@ -309,8 +309,8 @@ export class SlackHttpChannel implements Channel, EventDispatchHost {
 		return egressPostToChannel(this.egressContext(), channelId, text);
 	}
 
-	async sendDm(userId: string, text: string): Promise<string | null> {
-		return egressSendDm(this.egressContext(), userId, text);
+	async sendDm(userId: string, text: string, blocks?: SlackBlock[]): Promise<string | null> {
+		return egressSendDm(this.egressContext(), userId, text, blocks);
 	}
 
 	async postThinking(channel: string, threadTs: string): Promise<string | null> {

--- a/src/channels/slack-introduction.ts
+++ b/src/channels/slack-introduction.ts
@@ -9,16 +9,27 @@
 //
 // The introduction is the user's first contact with the agent: when a
 // hosted operator stamps an installer through the channel install flow,
-// this DM is what the user sees first. The body is pinned by a test
-// (composeIntroductionText test in __tests__). Change here, change
-// there.
+// this DM is what the user sees first. Voice contract: co-worker on
+// day 1, NOT chatbot. We greet by PHANTOM_OWNER_NAME when present, lead
+// with one specific commitment (the 8am morning brief), and ask for
+// confirmation via three Block Kit buttons rather than open-ended
+// suggestion prompts. The body is pinned by the test in __tests__.
+// Change here, change there.
 
 import { DEFAULT_METADATA_BASE_URL } from "../config/identity-fetcher.ts";
 import { reportFirstDmSent } from "../tenancy/heartbeat.ts";
+import type { SlackBlock } from "./feedback.ts";
 import { readSlackTransportFromEnv } from "./slack-channel-factory.ts";
 import { redactTokens } from "./slack-http-utils.ts";
 
 const INTRODUCTION_LOG_TAG = "slack-introduction";
+
+// Block Kit action ids for the three morning-brief confirmation buttons.
+// Exported so the actions dispatcher (slack-actions.ts) can register the
+// matching handlers and the test can pin the wire shape.
+export const MORNING_BRIEF_LOCK_ACTION_ID = "phantom:morning_brief:lock";
+export const MORNING_BRIEF_RETIME_ACTION_ID = "phantom:morning_brief:retime";
+export const MORNING_BRIEF_SKIP_ACTION_ID = "phantom:morning_brief:skip";
 
 export type IntroductionDeps = {
 	phantomName: string;
@@ -26,9 +37,12 @@ export type IntroductionDeps = {
 	installerUserId: string;
 	// sendDm returns the Slack message_ts on success, or null when Slack
 	// accepted the conversations.open but chat.postMessage failed (rate
-	// limit, archived channel, etc). Inheriting the existing channel
-	// helper keeps the test surface identical.
-	sendDm(userId: string, text: string): Promise<string | null>;
+	// limit, archived channel, etc). The blocks argument carries the
+	// Block Kit shape; the text argument is the fallback for clients
+	// that do not render blocks (mobile push notifications, screen
+	// readers, the Slack search index). Inheriting the existing channel
+	// helper keeps the egress test surface identical.
+	sendDm(userId: string, text: string, blocks?: SlackBlock[]): Promise<string | null>;
 };
 
 export type IntroductionResult = {
@@ -55,9 +69,13 @@ export type IntroductionResult = {
  * is not derailed by a transient Slack hiccup.
  */
 export async function sendIntroductionDm(deps: IntroductionDeps): Promise<IntroductionResult> {
-	const text = composeIntroductionText(deps.phantomName, deps.teamName, resolveDashboardUrl());
+	const ownerName = readOwnerName();
+	const homeUrl = resolveHomeUrl();
+	const dashboardUrl = resolveDashboardUrl();
+	const text = composeIntroductionText(deps.phantomName, ownerName, homeUrl, dashboardUrl);
+	const blocks = composeIntroductionBlocks(deps.phantomName, ownerName, homeUrl, dashboardUrl);
 	try {
-		const messageTs = await deps.sendDm(deps.installerUserId, text);
+		const messageTs = await deps.sendDm(deps.installerUserId, text, blocks);
 		if (!messageTs) {
 			console.warn(`[${INTRODUCTION_LOG_TAG}] introduction DM returned no message_ts; skipping first_dm_sent ack`);
 			return { sent: false, messageTs: null };
@@ -88,33 +106,157 @@ export async function sendIntroductionDm(deps: IntroductionDeps): Promise<Introd
 	}
 }
 
-// composeIntroductionText is exported for the test that pins the copy.
-// dashboardUrl is optional: when unset, the "manage me" line is omitted
-// so self-hosters who do not have a management URL are not pointed at a
-// dashboard they cannot reach. When set, the line appears verbatim.
-export function composeIntroductionText(phantomName: string, teamName: string, dashboardUrl?: string): string {
+// composeIntroductionText is exported for the test that pins the copy
+// AND as the text fallback for Slack clients that do not render blocks
+// (mobile push previews, screen readers, the Slack search index). The
+// shape is co-worker voice, not chatbot voice: a named greeting, a
+// single concrete commitment (the 8am morning brief), and an offer to
+// start now. No feature catalog, no "what can I help you with",
+// no em dashes, no emojis.
+//
+// Five-or-fewer sentences by design. The voice contract is in the
+// architect doc at phantom-cloud-deploy/local/2026-05-02-first-five-
+// minutes-audit.md section 1.8 and the strategy doc at
+// phantom-cloud-deploy/local/2026-05-02-phantom-as-product-strategy.md.
+export function composeIntroductionText(
+	phantomName: string,
+	ownerName?: string,
+	homeUrl?: string,
+	dashboardUrl?: string,
+): string {
+	const greeting = ownerName ? `Hi ${ownerName}.` : "Hi there.";
+	const introSentence = homeUrl
+		? `I'm in. I live at ${homeUrl} and I'll be your co-worker in this Slack as ${phantomName} from now on.`
+		: `I'm in. I'll be your co-worker in this Slack as ${phantomName} from now on.`;
+	// Text fallback for clients that do not render Block Kit (mobile push
+	// previews, screen readers, the Slack search index). The buttons row
+	// is replaced with a "tap a button below" cue so screen-reader users
+	// hear that there is something to interact with rather than dead-end
+	// at the question; the buttons themselves render in the blocks
+	// payload above this fallback.
 	const lines = [
-		`Hi! I'm ${phantomName}. I'm now connected to ${teamName}.`,
+		`${greeting} ${introSentence}`,
 		"",
-		"Reply to this DM to start a conversation, or @-mention me in any channel.",
+		"Tomorrow at 8am your time I'll send you a quick read on what changed overnight and what needs you. Lock it in, pick another time, or skip mornings using the buttons below.",
 		"",
-		"A few things to try:",
-		'  - "What can you do?"',
-		'  - "Tell me about my workspace."',
-		'  - "Read the latest in #general."',
+		"If you want me to start on something now, just tell me what.",
 	];
 	if (dashboardUrl) {
-		lines.push("", `You can manage me at ${dashboardUrl}.`);
+		lines.push("", `If you want to change anything about me, I live at ${dashboardUrl}.`);
 	}
 	return lines.join("\n");
+}
+
+// composeIntroductionBlocks renders the introduction as Slack Block Kit:
+// a header, a section with the body, an actions row with three buttons,
+// and a context footer (when a dashboard URL is configured) so the user
+// has a route back to the management surface without it crowding the
+// primary copy. The buttons confirm the morning-brief schedule; the
+// handlers in slack-actions.ts persist the choice and update the message
+// to acknowledge the click.
+export function composeIntroductionBlocks(
+	phantomName: string,
+	ownerName?: string,
+	homeUrl?: string,
+	dashboardUrl?: string,
+): SlackBlock[] {
+	const greeting = ownerName ? `Hi ${ownerName}.` : "Hi there.";
+	const introSentence = homeUrl
+		? `I'm in. I live at <${homeUrl}|${stripScheme(homeUrl)}> and I'll be your co-worker in this Slack as *${phantomName}* from now on.`
+		: `I'm in. I'll be your co-worker in this Slack as *${phantomName}* from now on.`;
+	const intro = `${greeting} ${introSentence}`;
+	const commitment =
+		"Tomorrow at 8am your time I'll send you a quick read on what changed overnight and what needs you. Lock it in?";
+	const offer = "If you want me to start on something now, just tell me what.";
+
+	const blocks: SlackBlock[] = [
+		{
+			type: "header",
+			text: { type: "plain_text", text: `${phantomName} is in.` },
+		},
+		{
+			type: "section",
+			text: { type: "mrkdwn", text: `${intro}\n\n${commitment}` },
+		},
+		{
+			type: "actions",
+			block_id: "phantom_morning_brief",
+			elements: [
+				{
+					type: "button",
+					text: { type: "plain_text", text: "Lock 8am", emoji: false },
+					action_id: MORNING_BRIEF_LOCK_ACTION_ID,
+					style: "primary",
+					value: "lock_8am",
+				},
+				{
+					type: "button",
+					text: { type: "plain_text", text: "Pick another time", emoji: false },
+					action_id: MORNING_BRIEF_RETIME_ACTION_ID,
+					value: "retime",
+				},
+				{
+					type: "button",
+					text: { type: "plain_text", text: "Skip mornings", emoji: false },
+					action_id: MORNING_BRIEF_SKIP_ACTION_ID,
+					value: "skip",
+				},
+			],
+		},
+		{
+			type: "section",
+			text: { type: "mrkdwn", text: offer },
+		},
+	];
+
+	if (dashboardUrl) {
+		blocks.push({
+			type: "context",
+			elements: [
+				{
+					type: "mrkdwn",
+					text: `If you want to change anything about me, I live at <${dashboardUrl}|${stripScheme(dashboardUrl)}>.`,
+				},
+			],
+		});
+	}
+
+	return blocks;
+}
+
+// readOwnerName reads PHANTOM_OWNER_NAME and returns the trimmed value
+// when non-empty. The greeting falls back to "Hi there." when the owner
+// name is missing so the DM never reads as a half-finished mail merge
+// (e.g. "Hi ,") to a self-hoster who has not set the env.
+function readOwnerName(): string | undefined {
+	const raw = process.env.PHANTOM_OWNER_NAME?.trim();
+	return raw && raw.length > 0 ? raw : undefined;
+}
+
+// resolveHomeUrl reads PHANTOM_DOMAIN, falling back to a slug-derived
+// hostname under phantom.ghostwright.dev so Phase-9-era tenants whose
+// firstboot pre-dates the PHANTOM_DOMAIN injection still surface a real
+// per-tenant URL. Returns undefined for single-tenant dev (neither var
+// set) so the line drops cleanly.
+function resolveHomeUrl(): string | undefined {
+	const domain = process.env.PHANTOM_DOMAIN?.trim();
+	if (domain && domain.length > 0) {
+		const cleaned = domain.replace(/^https?:\/\//i, "").replace(/\/+$/, "");
+		if (cleaned.length > 0) return `https://${cleaned}`;
+	}
+	const slug = process.env.PHANTOM_TENANT_SLUG?.trim();
+	if (slug && slug.length > 0) {
+		return `https://${slug}.phantom.ghostwright.dev`;
+	}
+	return undefined;
 }
 
 // resolveDashboardUrl reads PHANTOM_DASHBOARD_URL and validates it as a
 // well-formed URL. Operators set this in the agent's environment when
 // the deployment has a management surface; self-hosters leave it unset
-// and the "manage me" line is dropped from the introduction. A malformed
-// value is logged and dropped so a misconfigured env var cannot inject
-// unparseable text into a user-facing DM.
+// and the dashboard footer line drops. A malformed value is logged and
+// dropped so a misconfigured env var cannot inject unparseable text
+// into a user-facing DM.
 function resolveDashboardUrl(): string | undefined {
 	const raw = process.env.PHANTOM_DASHBOARD_URL?.trim();
 	if (!raw) return undefined;
@@ -122,7 +264,15 @@ function resolveDashboardUrl(): string | undefined {
 		new URL(raw);
 		return raw;
 	} catch {
-		console.warn(`[${INTRODUCTION_LOG_TAG}] PHANTOM_DASHBOARD_URL is not a valid URL; dropping the manage-me line`);
+		console.warn(`[${INTRODUCTION_LOG_TAG}] PHANTOM_DASHBOARD_URL is not a valid URL; dropping the dashboard line`);
 		return undefined;
 	}
+}
+
+// stripScheme strips the URL scheme for cleaner Slack link display.
+// Slack renders <url|label> with the label visible; we keep the URL
+// readable by dropping the redundant https:// while leaving the
+// underlying href intact.
+function stripScheme(url: string): string {
+	return url.replace(/^https?:\/\//i, "");
 }


### PR DESCRIPTION
## Summary

The synthetic introduction DM is the user's first contact moment with their phantom. Today it reads like a chatbot ("Hi! I'm Phantom. I can help you with: ..."), which contradicts the co-worker framing the strategy doc locks. This PR rewrites the intro voice and ships a Block Kit actions row that asks the user to confirm one specific commitment: the 8am morning brief.

Scope is intentionally tight. The actual scheduled brief lands in slice 15; this PR captures the user's preference at the click site so the brief lands with the already-recorded choice on day one.

## Before / After

**Before** (chatbot voice):
```
Hi! I'm Phantom. I'm now connected to Acme Corp.

Reply to this DM to start a conversation, or @-mention me in any channel.

A few things to try:
  - "What can you do?"
  - "Tell me about my workspace."
  - "Read the latest in #general."
```

**After** (co-worker voice, named greeting, proactive commitment):
```
Hi Cheema. I'm in. I live at https://gilded-hearth.phantom.ghostwright.dev and I'll be your co-worker in this Slack as Phantom from now on.

Tomorrow at 8am your time I'll send you a quick read on what changed overnight and what needs you. Lock it in, pick another time, or skip mornings using the buttons below.

If you want me to start on something now, just tell me what.
```

The text fallback above ships in push notifications and screen readers. Block Kit clients render a header (`Phantom is in.`), a body section (the same intro + commitment), an actions row with three buttons, an offer section, and a context footer linking to `PHANTOM_DASHBOARD_URL` when set.

## 3-button shape

Action ids exported from `slack-introduction.ts`, handlers registered in `slack-actions.ts` next to the existing feedback + agent-action button handlers:

- `phantom:morning_brief:lock` (primary style, "Lock 8am") -> "Locked. Tomorrow at 8am your time."
- `phantom:morning_brief:retime` (default, "Pick another time") -> "Got it. Reply with the time you want, like '7am' or '9:30am', and I'll match it."
- `phantom:morning_brief:skip` (default, "Skip mornings") -> "No morning brief. I'll wait for you to ping me."

Each handler swaps the actions block for a context block recording the choice, mirroring the existing `phantom:action:N` handler shape so the click feedback feels consistent across the product. The handler then calls an optional `MorningBriefPreferenceRecorder` that slice 15 will wire against the SQLite preference table; until slice 15 lands, the click is logged structurally (`user`, `channel`, `choice`, `ts`) so operators can confirm the wire shape end-to-end.

## Env wiring

- `PHANTOM_OWNER_NAME` drives the named greeting; falls back to "Hi there." when unset (single-tenant dev / self-host).
- `PHANTOM_DOMAIN` drives the home URL; `PHANTOM_TENANT_SLUG` fallback for Phase-9-era tenants whose firstboot pre-dates the domain injection. Defensive scheme-stripping so a misconfigured `https://...` value does not double-prefix.
- `PHANTOM_DASHBOARD_URL` drives the footer; malformed values are logged + dropped (defensive against env-injection accidents).

## Tests

- `src/channels/__tests__/slack-introduction.test.ts`: 33 tests (was 16). New coverage: named greeting + fallback, co-worker voice anti-patterns ("I can help you with", "What would you like", em dashes, en dashes, emojis, marketing voice), morning brief commitment, Block Kit shape (header + sections + actions + context), three-button order + ids + primary style, PHANTOM_DOMAIN + PHANTOM_TENANT_SLUG resolution, scheme-stripping defense.
- `src/channels/__tests__/slack-http-receiver.test.ts`: updated the snapshot pin on the synthetic-DM test to assert the new voice ("co-worker", phantom name) AND the actions block_id (`phantom_morning_brief`).

Test count delta: +18 tests (33 vs 16 in the introduction file). Full suite: 2428 pass / 0 fail. Typecheck clean. Lint clean.

## What still gates the actual 8am Daily Brief

Slice 15 ("First Hour of Work") owns:
- The persistent SQLite table behind `MorningBriefPreference` (today the recorder is an optional callback that defaults to a structured log line).
- The 8am cron + persona-aware draft pipeline (PULL -> IDENTIFY -> DRAFT -> APPROVE).
- The retime parser ("7am", "9:30am") that turns a free-text reply after the "Pick another time" click into a stored hour.

This PR locks the wire shape so slice 15 wires the recorder against a real table without a copy-or-button-shape change.

## Test plan

- [ ] Unit tests pass locally: `bun test src/channels/__tests__/slack-introduction.test.ts`
- [ ] Channels suite stays green: `bun test src/channels/__tests__/`
- [ ] Full suite stays green: `bun test`
- [ ] Typecheck clean: `bun run typecheck`
- [ ] Lint clean: `bun run lint`
- [ ] After merge, watch a fresh tenant provision and verify the intro DM lands with the named greeting + three buttons in Slack mobile + desktop. Click each button in turn and verify the message updates with the confirmation context block and the structured log line.