### PR TITLE
fix(memory): dedup exact-triple semantic facts on store

### DIFF
--- a/src/memory/__tests__/semantic.test.ts
+++ b/src/memory/__tests__/semantic.test.ts
@@ -272,4 +272,147 @@ describe("SemanticStore", () => {
 		expect(payload.valid_until).toBeDefined();
 		expect(typeof payload.valid_until).toBe("number");
 	});
+
+	test("store() returns existing id and skips upsert when an exact duplicate is already stored", async () => {
+		const vec = make768dVector();
+		let upsertCalled = false;
+		let scrollFilter: Record<string, unknown> | null = null;
+
+		globalThis.fetch = mock((url: string | Request, init?: RequestInit) => {
+			const urlStr = typeof url === "string" ? url : url.url;
+
+			if (urlStr.includes("/api/embed")) {
+				return Promise.resolve(new Response(JSON.stringify({ embeddings: [vec] }), { status: 200 }));
+			}
+
+			if (urlStr.includes("/points/scroll")) {
+				if (init?.body) {
+					const body = JSON.parse(init.body as string) as Record<string, unknown>;
+					scrollFilter = body.filter as Record<string, unknown>;
+				}
+				return Promise.resolve(
+					new Response(
+						JSON.stringify({
+							result: {
+								points: [
+									{
+										id: "fact-existing",
+										payload: {
+											subject: "staging server",
+											predicate: "runs on",
+											object: "port 3001",
+											natural_language: "The staging server runs on port 3001",
+											valid_from: Date.now(),
+											valid_until: null,
+											confidence: 0.9,
+											category: "domain_knowledge",
+											version: 1,
+										},
+									},
+								],
+							},
+						}),
+						{ status: 200, headers: { "Content-Type": "application/json" } },
+					),
+				);
+			}
+
+			if (urlStr.includes("/points?") && init?.method === "PUT") {
+				upsertCalled = true;
+			}
+
+			return Promise.resolve(new Response(JSON.stringify({ status: "ok" }), { status: 200 }));
+		}) as unknown as typeof fetch;
+
+		const qdrant = new QdrantClient(TEST_CONFIG);
+		const embedder = new EmbeddingClient(TEST_CONFIG);
+		const store = new SemanticStore(qdrant, embedder, TEST_CONFIG);
+
+		const fact = makeTestFact({ id: "fact-fresh-uuid" });
+		const id = await store.store(fact);
+
+		expect(id).toBe("fact-existing");
+		expect(upsertCalled).toBe(false);
+		expect(scrollFilter).not.toBeNull();
+		const must = (scrollFilter as unknown as { must?: Array<Record<string, unknown>> })?.must ?? [];
+		const matchKeys = must
+			.filter((c) => "match" in c)
+			.map((c) => (c as { key: string }).key)
+			.sort();
+		expect(matchKeys).toEqual(["object", "predicate", "subject"]);
+	});
+
+	test("store() proceeds with upsert when scroll returns no duplicate", async () => {
+		const vec = make768dVector();
+		let upsertCalled = false;
+
+		globalThis.fetch = mock((url: string | Request, init?: RequestInit) => {
+			const urlStr = typeof url === "string" ? url : url.url;
+
+			if (urlStr.includes("/api/embed")) {
+				return Promise.resolve(new Response(JSON.stringify({ embeddings: [vec] }), { status: 200 }));
+			}
+
+			if (urlStr.includes("/points/scroll")) {
+				return Promise.resolve(new Response(JSON.stringify({ result: { points: [] } }), { status: 200 }));
+			}
+
+			if (urlStr.includes("/points/query")) {
+				return Promise.resolve(new Response(JSON.stringify({ result: { points: [] } }), { status: 200 }));
+			}
+
+			if (urlStr.includes("/points?") && init?.method === "PUT") {
+				upsertCalled = true;
+			}
+
+			return Promise.resolve(new Response(JSON.stringify({ status: "ok" }), { status: 200 }));
+		}) as unknown as typeof fetch;
+
+		const qdrant = new QdrantClient(TEST_CONFIG);
+		const embedder = new EmbeddingClient(TEST_CONFIG);
+		const store = new SemanticStore(qdrant, embedder, TEST_CONFIG);
+
+		const fact = makeTestFact({ id: "fact-fresh-uuid" });
+		const id = await store.store(fact);
+
+		expect(id).toBe("fact-fresh-uuid");
+		expect(upsertCalled).toBe(true);
+	});
+
+	test("findExactDuplicate() filters scroll on subject + predicate + object and excludes invalidated facts", async () => {
+		let scrollFilter: Record<string, unknown> | null = null;
+
+		globalThis.fetch = mock((url: string | Request, init?: RequestInit) => {
+			const urlStr = typeof url === "string" ? url : url.url;
+
+			if (urlStr.includes("/points/scroll")) {
+				if (init?.body) {
+					const body = JSON.parse(init.body as string) as Record<string, unknown>;
+					scrollFilter = body.filter as Record<string, unknown>;
+				}
+				return Promise.resolve(new Response(JSON.stringify({ result: { points: [] } }), { status: 200 }));
+			}
+
+			return Promise.resolve(new Response(JSON.stringify({ status: "ok" }), { status: 200 }));
+		}) as unknown as typeof fetch;
+
+		const qdrant = new QdrantClient(TEST_CONFIG);
+		const embedder = new EmbeddingClient(TEST_CONFIG);
+		const store = new SemanticStore(qdrant, embedder, TEST_CONFIG);
+
+		const result = await store.findExactDuplicate(makeTestFact());
+
+		expect(result).toBeNull();
+		expect(scrollFilter).not.toBeNull();
+		const must = (scrollFilter as unknown as { must?: Array<Record<string, unknown>> })?.must ?? [];
+		const subjectClause = must.find((c) => (c as { key?: string }).key === "subject");
+		const predicateClause = must.find((c) => (c as { key?: string }).key === "predicate");
+		const objectClause = must.find((c) => (c as { key?: string }).key === "object");
+		const validClause = must.find((c) => "is_null" in c);
+
+		expect(subjectClause).toMatchObject({ match: { value: "staging server" } });
+		expect(predicateClause).toMatchObject({ match: { value: "runs on" } });
+		expect(objectClause).toMatchObject({ match: { value: "port 3001" } });
+		expect(validClause).toMatchObject({ is_null: { key: "valid_until" } });
+	});
 });

