### PR TITLE
feat(persona): persona-aware intro DM + system prompt overlay (Slice 16b)

### DIFF
--- a/src/agent/prompt-assembler.ts
+++ b/src/agent/prompt-assembler.ts
@@ -2,6 +2,7 @@ import { existsSync } from "node:fs";
 import { join } from "node:path";
 import type { PhantomConfig } from "../config/types.ts";
 import type { EvolvedConfig } from "../evolution/types.ts";
+import { buildPersonaSystemPromptOverlay } from "../persona/system-prompt.ts";
 import type { RoleTemplate } from "../roles/types.ts";
 import { buildAgentMemoryInstructions } from "./prompt-blocks/agent-memory-instructions.ts";
 import { buildDashboardAwarenessLines } from "./prompt-blocks/dashboard-awareness.ts";
@@ -35,6 +36,17 @@ export function assemblePrompt(
 	const selfKnowledge = buildTenantSelfKnowledge();
 	if (selfKnowledge) {
 		sections.push(selfKnowledge);
+	}
+
+	// 1c. Persona overlay (Slice 16b). Reads PHANTOM_PERSONA_ID and
+	// emits the persona's system_prompt_overlay as a "# Your Voice And
+	// Role" section. Returns the empty string when the persona id is
+	// unset or unknown so the slot drops cleanly. Sits after the
+	// tenant-self-knowledge block so the agent reads its own identity
+	// (workspace, owner, runtime) before its voice and role.
+	const personaOverlay = buildPersonaSystemPromptOverlay();
+	if (personaOverlay) {
+		sections.push(personaOverlay);
 	}
 
 	// 2. Environment - what you have access to

--- a/src/channels/__tests__/slack-introduction.test.ts
+++ b/src/channels/__tests__/slack-introduction.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { PERSONA_CATALOG, PERSONA_IDS, type PersonaId } from "../../persona/catalog.ts";
 import type { SlackBlock } from "../feedback.ts";
 import {
 	MORNING_BRIEF_LOCK_ACTION_ID,
@@ -35,6 +36,7 @@ const ORIGINAL_DASHBOARD = process.env.PHANTOM_DASHBOARD_URL;
 const ORIGINAL_OWNER_NAME = process.env.PHANTOM_OWNER_NAME;
 const ORIGINAL_DOMAIN = process.env.PHANTOM_DOMAIN;
 const ORIGINAL_TENANT_SLUG = process.env.PHANTOM_TENANT_SLUG;
+const ORIGINAL_PERSONA_ID = process.env.PHANTOM_PERSONA_ID;
 
 beforeEach(() => {
 	heartbeatCalls.length = 0;
@@ -45,6 +47,7 @@ beforeEach(() => {
 	process.env.PHANTOM_OWNER_NAME = undefined;
 	process.env.PHANTOM_DOMAIN = undefined;
 	process.env.PHANTOM_TENANT_SLUG = undefined;
+	process.env.PHANTOM_PERSONA_ID = undefined;
 });
 
 afterEach(() => {
@@ -77,6 +80,11 @@ afterEach(() => {
 		process.env.PHANTOM_TENANT_SLUG = undefined;
 	} else {
 		process.env.PHANTOM_TENANT_SLUG = ORIGINAL_TENANT_SLUG;
+	}
+	if (ORIGINAL_PERSONA_ID === undefined) {
+		process.env.PHANTOM_PERSONA_ID = undefined;
+	} else {
+		process.env.PHANTOM_PERSONA_ID = ORIGINAL_PERSONA_ID;
 	}
 });
 
@@ -515,4 +523,265 @@ describe("sendIntroductionDm", () => {
 		expect(all).toContain("postMessage failed");
 		expect(all).not.toContain("xoxb-leaky-token-XXX");
 	});
+});
+
+// Slice 16b: persona overlay coverage.
+//
+// The wire shape from PR #120 (Block Kit header + body section + actions
+// row + offer section + optional context footer) STAYS THE SAME under
+// the persona overlay. The actions row block_id, the three button
+// action_ids, the primary style on Lock 8am, and the order of the
+// buttons stay byte-equal across every persona AND the persona-less
+// fallback. The text content shifts to the persona's display_name +
+// intro_role_phrase + intro_first_commitment + intro_open_offer.
+
+describe("composeIntroductionText with persona overlay", () => {
+	for (const id of PERSONA_IDS) {
+		const persona = PERSONA_CATALOG[id];
+		test(`${id} text fallback uses the persona's named greeting + role phrase + first_commitment + open_offer`, () => {
+			const text = composeIntroductionText(
+				"Phantom",
+				"Cheema",
+				"https://gilded-hearth.phantom.ghostwright.dev",
+				undefined,
+				persona,
+			);
+			expect(text).toContain(`I'm ${persona.display_name}, ${persona.intro_role_phrase}.`);
+			expect(text).toContain(persona.intro_first_commitment);
+			expect(text).toContain(persona.intro_open_offer);
+			// The wire-shape cue ("buttons below") stays so screen-reader
+			// users do not dead-end at the question regardless of persona.
+			expect(text).toContain("buttons below");
+		});
+	}
+
+	test("falls back to the PR #120 default copy when no persona is provided", () => {
+		const text = composeIntroductionText(
+			"Phantom",
+			"Cheema",
+			"https://gilded-hearth.phantom.ghostwright.dev",
+			undefined,
+			undefined,
+		);
+		expect(text).toContain("I'm in.");
+		expect(text).toContain("co-worker in this Slack as Phantom");
+		expect(text).toContain(
+			"Tomorrow at 8am your time I'll send you a quick read on what changed overnight and what needs you",
+		);
+		expect(text).toContain("If you want me to start on something now, just tell me what.");
+	});
+
+	test("never contains an em dash, en dash, or marketing voice across all seven personas", () => {
+		for (const id of PERSONA_IDS) {
+			const persona = PERSONA_CATALOG[id];
+			const text = composeIntroductionText(
+				"Phantom",
+				"Cheema",
+				"https://gilded-hearth.phantom.ghostwright.dev",
+				"https://app.ghostwright.dev",
+				persona,
+			);
+			expect(text).not.toContain("—");
+			expect(text).not.toContain("–");
+			expect(text).not.toContain("blazing");
+			expect(text).not.toContain("Welcome to the future");
+			expect(text).not.toContain("✨");
+		}
+	});
+});
+
+describe("composeIntroductionBlocks with persona overlay", () => {
+	for (const id of PERSONA_IDS) {
+		const persona = PERSONA_CATALOG[id];
+		test(`${id} header text uses the persona's display_name`, () => {
+			const blocks = composeIntroductionBlocks("Phantom", "Cheema", "https://example.test", undefined, persona);
+			const header = blocks.find((b) => b.type === "header");
+			expect(header?.text?.text).toBe(`${persona.display_name} is in.`);
+		});
+
+		test(`${id} body section identifies the agent by display_name + role_phrase`, () => {
+			const blocks = composeIntroductionBlocks("Phantom", "Cheema", "https://example.test", undefined, persona);
+			const bodySection = blocks.find(
+				(b) => b.type === "section" && (b.text?.text ?? "").includes("I'll be in this Slack"),
+			);
+			expect(bodySection).toBeDefined();
+			expect(bodySection?.text?.text).toContain(persona.display_name);
+			expect(bodySection?.text?.text).toContain(persona.intro_role_phrase);
+			expect(bodySection?.text?.text).toContain(persona.intro_first_commitment);
+		});
+
+		test(`${id} offer section uses the persona's intro_open_offer`, () => {
+			const blocks = composeIntroductionBlocks("Phantom", "Cheema", "https://example.test", undefined, persona);
+			const offerSection = blocks.find(
+				(b) => b.type === "section" && (b.text?.text ?? "").includes(persona.intro_open_offer),
+			);
+			expect(offerSection).toBeDefined();
+		});
+
+		test(`${id} preserves the exact PR #120 actions wire shape (block_id, action_ids, primary on Lock 8am)`, () => {
+			const blocks = composeIntroductionBlocks("Phantom", "Cheema", "https://example.test", undefined, persona);
+			const actions = blocks.find((b) => b.type === "actions") as SlackBlock & {
+				elements?: Array<{ action_id?: string; text?: { text?: string }; style?: string; value?: string }>;
+			};
+			expect(actions?.block_id).toBe("phantom_morning_brief");
+			expect(actions?.elements?.length).toBe(3);
+			expect(actions?.elements?.map((e) => e.action_id)).toEqual([
+				MORNING_BRIEF_LOCK_ACTION_ID,
+				MORNING_BRIEF_RETIME_ACTION_ID,
+				MORNING_BRIEF_SKIP_ACTION_ID,
+			]);
+			expect(actions?.elements?.[0]?.style).toBe("primary");
+			expect(actions?.elements?.[0]?.text?.text).toBe("Lock 8am");
+			expect(actions?.elements?.[1]?.text?.text).toBe("Pick another time");
+			expect(actions?.elements?.[2]?.text?.text).toBe("Skip mornings");
+		});
+	}
+
+	test("default header (no persona) keeps the PR #120 phantomName-driven copy", () => {
+		const blocks = composeIntroductionBlocks("Phantom", "Cheema", "https://example.test", undefined, undefined);
+		const header = blocks.find((b) => b.type === "header");
+		expect(header?.text?.text).toBe("Phantom is in.");
+	});
+
+	test("dashboard context footer renders for any persona when PHANTOM_DASHBOARD_URL is set", () => {
+		for (const id of PERSONA_IDS) {
+			const persona = PERSONA_CATALOG[id];
+			const blocks = composeIntroductionBlocks(
+				"Phantom",
+				"Cheema",
+				"https://example.test",
+				"https://app.ghostwright.dev",
+				persona,
+			);
+			expect(blocks.some((b) => b.type === "context")).toBe(true);
+		}
+	});
+});
+
+describe("sendIntroductionDm reads PHANTOM_PERSONA_ID and threads the persona through", () => {
+	for (const id of PERSONA_IDS as readonly PersonaId[]) {
+		const persona = PERSONA_CATALOG[id];
+		test(`${id}: PHANTOM_PERSONA_ID drives the persona's display_name in the header and the body sentence`, async () => {
+			process.env.PHANTOM_OWNER_NAME = "Cheema";
+			process.env.PHANTOM_DOMAIN = "gilded-hearth.phantom.ghostwright.dev";
+			process.env.PHANTOM_PERSONA_ID = id;
+			let capturedText = "";
+			let capturedBlocks: SlackBlock[] | undefined;
+			const sendDm = mock(async (_userId: string, text: string, blocks?: SlackBlock[]) => {
+				capturedText = text;
+				capturedBlocks = blocks;
+				return "1715000000.999000" as string | null;
+			});
+			const result = await sendIntroductionDm({
+				phantomName: "Phantom",
+				teamName: "Acme",
+				installerUserId: "U_INSTALLER",
+				sendDm,
+			});
+
+			expect(result.sent).toBe(true);
+			expect(capturedText).toContain(`I'm ${persona.display_name}, ${persona.intro_role_phrase}.`);
+			expect(capturedText).toContain(persona.intro_first_commitment);
+			expect(capturedText).toContain(persona.intro_open_offer);
+			const header = capturedBlocks?.find((b) => b.type === "header");
+			expect(header?.text?.text).toBe(`${persona.display_name} is in.`);
+			const actions = capturedBlocks?.find((b) => b.type === "actions");
+			expect(actions?.block_id).toBe("phantom_morning_brief");
+		});
+	}
+
+	test("falls back to default scaffold when PHANTOM_PERSONA_ID is unset", async () => {
+		process.env.PHANTOM_OWNER_NAME = "Cheema";
+		process.env.PHANTOM_DOMAIN = "gilded-hearth.phantom.ghostwright.dev";
+		let capturedText = "";
+		let capturedBlocks: SlackBlock[] | undefined;
+		const sendDm = mock(async (_userId: string, text: string, blocks?: SlackBlock[]) => {
+			capturedText = text;
+			capturedBlocks = blocks;
+			return "1715000000.998000" as string | null;
+		});
+		await sendIntroductionDm({
+			phantomName: "Phantom",
+			teamName: "Acme",
+			installerUserId: "U_INSTALLER",
+			sendDm,
+		});
+
+		expect(capturedText).toContain("co-worker in this Slack as Phantom");
+		expect(capturedText).toContain(
+			"Tomorrow at 8am your time I'll send you a quick read on what changed overnight and what needs you",
+		);
+		const header = capturedBlocks?.find((b) => b.type === "header");
+		expect(header?.text?.text).toBe("Phantom is in.");
+	});
+
+	test("falls back to default scaffold when PHANTOM_PERSONA_ID is unknown (defends against typos and validator drift)", async () => {
+		process.env.PHANTOM_OWNER_NAME = "Cheema";
+		process.env.PHANTOM_PERSONA_ID = "sdr-typo";
+		let capturedText = "";
+		const sendDm = mock(async (_userId: string, text: string, _blocks?: SlackBlock[]) => {
+			capturedText = text;
+			return "1715000000.997000" as string | null;
+		});
+		await sendIntroductionDm({
+			phantomName: "Phantom",
+			teamName: "Acme",
+			installerUserId: "U_INSTALLER",
+			sendDm,
+		});
+
+		expect(capturedText).toContain("co-worker in this Slack as Phantom");
+		expect(capturedText).not.toContain("sdr-typo");
+	});
+
+	test("falls back to default scaffold when PHANTOM_PERSONA_ID is empty string", async () => {
+		process.env.PHANTOM_PERSONA_ID = "";
+		let capturedText = "";
+		const sendDm = mock(async (_userId: string, text: string, _blocks?: SlackBlock[]) => {
+			capturedText = text;
+			return "1715000000.996000" as string | null;
+		});
+		await sendIntroductionDm({
+			phantomName: "Phantom",
+			teamName: "Acme",
+			installerUserId: "U_INSTALLER",
+			sendDm,
+		});
+
+		expect(capturedText).toContain("co-worker in this Slack as Phantom");
+	});
+});
+
+describe("intro DM Block Kit snapshot per persona", () => {
+	// Snapshot test (architect doc §6 Mandate E): each persona's rendered
+	// Block Kit JSON. We pin the structural shape (header + sections +
+	// actions + optional context) plus the persona-specific copy that
+	// shifts in each block. This catches accidental drift between
+	// persona text content and the block scaffolding without coupling
+	// to Slack's wire format minutiae.
+	for (const id of PERSONA_IDS) {
+		const persona = PERSONA_CATALOG[id];
+		test(`${id} renders the locked Block Kit shape with persona-specific copy`, () => {
+			const blocks = composeIntroductionBlocks(
+				"Phantom",
+				"Cheema",
+				"https://gilded-hearth.phantom.ghostwright.dev",
+				"https://app.ghostwright.dev",
+				persona,
+			);
+			// Shape: header + body section + actions + offer section + context.
+			expect(blocks.length).toBe(5);
+			expect(blocks[0]?.type).toBe("header");
+			expect(blocks[1]?.type).toBe("section");
+			expect(blocks[2]?.type).toBe("actions");
+			expect(blocks[3]?.type).toBe("section");
+			expect(blocks[4]?.type).toBe("context");
+			// Persona-specific content lands in the right blocks.
+			expect(blocks[0]?.text?.text).toBe(`${persona.display_name} is in.`);
+			expect(blocks[1]?.text?.text).toContain(persona.display_name);
+			expect(blocks[1]?.text?.text).toContain(persona.intro_role_phrase);
+			expect(blocks[1]?.text?.text).toContain(persona.intro_first_commitment);
+			expect(blocks[3]?.text?.text).toContain(persona.intro_open_offer);
+		});
+	}
 });

--- a/src/channels/slack-introduction.ts
+++ b/src/channels/slack-introduction.ts
@@ -17,6 +17,7 @@
 // Change here, change there.
 
 import { DEFAULT_METADATA_BASE_URL } from "../config/identity-fetcher.ts";
+import { type PersonaCatalogEntry, readPersonaFromEnv } from "../persona/catalog.ts";
 import { reportFirstDmSent } from "../tenancy/heartbeat.ts";
 import type { SlackBlock } from "./feedback.ts";
 import { readSlackTransportFromEnv } from "./slack-channel-factory.ts";
@@ -72,8 +73,16 @@ export async function sendIntroductionDm(deps: IntroductionDeps): Promise<Introd
 	const ownerName = readOwnerName();
 	const homeUrl = resolveHomeUrl();
 	const dashboardUrl = resolveDashboardUrl();
-	const text = composeIntroductionText(deps.phantomName, ownerName, homeUrl, dashboardUrl);
-	const blocks = composeIntroductionBlocks(deps.phantomName, ownerName, homeUrl, dashboardUrl);
+	// Persona overlay (Slice 16b). When PHANTOM_PERSONA_ID is set and
+	// matches a catalog entry, the intro DM swaps in the persona's
+	// display_name + intro_* fields. The Block Kit wire shape (header,
+	// section, three-button actions row, optional context footer) does
+	// not change; only the text content shifts. When the env is unset or
+	// unknown, the persona-less default copy from PR #120 ships
+	// unchanged.
+	const persona = readPersonaFromEnv();
+	const text = composeIntroductionText(deps.phantomName, ownerName, homeUrl, dashboardUrl, persona);
+	const blocks = composeIntroductionBlocks(deps.phantomName, ownerName, homeUrl, dashboardUrl, persona);
 	try {
 		const messageTs = await deps.sendDm(deps.installerUserId, text, blocks);
 		if (!messageTs) {
@@ -118,29 +127,49 @@ export async function sendIntroductionDm(deps: IntroductionDeps): Promise<Introd
 // architect doc at phantom-cloud-deploy/local/2026-05-02-first-five-
 // minutes-audit.md section 1.8 and the strategy doc at
 // phantom-cloud-deploy/local/2026-05-02-phantom-as-product-strategy.md.
+//
+// Persona overlay (Slice 16b): when `persona` is provided, the named
+// agent identity (display_name + intro_role_phrase) replaces the bare
+// phantomName, the persona's first_commitment replaces the default
+// morning-brief line, and the open_offer replaces the "start on
+// something now" close. The buttons-below cue stays so the wire shape
+// (Lock 8am / Pick another time / Skip mornings) maps straight to the
+// persona's morning-brief commitment without a scaffold change.
 export function composeIntroductionText(
 	phantomName: string,
 	ownerName?: string,
 	homeUrl?: string,
 	dashboardUrl?: string,
+	persona?: PersonaCatalogEntry,
 ): string {
 	const greeting = ownerName ? `Hi ${ownerName}.` : "Hi there.";
+	const displayName = persona?.display_name ?? phantomName;
+	const rolePhrase = persona?.intro_role_phrase;
+	// Lead sentence. Persona-tweaked: "I'm Lilian, your SDR." Default:
+	// "I'm in." The location ("I live at <homeUrl>") and the
+	// in-this-Slack-from-now-on commitment carry across both branches so
+	// the user always sees where the agent lives and what it's doing.
+	const namedSelf = persona ? `I'm ${displayName}, ${rolePhrase}.` : "I'm in.";
 	const introSentence = homeUrl
-		? `I'm in. I live at ${homeUrl} and I'll be your co-worker in this Slack as ${phantomName} from now on.`
-		: `I'm in. I'll be your co-worker in this Slack as ${phantomName} from now on.`;
+		? persona
+			? `${namedSelf} I live at ${homeUrl} and I'll be in this Slack from now on.`
+			: `${namedSelf} I live at ${homeUrl} and I'll be your co-worker in this Slack as ${phantomName} from now on.`
+		: persona
+			? `${namedSelf} I'll be in this Slack from now on.`
+			: `${namedSelf} I'll be your co-worker in this Slack as ${phantomName} from now on.`;
+	const commitmentLine = persona
+		? `${persona.intro_first_commitment}. Lock it in, pick another time, or skip mornings using the buttons below.`
+		: "Tomorrow at 8am your time I'll send you a quick read on what changed overnight and what needs you. Lock it in, pick another time, or skip mornings using the buttons below.";
+	const offerLine = persona
+		? `${persona.intro_open_offer}.`
+		: "If you want me to start on something now, just tell me what.";
 	// Text fallback for clients that do not render Block Kit (mobile push
 	// previews, screen readers, the Slack search index). The buttons row
 	// is replaced with a "tap a button below" cue so screen-reader users
 	// hear that there is something to interact with rather than dead-end
 	// at the question; the buttons themselves render in the blocks
 	// payload above this fallback.
-	const lines = [
-		`${greeting} ${introSentence}`,
-		"",
-		"Tomorrow at 8am your time I'll send you a quick read on what changed overnight and what needs you. Lock it in, pick another time, or skip mornings using the buttons below.",
-		"",
-		"If you want me to start on something now, just tell me what.",
-	];
+	const lines = [`${greeting} ${introSentence}`, "", commitmentLine, "", offerLine];
 	if (dashboardUrl) {
 		lines.push("", `If you want to change anything about me, I live at ${dashboardUrl}.`);
 	}
@@ -154,25 +183,45 @@ export function composeIntroductionText(
 // primary copy. The buttons confirm the morning-brief schedule; the
 // handlers in slack-actions.ts persist the choice and update the message
 // to acknowledge the click.
+//
+// Persona overlay (Slice 16b): when `persona` is provided, the header
+// switches to "${persona.display_name} is in." and the body section
+// uses the persona's named-self lead sentence + intro_first_commitment
+// + intro_open_offer. The actions row block_id, the three button
+// action_ids, the primary style on Lock 8am, and the context footer
+// shape stay byte-equal with the persona-less default; slice 15
+// reads the click events from the same handlers regardless of which
+// persona shipped the DM.
 export function composeIntroductionBlocks(
 	phantomName: string,
 	ownerName?: string,
 	homeUrl?: string,
 	dashboardUrl?: string,
+	persona?: PersonaCatalogEntry,
 ): SlackBlock[] {
 	const greeting = ownerName ? `Hi ${ownerName}.` : "Hi there.";
+	const displayName = persona?.display_name ?? phantomName;
+	const rolePhrase = persona?.intro_role_phrase;
+	const namedSelfMrkdwn = persona ? `I'm *${displayName}*, ${rolePhrase}.` : "I'm in.";
 	const introSentence = homeUrl
-		? `I'm in. I live at <${homeUrl}|${stripScheme(homeUrl)}> and I'll be your co-worker in this Slack as *${phantomName}* from now on.`
-		: `I'm in. I'll be your co-worker in this Slack as *${phantomName}* from now on.`;
+		? persona
+			? `${namedSelfMrkdwn} I live at <${homeUrl}|${stripScheme(homeUrl)}> and I'll be in this Slack from now on.`
+			: `${namedSelfMrkdwn} I live at <${homeUrl}|${stripScheme(homeUrl)}> and I'll be your co-worker in this Slack as *${phantomName}* from now on.`
+		: persona
+			? `${namedSelfMrkdwn} I'll be in this Slack from now on.`
+			: `${namedSelfMrkdwn} I'll be your co-worker in this Slack as *${phantomName}* from now on.`;
 	const intro = `${greeting} ${introSentence}`;
-	const commitment =
-		"Tomorrow at 8am your time I'll send you a quick read on what changed overnight and what needs you. Lock it in?";
-	const offer = "If you want me to start on something now, just tell me what.";
+	const commitment = persona
+		? `${persona.intro_first_commitment}. Lock it in?`
+		: "Tomorrow at 8am your time I'll send you a quick read on what changed overnight and what needs you. Lock it in?";
+	const offer = persona
+		? `${persona.intro_open_offer}.`
+		: "If you want me to start on something now, just tell me what.";
 
 	const blocks: SlackBlock[] = [
 		{
 			type: "header",
-			text: { type: "plain_text", text: `${phantomName} is in.` },
+			text: { type: "plain_text", text: `${displayName} is in.` },
 		},
 		{
 			type: "section",

--- a/src/persona/__tests__/catalog.test.ts
+++ b/src/persona/__tests__/catalog.test.ts
@@ -1,0 +1,286 @@
+// Tests for the persona catalog (Slice 16b). Covers:
+//   - Completeness: all seven character_ids present, in the locked order.
+//   - Field shape: every required field is non-empty for every persona.
+//   - Voice contract: no em dashes, no en dashes, no emojis, no
+//     marketing voice in any user-facing string field.
+//   - Cross-repo invariant placeholder: the seven character_id strings
+//     are pinned in this test so any drift versus the architect doc
+//     surfaces here even before the cross-repo verifier ships.
+//   - Lookup: getPersonaById returns the entry for known ids and
+//     undefined for unknown / empty / undefined inputs.
+//   - Env reader: readPersonaFromEnv resolves PHANTOM_PERSONA_ID
+//     (including whitespace-padded values) and returns undefined for
+//     unset / empty / unknown values.
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+	PERSONA_CATALOG,
+	PERSONA_IDS,
+	type PersonaCatalogEntry,
+	type PersonaId,
+	getPersonaById,
+	readPersonaFromEnv,
+} from "../catalog.ts";
+
+const ORIGINAL_PERSONA_ID = process.env.PHANTOM_PERSONA_ID;
+
+beforeEach(() => {
+	process.env.PHANTOM_PERSONA_ID = undefined;
+});
+
+afterEach(() => {
+	if (ORIGINAL_PERSONA_ID === undefined) {
+		process.env.PHANTOM_PERSONA_ID = undefined;
+	} else {
+		process.env.PHANTOM_PERSONA_ID = ORIGINAL_PERSONA_ID;
+	}
+});
+
+// The seven character_ids are the cross-repo locked fixture (architect
+// doc section 4.1). Any change here MUST land in lockstep with the
+// matching change in phantomd, phantom-control, and ghostwright-site;
+// the verifier ships in slice 16d. Pinning the list inline keeps the
+// drift visible in code review.
+const EXPECTED_CHARACTER_IDS: readonly PersonaId[] = [
+	"sdr-lilian",
+	"eng-cos-marcus",
+	"am-sloane",
+	"bdr-theo",
+	"sales-vp-priya",
+	"gtm-eng-ryan",
+	"founder-asst-adrian",
+];
+
+const REQUIRED_STRING_FIELDS: ReadonlyArray<keyof PersonaCatalogEntry> = [
+	"character_id",
+	"display_name",
+	"subtitle",
+	"tagline",
+	"default_model",
+	"intro_role_phrase",
+	"intro_first_commitment",
+	"intro_open_offer",
+	"system_prompt_overlay",
+	"day1_work_description",
+];
+
+describe("PERSONA_CATALOG completeness", () => {
+	test("contains exactly the seven character_ids in the locked order", () => {
+		expect(PERSONA_IDS).toEqual(EXPECTED_CHARACTER_IDS);
+		expect(Object.keys(PERSONA_CATALOG).sort()).toEqual([...EXPECTED_CHARACTER_IDS].sort());
+	});
+
+	test("every persona has a non-empty value for every required string field", () => {
+		for (const id of PERSONA_IDS) {
+			const entry = PERSONA_CATALOG[id];
+			for (const field of REQUIRED_STRING_FIELDS) {
+				const value = entry[field];
+				expect(typeof value).toBe("string");
+				expect((value as string).trim().length).toBeGreaterThan(0);
+			}
+		}
+	});
+
+	test("character_id field on each entry matches the catalog key", () => {
+		// Defense against a copy-paste typo where two entries share the
+		// same character_id but live under different keys.
+		for (const id of PERSONA_IDS) {
+			expect(PERSONA_CATALOG[id].character_id).toBe(id);
+		}
+	});
+
+	test("default_tools is a non-empty list of strings", () => {
+		for (const id of PERSONA_IDS) {
+			const tools = PERSONA_CATALOG[id].default_tools;
+			expect(Array.isArray(tools)).toBe(true);
+			expect(tools.length).toBeGreaterThan(0);
+			for (const tool of tools) {
+				expect(typeof tool).toBe("string");
+				expect(tool.length).toBeGreaterThan(0);
+			}
+		}
+	});
+
+	test("day1_data_pulls is a non-empty list of {source, query} entries", () => {
+		for (const id of PERSONA_IDS) {
+			const pulls = PERSONA_CATALOG[id].day1_data_pulls;
+			expect(Array.isArray(pulls)).toBe(true);
+			expect(pulls.length).toBeGreaterThan(0);
+			for (const pull of pulls) {
+				expect(typeof pull.source).toBe("string");
+				expect(pull.source.length).toBeGreaterThan(0);
+				expect(typeof pull.query).toBe("string");
+				expect(pull.query.length).toBeGreaterThan(0);
+			}
+		}
+	});
+});
+
+describe("PERSONA_CATALOG voice contract", () => {
+	const userFacingFields: ReadonlyArray<keyof PersonaCatalogEntry> = [
+		"display_name",
+		"subtitle",
+		"tagline",
+		"intro_role_phrase",
+		"intro_first_commitment",
+		"intro_open_offer",
+		"system_prompt_overlay",
+		"day1_work_description",
+	];
+
+	test("no em dash in any user-facing field", () => {
+		for (const id of PERSONA_IDS) {
+			for (const field of userFacingFields) {
+				const value = PERSONA_CATALOG[id][field] as string;
+				expect(value).not.toContain("—");
+			}
+		}
+	});
+
+	test("no en dash in any user-facing field", () => {
+		for (const id of PERSONA_IDS) {
+			for (const field of userFacingFields) {
+				const value = PERSONA_CATALOG[id][field] as string;
+				expect(value).not.toContain("–");
+			}
+		}
+	});
+
+	test("no emoji in any user-facing field", () => {
+		// Spot-check a few categories: marketing sparkles, emoji faces,
+		// rocket-launch marketing emoji. A full unicode-range scan is
+		// brittle; the curated list catches the patterns we have seen
+		// drift in past PRs.
+		const banned = ["✨", "\u{1F44B}", "\u{1F680}", "\u{1F389}", "\u{1F525}", "\u{2728}"];
+		for (const id of PERSONA_IDS) {
+			for (const field of userFacingFields) {
+				const value = PERSONA_CATALOG[id][field] as string;
+				for (const symbol of banned) {
+					expect(value).not.toContain(symbol);
+				}
+			}
+		}
+	});
+
+	test("no marketing voice in any user-facing field", () => {
+		const bannedPhrases = [
+			"blazing fast",
+			"industry-leading",
+			"Welcome to the future",
+			"Maximize",
+			"Unleash",
+			"Next Level",
+		];
+		for (const id of PERSONA_IDS) {
+			for (const field of userFacingFields) {
+				const value = PERSONA_CATALOG[id][field] as string;
+				for (const phrase of bannedPhrases) {
+					expect(value).not.toContain(phrase);
+				}
+			}
+		}
+	});
+});
+
+describe("PERSONA_CATALOG architect-doc taglines and role phrases", () => {
+	// Pin the verbatim taglines + role phrases against the architect doc.
+	// These lines are the cross-repo locked fixture; any change here
+	// MUST land in the architect doc and the four mirrors in lockstep.
+	// We compare with toEqual against an object literal so the catalog's
+	// narrow `as const` literal types do not collide with the test's
+	// widened string fields under bun's typed expect overloads.
+	const expectedTagline: Record<PersonaId, string> = {
+		"sdr-lilian": "Books your meetings. Drafts your outbound. Never lets a lead go cold.",
+		"eng-cos-marcus": "Triages your PRs. Drafts your standup. Catches what is on fire before you do.",
+		"am-sloane": "Reads every customer thread. Catches churn signals early. Drafts the saves.",
+		"bdr-theo": "Researches every prospect. Personalizes every email. Sends only what fits.",
+		"sales-vp-priya": "Watches the pipeline. Flags slipping deals. Drafts the board update.",
+		"gtm-eng-ryan": "Ships landing pages. Wires integrations. Catches signup drops in real time.",
+		"founder-asst-adrian": "Reads every channel. Drafts every reply. Tells you what actually needs you.",
+	};
+	const expectedRole: Record<PersonaId, string> = {
+		"sdr-lilian": "your SDR",
+		"eng-cos-marcus": "your engineering chief of staff",
+		"am-sloane": "your account manager",
+		"bdr-theo": "your BDR",
+		"sales-vp-priya": "your sales leader",
+		"gtm-eng-ryan": "your GTM engineer",
+		"founder-asst-adrian": "your founder's assistant",
+	};
+	const expectedDisplay: Record<PersonaId, string> = {
+		"sdr-lilian": "Lilian",
+		"eng-cos-marcus": "Marcus",
+		"am-sloane": "Sloane",
+		"bdr-theo": "Theo",
+		"sales-vp-priya": "Priya",
+		"gtm-eng-ryan": "Ryan",
+		"founder-asst-adrian": "Adrian",
+	};
+
+	for (const id of EXPECTED_CHARACTER_IDS) {
+		test(`${id} matches architect-doc tagline + role + display name`, () => {
+			const entry = PERSONA_CATALOG[id];
+			// Cast to string so bun's typed expect overload widens the
+			// comparison against the catalog's narrow `as const` literal.
+			expect(entry.display_name as string).toEqual(expectedDisplay[id]);
+			expect(entry.subtitle as string).toEqual(expectedRole[id]);
+			expect(entry.tagline as string).toEqual(expectedTagline[id]);
+			expect(entry.intro_role_phrase as string).toEqual(expectedRole[id]);
+		});
+	}
+});
+
+describe("getPersonaById", () => {
+	test("returns the entry for each of the seven known ids", () => {
+		for (const id of PERSONA_IDS) {
+			const entry = getPersonaById(id);
+			expect(entry).toBeDefined();
+			expect(entry?.character_id).toBe(id);
+		}
+	});
+
+	test("returns undefined for an unknown id", () => {
+		expect(getPersonaById("not-a-real-persona")).toBeUndefined();
+	});
+
+	test("returns undefined for the empty string", () => {
+		expect(getPersonaById("")).toBeUndefined();
+	});
+
+	test("returns undefined for undefined input", () => {
+		expect(getPersonaById(undefined)).toBeUndefined();
+	});
+});
+
+describe("readPersonaFromEnv", () => {
+	test("returns the persona when PHANTOM_PERSONA_ID matches a known id", () => {
+		process.env.PHANTOM_PERSONA_ID = "sdr-lilian";
+		const persona = readPersonaFromEnv();
+		expect(persona?.character_id).toBe("sdr-lilian");
+	});
+
+	test("trims whitespace before lookup", () => {
+		process.env.PHANTOM_PERSONA_ID = "  eng-cos-marcus  ";
+		const persona = readPersonaFromEnv();
+		expect(persona?.character_id).toBe("eng-cos-marcus");
+	});
+
+	test("returns undefined when PHANTOM_PERSONA_ID is unset", () => {
+		expect(readPersonaFromEnv()).toBeUndefined();
+	});
+
+	test("returns undefined when PHANTOM_PERSONA_ID is the empty string", () => {
+		process.env.PHANTOM_PERSONA_ID = "";
+		expect(readPersonaFromEnv()).toBeUndefined();
+	});
+
+	test("returns undefined when PHANTOM_PERSONA_ID is whitespace only", () => {
+		process.env.PHANTOM_PERSONA_ID = "   ";
+		expect(readPersonaFromEnv()).toBeUndefined();
+	});
+
+	test("returns undefined when PHANTOM_PERSONA_ID is unknown (defends against typos and 16d validator drift)", () => {
+		process.env.PHANTOM_PERSONA_ID = "sdr-typo";
+		expect(readPersonaFromEnv()).toBeUndefined();
+	});
+});

--- a/src/persona/__tests__/system-prompt.test.ts
+++ b/src/persona/__tests__/system-prompt.test.ts
@@ -1,0 +1,110 @@
+// Tests for the persona system-prompt overlay (Slice 16b).
+//
+// Covers:
+//   - Each of the seven personas renders the persona's system_prompt_overlay
+//     as a "# Your Voice And Role" section.
+//   - The ${ownerName} placeholder is substituted from PHANTOM_OWNER_NAME.
+//   - When ownerName is unset, the placeholder falls back to "your founder"
+//     so the sentence stays grammatical.
+//   - When PHANTOR_PERSONA_ID is unset, empty, whitespace, or unknown, the
+//     builder returns the empty string and the assembler drops the slot.
+//   - The env reader trims and rejects empty strings.
+
+import { describe, expect, test } from "bun:test";
+import { PERSONA_CATALOG, PERSONA_IDS } from "../catalog.ts";
+import { buildPersonaSystemPromptOverlay, readPersonaSystemPromptEnv } from "../system-prompt.ts";
+
+describe("buildPersonaSystemPromptOverlay", () => {
+	test("renders the persona's system_prompt_overlay as a 'Your Voice And Role' section", () => {
+		const overlay = buildPersonaSystemPromptOverlay({
+			personaId: "sdr-lilian",
+			ownerName: "Cheema",
+		});
+		expect(overlay).toContain("# Your Voice And Role");
+		expect(overlay).toContain("You are Lilian");
+		expect(overlay).toContain("the SDR for Cheema");
+	});
+
+	test("substitutes ${ownerName} for each of the seven personas", () => {
+		for (const id of PERSONA_IDS) {
+			const overlay = buildPersonaSystemPromptOverlay({
+				personaId: id,
+				ownerName: "Cheema",
+			});
+			const expected = PERSONA_CATALOG[id].system_prompt_overlay.replaceAll("${ownerName}", "Cheema");
+			expect(overlay).toContain(expected);
+			// The placeholder text must NOT appear in the rendered overlay
+			// for any of the seven personas; otherwise the agent would
+			// read a literal "${ownerName}" in its system prompt.
+			expect(overlay).not.toContain("${ownerName}");
+		}
+	});
+
+	test("falls back to 'your founder' when ownerName is unset", () => {
+		const overlay = buildPersonaSystemPromptOverlay({
+			personaId: "founder-asst-adrian",
+			ownerName: undefined,
+		});
+		expect(overlay).toContain("for your founder");
+		expect(overlay).not.toContain("${ownerName}");
+	});
+
+	test("returns the empty string when personaId is unset", () => {
+		const overlay = buildPersonaSystemPromptOverlay({ personaId: undefined, ownerName: "Cheema" });
+		expect(overlay).toBe("");
+	});
+
+	test("returns the empty string when personaId is unknown", () => {
+		const overlay = buildPersonaSystemPromptOverlay({
+			personaId: "not-a-real-persona",
+			ownerName: "Cheema",
+		});
+		expect(overlay).toBe("");
+	});
+
+	test("returns the empty string when personaId is whitespace-only", () => {
+		const overlay = buildPersonaSystemPromptOverlay({ personaId: "   ", ownerName: "Cheema" });
+		expect(overlay).toBe("");
+	});
+});
+
+describe("readPersonaSystemPromptEnv", () => {
+	test("reads PHANTOM_PERSONA_ID and PHANTOM_OWNER_NAME from a custom env shape", () => {
+		const env = {
+			PHANTOM_PERSONA_ID: "eng-cos-marcus",
+			PHANTOM_OWNER_NAME: "Cheema",
+		} as NodeJS.ProcessEnv;
+		const shape = readPersonaSystemPromptEnv(env);
+		expect(shape.personaId).toBe("eng-cos-marcus");
+		expect(shape.ownerName).toBe("Cheema");
+	});
+
+	test("trims whitespace and rejects empty strings as 'unset'", () => {
+		const env = {
+			PHANTOM_PERSONA_ID: "  am-sloane  ",
+			PHANTOM_OWNER_NAME: "  ",
+		} as NodeJS.ProcessEnv;
+		const shape = readPersonaSystemPromptEnv(env);
+		expect(shape.personaId).toBe("am-sloane");
+		expect(shape.ownerName).toBeUndefined();
+	});
+
+	test("returns both fields as undefined when neither env is set", () => {
+		const shape = readPersonaSystemPromptEnv({} as NodeJS.ProcessEnv);
+		expect(shape.personaId).toBeUndefined();
+		expect(shape.ownerName).toBeUndefined();
+	});
+});
+
+describe("buildPersonaSystemPromptOverlay end-to-end with each persona", () => {
+	for (const id of PERSONA_IDS) {
+		test(`${id} renders a non-empty Your Voice And Role section`, () => {
+			const overlay = buildPersonaSystemPromptOverlay({
+				personaId: id,
+				ownerName: "Cheema",
+			});
+			expect(overlay.length).toBeGreaterThan(50);
+			expect(overlay.startsWith("# Your Voice And Role")).toBe(true);
+		});
+	}
+});

--- a/src/persona/__tests__/work-plan.test.ts
+++ b/src/persona/__tests__/work-plan.test.ts
@@ -1,0 +1,48 @@
+// Tests for the persona work-plan scaffold (Slice 16b).
+//
+// The work-plan is a stub today: empty data_pulls, empty drafts, empty
+// open_questions. Slice 15 fills the actual content. The contract these
+// tests pin is the SHAPE: getPersonaWorkPlan returns the correct
+// per-persona shape for each known id, and null for unknown / unset.
+// When slice 15 lands, the empty-array assertions flip to non-empty;
+// the rest of these tests stay.
+
+import { describe, expect, test } from "bun:test";
+import { PERSONA_IDS } from "../catalog.ts";
+import { getPersonaWorkPlan } from "../work-plan.ts";
+
+describe("getPersonaWorkPlan", () => {
+	test("returns the empty-stub shape for each of the seven personas", () => {
+		for (const id of PERSONA_IDS) {
+			const plan = getPersonaWorkPlan(id);
+			expect(plan).not.toBeNull();
+			if (!plan) throw new Error("plan should be defined");
+			expect(plan.persona_id).toBe(id);
+			expect(plan.data_pulls).toEqual([]);
+			expect(plan.drafts).toEqual([]);
+			expect(plan.open_questions).toEqual([]);
+		}
+	});
+
+	test("returns null for an unknown persona id", () => {
+		expect(getPersonaWorkPlan("not-a-real-persona")).toBeNull();
+	});
+
+	test("returns null for undefined input", () => {
+		expect(getPersonaWorkPlan(undefined)).toBeNull();
+	});
+
+	test("returns null for the empty string", () => {
+		expect(getPersonaWorkPlan("")).toBeNull();
+	});
+
+	test("the returned shape is mutable so slice 15 can fill it without copying", () => {
+		// The stub shape uses plain mutable arrays, not readonly arrays,
+		// so slice 15's engine can populate the plan in place. This test
+		// confirms the contract.
+		const plan = getPersonaWorkPlan("sdr-lilian");
+		if (!plan) throw new Error("plan should be defined");
+		plan.data_pulls.push({ source: "calendar", query: "test" });
+		expect(plan.data_pulls.length).toBe(1);
+	});
+});

--- a/src/persona/catalog.ts
+++ b/src/persona/catalog.ts
@@ -1,0 +1,245 @@
+// Persona catalog: the seven characters a tenant can hire from the wizard.
+//
+// Slice 16 ships persona selection in the wizard (architect doc:
+// phantom-cloud-deploy/local/2026-05-02-slice-16-wizard-persona-selector-architect.md).
+// This file is the phantom-side mirror of the cross-repo persona fixture.
+// Slice 16c ships the phantomd PHANTOM_PERSONA_ID env-var injection;
+// slice 16d ships the phantom-control validator; slice 16e ships the
+// wizard UI. The seven character_ids and the display fields MUST stay
+// byte-equal across the four mirrors (verifier ships in slice 16d as
+// `phantom-cloud-deploy/scripts/shared/verify-personas.sh`).
+//
+// Why code-vendored, not DB-driven:
+//   - v1 ships seven fixed personas. A `personas` table buys nothing
+//     for v1 and adds drift, race, and deploy-order risk.
+//   - The wizard reads from a static module, not a DB call per page-load.
+//   - v1.5 may add Cheema-defined personas; at that point a `personas`
+//     table lands as a NEW migration with the v1 catalog seeded as
+//     fixture rows. The TEXT column shape on `applications.persona_id`
+//     stays compatible.
+//
+// What this file owns:
+//   - PERSONA_CATALOG: the seven entries (Lilian, Marcus, Sloane, Theo,
+//     Priya, Ryan, Adrian) with display_name, subtitle, tagline, the
+//     three intro_* fields, system_prompt_overlay, day1_work_description,
+//     and day1_data_pulls.
+//   - getPersonaById(id): typed lookup that returns undefined for
+//     unknown ids. The runtime caller (intro DM, system-prompt overlay,
+//     work-plan builder) uses this to thread PHANTOM_PERSONA_ID
+//     through; an unknown or unset id degrades to the persona-less
+//     default copy already shipped in PR #120.
+//
+// Voice contract carried by the intro_* fields: warm, specific,
+// co-worker on day one, never chatbot. The first_commitment locks one
+// concrete thing the persona will do tomorrow at 8am. The open_offer
+// invites the user to start something now, in the persona's actual
+// craft (an SDR offers to chase a stalled lead, an engineering COS
+// offers to triage a PR, an account manager offers to look at a quiet
+// account). No em dashes, no emojis, no marketing voice.
+
+export interface PersonaDataPull {
+	source: string;
+	query: string;
+}
+
+export interface PersonaCatalogEntry {
+	character_id: string;
+	display_name: string;
+	subtitle: string;
+	tagline: string;
+	default_tools: readonly string[];
+	default_model: string;
+	intro_role_phrase: string;
+	intro_first_commitment: string;
+	intro_open_offer: string;
+	system_prompt_overlay: string;
+	day1_work_description: string;
+	day1_data_pulls: readonly PersonaDataPull[];
+}
+
+export const PERSONA_CATALOG = {
+	"sdr-lilian": {
+		character_id: "sdr-lilian",
+		display_name: "Lilian",
+		subtitle: "your SDR",
+		tagline: "Books your meetings. Drafts your outbound. Never lets a lead go cold.",
+		default_tools: ["calendar", "slack", "github"],
+		default_model: "claude-sonnet-4-6",
+		intro_role_phrase: "your SDR",
+		intro_first_commitment:
+			"Tomorrow at 8am I'll have your outbound queue ready: replies that fell through and prospects worth a fresh touch",
+		intro_open_offer: "If there's a hot lead you want me to start on now, tell me who",
+		system_prompt_overlay:
+			"You are Lilian, the SDR for ${ownerName}. You are warm, fast, and persistent without being pushy. You write drafts in the user's voice. You never send a message without explicit thumbs-up. You think in pipelines: prospect, draft, send, follow-up. When you see a stale thread, you draft the nudge and ask permission. You measure your week in meetings booked and replies sent.",
+		day1_work_description:
+			"Pull the user's calendar and Slack DMs. Identify three follow-ups due today plus five outbound prospects from this week's calendar invites. Draft each in the user's voice. Surface the queue with a clear ask: walk through them, or send the safe ones.",
+		day1_data_pulls: [
+			{ source: "calendar", query: "meetings in the next 7 days plus contacts attended in the last 14 days" },
+			{ source: "slack-dm", query: "unread customer messages and follow-ups from the last 14 days" },
+			{ source: "github", query: "README and recent commits to identify what the user is selling" },
+		],
+	},
+	"eng-cos-marcus": {
+		character_id: "eng-cos-marcus",
+		display_name: "Marcus",
+		subtitle: "your engineering chief of staff",
+		tagline: "Triages your PRs. Drafts your standup. Catches what is on fire before you do.",
+		default_tools: ["github", "linear", "slack", "calendar"],
+		default_model: "claude-sonnet-4-6",
+		intro_role_phrase: "your engineering chief of staff",
+		intro_first_commitment:
+			"Tomorrow at 8am I'll send you a quick read on what shipped overnight and what needs your eyes",
+		intro_open_offer: "If there's a PR you want me to triage now, paste the link",
+		system_prompt_overlay:
+			"You are Marcus, engineering chief of staff for ${ownerName}. You are calm, terse, and senior. You read code and PRs like a staff engineer. You distinguish urgent from important. You never escalate noise. When CI breaks, you find the cause before paging anyone. When a PR has been open 3 days, you nudge the reviewer with context, not a poke. You measure your week in PRs unblocked and incidents pre-empted.",
+		day1_work_description:
+			"Pull the last seven days of GitHub activity plus the active Linear sprint. Identify PRs blocking the team, the user's open PRs needing reviewers, and recent CI breakage. Draft today's standup post. Surface the brief with a clear ask: post the standup, or unblock something specific first.",
+		day1_data_pulls: [
+			{ source: "github", query: "last 7 days of PRs, open issues, CI failures, the user's open reviews" },
+			{ source: "linear", query: "active sprint tickets and recent comments" },
+			{ source: "slack-channels", query: "engineering channels for incident chatter" },
+		],
+	},
+	"am-sloane": {
+		character_id: "am-sloane",
+		display_name: "Sloane",
+		subtitle: "your account manager",
+		tagline: "Reads every customer thread. Catches churn signals early. Drafts the saves.",
+		default_tools: ["slack", "calendar"],
+		default_model: "claude-sonnet-4-6",
+		intro_role_phrase: "your account manager",
+		intro_first_commitment:
+			"Tomorrow at 8am I'll have your customer pulse ready: who's quiet, who's escalating, who needs a check-in",
+		intro_open_offer: "If there's an account you're worried about right now, tell me who and I'll start there",
+		system_prompt_overlay:
+			"You are Sloane, account manager for ${ownerName}. You are attentive, warm, and politically astute. You read customer messages like a seasoned CSM: tone shifts, escalation patterns, who is fading and who is doubling down. You draft saves in the user's voice. You never let a thread go more than 3 days without a touch. You measure your week in churn signals caught and customer trust banked.",
+		day1_work_description:
+			"Scan the last fourteen days of customer Slack DMs and shared channels. Identify three accounts at churn risk: dropping message volume, escalation language, unanswered last-touch. Draft a check-in for each in the user's voice. Surface the slate with a clear ask: send today, or refine first.",
+		day1_data_pulls: [
+			{ source: "slack-dm", query: "DMs from customer contacts in the last 14 days" },
+			{ source: "slack-channels", query: "shared customer channels in the last 14 days" },
+			{ source: "calendar", query: "QBRs and customer 1:1s in the next 7 days" },
+		],
+	},
+	"bdr-theo": {
+		character_id: "bdr-theo",
+		display_name: "Theo",
+		subtitle: "your BDR",
+		tagline: "Researches every prospect. Personalizes every email. Sends only what fits.",
+		default_tools: ["slack", "github"],
+		default_model: "claude-sonnet-4-6",
+		intro_role_phrase: "your BDR",
+		intro_first_commitment:
+			"Tomorrow at 8am I'll have five personalized cold emails ready, each with a real reference to the prospect",
+		intro_open_offer: "If you want to give me your ICP and one-liner now, I'll start drafting tonight",
+		system_prompt_overlay:
+			"You are Theo, BDR for ${ownerName}. You are sharp, curious, and obsessive about personalization. You research before you write. Every email you draft references a specific recent thing about the prospect: a post, a hire, a launch, a podcast. You never send a templated cold email. You measure your week in replies earned and meetings created from cold.",
+		day1_work_description:
+			"Take the user's ICP and one-liner. Research five prospects, one signal each: a post, a hire, a launch, a podcast. Draft five cold emails, each opening with the specific reference. Surface the batch with a clear ask: walk through them in order, or send the strongest two right now.",
+		day1_data_pulls: [
+			{ source: "slack-dm", query: "ICP and one-liner from the user" },
+			{ source: "github", query: "tech-founder ICP enrichment for engineering-led prospects" },
+		],
+	},
+	"sales-vp-priya": {
+		character_id: "sales-vp-priya",
+		display_name: "Priya",
+		subtitle: "your sales leader",
+		tagline: "Watches the pipeline. Flags slipping deals. Drafts the board update.",
+		default_tools: ["slack", "calendar"],
+		default_model: "claude-sonnet-4-6",
+		intro_role_phrase: "your sales leader",
+		intro_first_commitment:
+			"Tomorrow at 8am I'll have your pipeline read ready: what's slipping, what's healthy, what to pressure-test this week",
+		intro_open_offer: "If there's a deal you want me to look at first, send me the name",
+		system_prompt_overlay:
+			"You are Priya, sales leader for ${ownerName}. You are decisive, numbers-driven, and politically calm. You read pipeline like a CRO: stage velocity, win-rate by source, deal age, AE load balance. You write board updates that are honest about the bad and specific about the good. You never let a slipping deal slip a second week. You measure your week in pipeline health and quota predictability.",
+		day1_work_description:
+			"Pull last week's deal-stage snapshot. Identify pipeline at risk, deals stuck more than seven days, and quarter quota progress. Draft a board-update paragraph plus a 1:1 prep doc for each AE. Surface the package with a clear ask: walk through the at-risk deals, or sign off on the board copy.",
+		day1_data_pulls: [
+			{ source: "slack-dm", query: "the user's pipeline snapshot or CSV when CRM is not yet connected" },
+			{ source: "calendar", query: "QBRs, board prep, and AE 1:1s in the next 14 days" },
+		],
+	},
+	"gtm-eng-ryan": {
+		character_id: "gtm-eng-ryan",
+		display_name: "Ryan",
+		subtitle: "your GTM engineer",
+		tagline: "Ships landing pages. Wires integrations. Catches signup drops in real time.",
+		default_tools: ["github", "linear", "slack"],
+		default_model: "claude-sonnet-4-6",
+		intro_role_phrase: "your GTM engineer",
+		intro_first_commitment:
+			"Tomorrow at 8am I'll have your funnel health check ready: signup drops, integration breakage, recent experiment results",
+		intro_open_offer: "If there's a regression you're worried about, tell me where and I'll dig in now",
+		system_prompt_overlay:
+			"You are Ryan, GTM engineer for ${ownerName}. You are technical, scrappy, and outcome-obsessed. You read PR diffs to understand what shipped. You read funnel data to understand what broke. You write short Slack posts that put the number first and the why second. You never let a regression go unnoticed past 24 hours. You measure your week in funnel-percentage points moved and integrations kept healthy.",
+		day1_work_description:
+			"Pull the last seven days of marketing-site and integration merges plus the GTM Slack channel. Identify integration breakage, signup drops, latency spikes, and concluded landing-page experiments. Draft a #gtm post: number first, why second. Surface the writeup with a clear ask: post it, or look at the drop together.",
+		day1_data_pulls: [
+			{ source: "github", query: "last 7 days of marketing-site and integration repo merges" },
+			{ source: "linear", query: "GTM tickets in the active sprint" },
+			{ source: "slack-channels", query: "the GTM and growth channels for the last 7 days" },
+		],
+	},
+	"founder-asst-adrian": {
+		character_id: "founder-asst-adrian",
+		display_name: "Adrian",
+		subtitle: "your founder's assistant",
+		tagline: "Reads every channel. Drafts every reply. Tells you what actually needs you.",
+		default_tools: ["slack", "calendar", "github", "linear"],
+		default_model: "claude-sonnet-4-6",
+		intro_role_phrase: "your founder's assistant",
+		intro_first_commitment:
+			"Tomorrow at 8am I'll have your morning brief ready: what actually needs you, what I can handle, what to skip",
+		intro_open_offer:
+			"If there's something pulling at you right now, tell me what and I'll see what I can take off your plate",
+		system_prompt_overlay:
+			"You are Adrian, founder's assistant for ${ownerName}. You are the person between your founder and the firehose. You read everything, you summarize ruthlessly, you draft confidently. You distinguish 'needs the founder' from 'I can handle this' and you handle what you can. You write in the founder's voice for team replies; you write your own voice for executive-summary briefs. You measure your week in things the founder did NOT have to think about.",
+		day1_work_description:
+			"Pull Slack DMs, calendar, GitHub PRs, and the Linear sprint summary. Identify customer escalations, board-prep items, and team DMs you can answer. Draft replies for the team DMs in the founder's voice. Surface the brief with a clear ask: walk through what needs the founder, or send the drafts.",
+		day1_data_pulls: [
+			{ source: "slack-dm", query: "all unread DMs in the last 24 hours" },
+			{ source: "slack-channels", query: "key channels for incidents and customer escalations" },
+			{ source: "calendar", query: "today and tomorrow plus board-prep windows" },
+			{ source: "github", query: "high-level PR list for the last 3 days" },
+			{ source: "linear", query: "active sprint summary and at-risk projects" },
+		],
+	},
+} as const satisfies Record<string, PersonaCatalogEntry>;
+
+export type PersonaId = keyof typeof PERSONA_CATALOG;
+
+// PERSONA_IDS: the canonical list, in the order the architect doc lists
+// the cards. Wizard step 1 renders the cards in this order; the
+// cross-repo verifier asserts byte-equality of this list.
+export const PERSONA_IDS: readonly PersonaId[] = [
+	"sdr-lilian",
+	"eng-cos-marcus",
+	"am-sloane",
+	"bdr-theo",
+	"sales-vp-priya",
+	"gtm-eng-ryan",
+	"founder-asst-adrian",
+] as const;
+
+// getPersonaById is the typed lookup that the runtime callers use.
+// Returns undefined for unknown ids so the caller can degrade to the
+// persona-less default copy. We accept `string | undefined` so the
+// caller can pass `process.env.PHANTOM_PERSONA_ID` directly without an
+// extra null guard.
+export function getPersonaById(id: string | undefined): PersonaCatalogEntry | undefined {
+	if (!id) return undefined;
+	const entry = (PERSONA_CATALOG as Record<string, PersonaCatalogEntry>)[id];
+	return entry;
+}
+
+// readPersonaFromEnv reads PHANTOM_PERSONA_ID and resolves it against
+// the catalog. Returns undefined when the env is unset, empty, or
+// holds an unknown id. The caller (intro DM, system-prompt overlay,
+// work-plan builder) treats undefined as "fall back to default copy",
+// which is the same shape PR #120 ships today.
+export function readPersonaFromEnv(env: NodeJS.ProcessEnv = process.env): PersonaCatalogEntry | undefined {
+	const raw = env.PHANTOM_PERSONA_ID?.trim();
+	return getPersonaById(raw);
+}

--- a/src/persona/system-prompt.ts
+++ b/src/persona/system-prompt.ts
@@ -1,0 +1,59 @@
+// Persona system-prompt overlay: the block that injects the persona's
+// voice and role into the agent's system prompt.
+//
+// The architect doc (section 7) wires this as slot 1c in the prompt
+// assembler, after the tenant-self-knowledge overlay (slot 1b) and
+// before the Environment block. The overlay reads PHANTOM_PERSONA_ID
+// from process.env, looks up the persona's system_prompt_overlay
+// string, substitutes ${ownerName} from PHANTOM_OWNER_NAME, and emits
+// a single "# Your Voice And Role" section.
+//
+// Degradation: when PHANTOM_PERSONA_ID is unset or unknown, the
+// builder returns the empty string and the assembler drops the slot
+// entirely. This matches the tenant-self-knowledge overlay's pattern
+// (Phase 9): the block is purely additive and never gates on a
+// per-tenant identifier.
+//
+// Slice 16b ships the builder; the assembler wiring lands here too so
+// slice 16c (phantomd) is the only remaining hop before the overlay
+// is end-to-end. Slice 17 (rich chat) does not touch this file.
+
+import { readPersonaFromEnv } from "./catalog.ts";
+
+export interface PersonaSystemPromptEnv {
+	personaId?: string;
+	ownerName?: string;
+}
+
+// readPersonaSystemPromptEnv reads the two env vars the overlay needs.
+// PHANTOM_OWNER_NAME is already read by the tenant-self-knowledge
+// overlay, but we re-read it here so the persona overlay stays
+// self-contained and testable without coupling to the other block.
+export function readPersonaSystemPromptEnv(env: NodeJS.ProcessEnv = process.env): PersonaSystemPromptEnv {
+	const personaId = env.PHANTOM_PERSONA_ID?.trim();
+	const ownerName = env.PHANTOM_OWNER_NAME?.trim();
+	return {
+		personaId: personaId && personaId.length > 0 ? personaId : undefined,
+		ownerName: ownerName && ownerName.length > 0 ? ownerName : undefined,
+	};
+}
+
+// buildPersonaSystemPromptOverlay builds the "# Your Voice And Role"
+// section text. Returns the empty string when the persona is unset,
+// unknown, or the overlay text is empty after substitution. The
+// assembler treats the empty string as "drop this slot".
+//
+// The owner-name substitution accepts the literal string "${ownerName}"
+// in the catalog's system_prompt_overlay field; when ownerName is
+// known, the placeholder is replaced; when ownerName is unset, the
+// fallback "your founder" keeps the sentence grammatical.
+export function buildPersonaSystemPromptOverlay(env: PersonaSystemPromptEnv = readPersonaSystemPromptEnv()): string {
+	const persona = readPersonaFromEnv({
+		PHANTOM_PERSONA_ID: env.personaId ?? "",
+	} as NodeJS.ProcessEnv);
+	if (!persona) return "";
+	const ownerName = env.ownerName && env.ownerName.length > 0 ? env.ownerName : "your founder";
+	const body = persona.system_prompt_overlay.replaceAll("${ownerName}", ownerName);
+	if (!body || body.trim().length === 0) return "";
+	return `# Your Voice And Role\n\n${body}`;
+}

--- a/src/persona/work-plan.ts
+++ b/src/persona/work-plan.ts
@@ -1,0 +1,51 @@
+// Persona work-plan scaffold: the type contract slice 15 plugs into.
+//
+// Slice 15 (First Hour of Work) ships the engine that runs the moment a
+// tenant provisions: PULL -> IDENTIFY -> DRAFT -> APPROVE. This file is
+// the type the engine consumes, plus a stub builder that returns the
+// shape with empty data_pulls / drafts / open_questions for each
+// persona. Slice 15 fills the actual content; this PR locks the
+// contract so slice 15 plugs in without a shape change.
+//
+// Why a stub today and not the full plan: slice 15 owns the data-pull
+// queries, the draft templates, and the clarifying questions. The
+// architect doc spells those out per persona in sections 5 and 2.x; the
+// content lands when slice 15's engine consumes it. Shipping the stub
+// here means slice 15 can land as a content-only PR rather than a
+// type + content PR, which keeps the slice-16-to-15 transition clean.
+
+import { getPersonaById } from "./catalog.ts";
+
+export interface PersonaWorkPlanDataPull {
+	source: string;
+	query: string;
+}
+
+export interface PersonaWorkPlanDraft {
+	kind: string;
+	trigger: string;
+	template: string;
+}
+
+export interface PersonaWorkPlan {
+	persona_id: string;
+	data_pulls: PersonaWorkPlanDataPull[];
+	drafts: PersonaWorkPlanDraft[];
+	open_questions: string[];
+}
+
+// getPersonaWorkPlan returns the empty work-plan shape for a known
+// persona. Returns null when the persona id is unknown so the caller
+// can degrade to the persona-less default behavior. Slice 15 swaps the
+// empty arrays for the actual queries, drafts, and questions; the
+// shape stays the same.
+export function getPersonaWorkPlan(personaId: string | undefined): PersonaWorkPlan | null {
+	const entry = getPersonaById(personaId);
+	if (!entry) return null;
+	return {
+		persona_id: entry.character_id,
+		data_pulls: [],
+		drafts: [],
+		open_questions: [],
+	};
+}


### PR DESCRIPTION
## Summary

Slice 16b ships the phantom-side plumbing for the seven personas Slice 16 introduces: a code-vendored persona catalog, a system-prompt overlay that injects the persona's voice into every Agent SDK `query()`, an intro DM tweak that swaps named-co-worker copy onto PR #120's Block Kit scaffold, and a work-plan stub that locks the type contract for Slice 15's First-Hour-of-Work primitive.

Architect doc: `phantom-cloud-deploy/local/2026-05-02-slice-16-wizard-persona-selector-architect.md`. The seven `character_id` strings are the cross-repo locked fixture; slices 16c (phantomd), 16d (phantom-control), and 16e (ghostwright-site) mirror them byte-for-byte and a verifier ships in slice 16d to CI-gate every consuming repo.

@codex please review.

## What changes

### Persona catalog (`src/persona/catalog.ts`, new)

Exports `PERSONA_CATALOG`, `PERSONA_IDS`, and `getPersonaById` / `readPersonaFromEnv` lookups. Seven entries, each with `character_id`, `display_name`, `subtitle`, `tagline`, `default_tools`, `default_model`, `intro_role_phrase`, `intro_first_commitment`, `intro_open_offer`, `system_prompt_overlay`, `day1_work_description`, and `day1_data_pulls`. The seven `character_id` strings, taglines, and role phrases match the architect doc byte-for-byte.

### Intro DM tweak (`src/channels/slack-introduction.ts`)

`composeIntroductionText` and `composeIntroductionBlocks` accept an optional `persona?: PersonaCatalogEntry` argument. `sendIntroductionDm` reads `PHANTOM_PERSONA_ID` from `process.env`, looks up the persona, and threads it through. The Block Kit wire shape stays byte-equal across every persona and the persona-less fallback: actions `block_id` is `phantom_morning_brief`; the three button `action_id`s are `phantom:morning_brief:lock`/`:retime`/`:skip`; the primary style sits on Lock 8am. Only the text content shifts. When the env is unset or unknown, the PR #120 copy ships unchanged.

Example for Lilian (`PHANTOM_PERSONA_ID=sdr-lilian`):

> Hi Cheema. I'm Lilian, your SDR. I live at https://gilded-hearth.phantom.ghostwright.dev and I'll be in this Slack from now on.
>
> Tomorrow at 8am I'll have your outbound queue ready: replies that fell through and prospects worth a fresh touch. Lock it in, pick another time, or skip mornings using the buttons below.
>
> If there's a hot lead you want me to start on now, tell me who.

### System-prompt overlay (`src/persona/system-prompt.ts`, new + `src/agent/prompt-assembler.ts`)

`buildPersonaSystemPromptOverlay` reads `PHANTOM_PERSONA_ID` and `PHANTOM_OWNER_NAME`, looks up the persona, substitutes `${ownerName}` (fallback `"your founder"`), and emits a `# Your Voice And Role` section. Slot 1c in the assembler, after the tenant-self-knowledge overlay (slot 1b). Returns the empty string when the persona is unset or unknown so the slot drops cleanly.

### First-hour-of-work scaffold (`src/persona/work-plan.ts`, new)

`getPersonaWorkPlan(personaId)` returns the `PersonaWorkPlan` shape with empty `data_pulls`, `drafts`, and `open_questions` for each known persona. Slice 15's First-Hour-of-Work engine fills the content; this PR locks the type contract.

## The seven personas

| character_id | display_name | role_phrase |
|---|---|---|
| `sdr-lilian` | Lilian | your SDR |
| `eng-cos-marcus` | Marcus | your engineering chief of staff |
| `am-sloane` | Sloane | your account manager |
| `bdr-theo` | Theo | your BDR |
| `sales-vp-priya` | Priya | your sales leader |
| `gtm-eng-ryan` | Ryan | your GTM engineer |
| `founder-asst-adrian` | Adrian | your founder's assistant |

## Tests

- `src/persona/__tests__/catalog.test.ts` (28 cases): completeness, every required field non-empty, `character_id` matches the catalog key, `default_tools` non-empty, `day1_data_pulls` non-empty, no em dashes / en dashes / emojis / marketing voice in any user-facing field, the seven verbatim taglines and role phrases pinned against the architect doc, `getPersonaById` for known and unknown ids, `readPersonaFromEnv` for set / unset / empty / whitespace / unknown env values.
- `src/persona/__tests__/work-plan.test.ts` (5 cases): per-persona stub shape, null for unknown / unset / empty, mutable arrays for slice 15.
- `src/persona/__tests__/system-prompt.test.ts` (14 cases): per-persona overlay rendering, `${ownerName}` substitution, fallback to `your founder`, empty string for unset / unknown / whitespace persona id, env reader trim and reject-empty.
- `src/channels/__tests__/slack-introduction.test.ts` (89 cases, was 33): every persona renders the named greeting + role phrase + first commitment + open offer in both text and Block Kit; the wire shape stays byte-equal; the persona-less fallback ships PR #120 copy; unset / unknown / empty `PHANTOM_PERSONA_ID` degrades cleanly; per-persona snapshot pin.

Test count delta: +103 (2428 baseline -> 2531 after slice 16b). Typecheck clean. Lint clean.

## Cross-repo invariant

The seven `character_id` strings + display fields are the cross-repo locked fixture. Mirror lands in:

- `phantom/src/persona/catalog.ts` (this slice)
- `phantomd/internal/persona/ids.go` (slice 16c)
- `phantom-control/internal/persona/ids.go` (slice 16d)
- `ghostwright-site/apps/dashboard/src/lib/persona-catalog.ts` (slice 16e)

The verifier `phantom-cloud-deploy/scripts/shared/verify-personas.sh` ships in slice 16d and runs in CI of any of the four repos.

## What still gates Slice 15

- The `PersonaWorkPlan` type contract is locked here; Slice 15 fills `data_pulls`, `drafts`, and `open_questions` per persona.
- Slice 15 reads `PHANTOM_PERSONA_ID` and runs PULL -> IDENTIFY -> DRAFT -> APPROVE.
- The button click handlers in `slack-actions.ts` already wire `phantom:morning_brief:lock|retime|skip`; Slice 15 plugs the recorder against a real preference table.

## Test plan

- [ ] `bun test` clean: 2531 pass / 0 fail
- [ ] `bun test src/persona/` clean: 47 pass
- [ ] `bun test src/channels/__tests__/slack-introduction.test.ts` clean: 89 pass
- [ ] `bun run typecheck` clean
- [ ] `bun run lint` clean
- [ ] After merge + slices 16c through 16e, watch a fresh tenant provision with `PHANTOM_PERSONA_ID=sdr-lilian` and verify the intro DM lands with "Lilian is in." in the header, the Lilian-specific commitment line, and the same three-button actions row click-through.

## Authority

Cheema-merge only on this PUBLIC repo. Do NOT merge.