### PR TITLE
memory: gate heuristic fact extractor against question/length false positives (#84)

### DIFF
--- a/src/memory/__tests__/consolidation.test.ts
+++ b/src/memory/__tests__/consolidation.test.ts
@@ -135,6 +135,60 @@ describe("consolidateSession", () => {
 		expect(storedFacts.length).toBe(0);
 	});
 
+	test("rejects pattern-matching messages that end in a question mark", async () => {
+		const { memory, storedFacts } = createMockMemory();
+		const data = makeTestSessionData({
+			userMessages: ["No did you see the images or no?", "Actually is the deploy script broken?"],
+		});
+
+		const result = await consolidateSession(memory, data);
+
+		expect(result.factsExtracted).toBe(0);
+		expect(storedFacts.length).toBe(0);
+	});
+
+	test("rejects pattern-matching messages with fewer than three words", async () => {
+		const { memory, storedFacts } = createMockMemory();
+		const data = makeTestSessionData({
+			userMessages: ["No actually", "Wrong"],
+		});
+
+		const result = await consolidateSession(memory, data);
+
+		expect(result.factsExtracted).toBe(0);
+		expect(storedFacts.length).toBe(0);
+	});
+
+	test("rejects pattern-matching messages longer than the truncation boundary", async () => {
+		const { memory, storedFacts } = createMockMemory();
+		const longThinkingOutLoud = `No need to ${"keep typing this whole long stream of consciousness ".repeat(6)}and a final clause`;
+		expect(longThinkingOutLoud.length).toBeGreaterThan(200);
+		const data = makeTestSessionData({
+			userMessages: [longThinkingOutLoud],
+		});
+
+		const result = await consolidateSession(memory, data);
+
+		expect(result.factsExtracted).toBe(0);
+		expect(storedFacts.length).toBe(0);
+	});
+
+	test("dedupes identical messages within the same session", async () => {
+		const { memory, storedFacts } = createMockMemory();
+		const data = makeTestSessionData({
+			userMessages: [
+				"I prefer PRs over direct pushes",
+				"I prefer PRs over direct pushes",
+				"  I prefer PRs over direct pushes  ",
+			],
+		});
+
+		const result = await consolidateSession(memory, data);
+
+		expect(result.factsExtracted).toBe(1);
+		expect(storedFacts.length).toBe(1);
+	});
+
 	test("episode detail includes tools and files", async () => {
 		const { memory, storedEpisodes } = createMockMemory();
 		const data = makeTestSessionData({

--- a/src/memory/consolidation.ts
+++ b/src/memory/consolidation.ts
@@ -98,6 +98,21 @@ function calculateImportance(data: SessionData): number {
 	return Math.min(importance, 1.0);
 }
 
+// Gate thresholds for the heuristic extractor. The LLM consolidation judge
+// removed in Phase 3 used to do topic and structure analysis; until that path
+// returns, these guard against the most common false-positive shapes.
+const MIN_FACT_WORDS = 3;
+const MAX_FACT_CHARS = 200;
+
+function isExtractable(message: string): boolean {
+	const trimmed = message.trim();
+	if (trimmed.length === 0) return false;
+	if (trimmed.length > MAX_FACT_CHARS) return false;
+	if (trimmed.endsWith("?")) return false;
+	if (trimmed.split(/\s+/).length < MIN_FACT_WORDS) return false;
+	return true;
+}
+
 /**
  * HEURISTIC FALLBACK: heuristic fact extraction from user messages.
  * Looks for correction patterns, preferences, and explicit facts.
@@ -105,8 +120,15 @@ function calculateImportance(data: SessionData): number {
 function extractFactsFromSession(data: SessionData, episodeId: string): SemanticFact[] {
 	const facts: SemanticFact[] = [];
 	const now = new Date().toISOString();
+	const seen = new Set<string>();
 
 	for (const message of data.userMessages) {
+		if (!isExtractable(message)) continue;
+
+		const normalized = message.trim().toLowerCase();
+		if (seen.has(normalized)) continue;
+		seen.add(normalized);
+
 		const lower = message.toLowerCase();
 
 		if (matchesCorrectionPattern(lower)) {


### PR DESCRIPTION
## Why

Issue #84: my injected `## Known Facts` section is contaminated with verbatim Slack utterances. With the Phase 3 LLM consolidation judge removed, the heuristic extractor at `src/memory/consolidation.ts::extractFactsFromSession` is the only path. Without topic or structure analysis it matches on `/^no[,.]?\s/`, `/make\s+sure\s+(to|you)\s/`, etc., and stores fragments like `No did you see the images or no?` and mid-word truncations of long Slack thinking-out-loud turns at confidence 0.8 / 0.9. `context-builder.ts:36-43` ranks facts above episodes, so the noise displaces real accumulated knowledge in every prompt build.

## What

Three pre-pattern gates plus intra-session dedupe. None touch `patterns.ts` (CLAUDE.md: do not expand) or confidence values (would shift global ranking).

- skip if message is empty or > 200 chars (matches the existing `slice(0, 200)` boundary so we never store a mid-word truncation)
- skip if message ends in `?` (questions aren't preferences or corrections)
- skip if word count < 3
- dedupe by `trim().toLowerCase()` within the session so identical reposts don't multiply

This is direction (1)+(2) from the issue body. The proper fix is restoring the LLM consolidation judge; until then this stops the most visible noise.

## Tests

Four new tests in `consolidation.test.ts`:

- `rejects pattern-matching messages that end in a question mark`
- `rejects pattern-matching messages with fewer than three words`
- `rejects pattern-matching messages longer than the truncation boundary`
- `dedupes identical messages within the same session`

`bun test src/memory/__tests__/consolidation.test.ts` → 13/13 pass. Full memory suite `bun test src/memory/` → 68/68 pass. `bun run lint` clean. `bun run typecheck` shows only pre-existing prom-client errors on `src/channels/slack-metrics.ts` and `src/email/metrics.ts` (unchanged from main).

Closes #84.