--- a/src/memory/semantic.ts
+++ b/src/memory/semantic.ts
@@ -48,6 +48,15 @@ export class SemanticStore {
 	}
 
 	async store(fact: SemanticFact): Promise<string> {
+		// If a currently-valid fact with the same subject + predicate + object already exists,
+		// return its id without inserting a duplicate row. Repeated extractions of the same user
+		// message would otherwise accumulate as separate points (each with a fresh randomUUID),
+		// since findContradictions intentionally ignores same-object matches.
+		const duplicate = await this.findExactDuplicate(fact);
+		if (duplicate) {
+			return duplicate.id;
+		}
+
 		// Check for contradictions before storing
 		const contradictions = await this.findContradictions(fact);
 
@@ -106,6 +115,28 @@ export class SemanticStore {
 
 		const minScore = options?.minScore ?? 0;
 		return results.filter((r) => r.score >= minScore).map((r) => this.payloadToFact(r));
+	}
+
+	/**
+	 * Look up a currently-valid fact that already encodes the same (subject, predicate, object)
+	 * triple. Returns the existing fact when one is present so callers can avoid inserting a
+	 * second row, and `null` otherwise.
+	 */
+	async findExactDuplicate(fact: SemanticFact): Promise<SemanticFact | null> {
+		const { points } = await this.qdrant.scroll(this.collectionName, {
+			limit: 1,
+			filter: {
+				must: [
+					{ key: "subject", match: { value: fact.subject } },
+					{ key: "predicate", match: { value: fact.predicate } },
+					{ key: "object", match: { value: fact.object } },
+					{ is_null: { key: "valid_until" } },
+				],
+			},
+			withPayload: true,
+		});
+		if (points.length === 0) return null;
+		return this.payloadToFact(points[0]);
 	}
 
 	async findContradictions(newFact: SemanticFact): Promise<SemanticFact[]> {


### PR DESCRIPTION
`SemanticStore.store` has only ever guarded against duplicates through `findContradictions`, which intentionally skips same-object matches (`src/memory/semantic.ts:131`):

```ts
return existingObject !== newFact.object;
```

`SemanticConsolidator.consolidate` mints a fresh `crypto.randomUUID()` per extraction (`src/memory/consolidation.ts:114, 132`), so re-running consolidation on the same input writes a new point each time even though the triple `(subject, predicate, object)` is unchanged. Working memory grows linearly with re-extraction count, which is exactly what #125 reports.

First-person evidence in my own working memory: same `Known Facts` line repeated four times across recent sessions, each at confidence 0.8 with a distinct UUID.

## Fix

Add `findExactDuplicate` as a single qdrant `scroll` filtered by `subject` + `predicate` + `object` + `is_null:valid_until`, called from `store` before any embed/upsert work. If a currently-valid fact already encodes the same triple, return its id and skip the upsert. Cost is one indexed scroll (`limit: 1`) — all four fields are already in `PAYLOAD_INDEXES`.

The check runs before `findContradictions` so the contradiction-resolution path is unchanged for genuine subject-predicate updates with a different object.

## Tests

Three new cases in `src/memory/__tests__/semantic.test.ts`:

- `store()` returns the existing id and skips upsert when a duplicate is already stored
- `store()` proceeds with upsert when scroll returns no duplicate
- `findExactDuplicate()` filters scroll on `subject` + `predicate` + `object` and excludes invalidated facts (`is_null: valid_until`)

`bun test src/memory/__tests__/semantic.test.ts` → 8 pass / 0 fail.

Closes #125