### PR TITLE
hooks: cover -f and +refspec force-push spellings

### DIFF
--- a/src/agent/__tests__/hooks.test.ts
+++ b/src/agent/__tests__/hooks.test.ts
@@ -109,6 +109,108 @@ describe("createDangerousCommandBlocker", () => {
 		expect(result).toHaveProperty("decision", "block");
 	});
 
+	test("blocks git push -f (short force flag)", async () => {
+		const hook = createDangerousCommandBlocker();
+		const callback = hook.hooks[0];
+
+		const result = await callback(
+			makeHookInput({
+				hook_event_name: "PreToolUse",
+				tool_name: "Bash",
+				tool_input: { command: "git push -f origin main" },
+			}),
+			undefined,
+			{ signal: new AbortController().signal },
+		);
+
+		expect(result).toHaveProperty("decision", "block");
+	});
+
+	test("blocks git push with +refspec force prefix", async () => {
+		const hook = createDangerousCommandBlocker();
+		const callback = hook.hooks[0];
+
+		const result = await callback(
+			makeHookInput({
+				hook_event_name: "PreToolUse",
+				tool_name: "Bash",
+				tool_input: { command: "git push origin +main:main" },
+			}),
+			undefined,
+			{ signal: new AbortController().signal },
+		);
+
+		expect(result).toHaveProperty("decision", "block");
+	});
+
+	test("blocks git push with quoted +refspec", async () => {
+		const hook = createDangerousCommandBlocker();
+		const callback = hook.hooks[0];
+
+		const result = await callback(
+			makeHookInput({
+				hook_event_name: "PreToolUse",
+				tool_name: "Bash",
+				tool_input: { command: 'git push origin "+HEAD:refs/heads/main"' },
+			}),
+			undefined,
+			{ signal: new AbortController().signal },
+		);
+
+		expect(result).toHaveProperty("decision", "block");
+	});
+
+	test("blocks git push --force-with-lease", async () => {
+		const hook = createDangerousCommandBlocker();
+		const callback = hook.hooks[0];
+
+		const result = await callback(
+			makeHookInput({
+				hook_event_name: "PreToolUse",
+				tool_name: "Bash",
+				tool_input: { command: "git push --force-with-lease origin main" },
+			}),
+			undefined,
+			{ signal: new AbortController().signal },
+		);
+
+		expect(result).toHaveProperty("decision", "block");
+	});
+
+	test("allows + inside a token (not a force refspec)", async () => {
+		const hook = createDangerousCommandBlocker();
+		const callback = hook.hooks[0];
+
+		const result = await callback(
+			makeHookInput({
+				hook_event_name: "PreToolUse",
+				tool_name: "Bash",
+				tool_input: { command: "git push origin tag+sign:main" },
+			}),
+			undefined,
+			{ signal: new AbortController().signal },
+		);
+
+		expect(result).toEqual({ continue: true });
+	});
+
+	test("allows -f outside a git push context", async () => {
+		const hook = createDangerousCommandBlocker();
+		const callback = hook.hooks[0];
+
+		const result = await callback(
+			makeHookInput({
+				hook_event_name: "PreToolUse",
+				tool_name: "Bash",
+				tool_input: { command: "ls -f /tmp" },
+			}),
+			undefined,
+			{ signal: new AbortController().signal },
+		);
+
+		expect(result).toEqual({ continue: true });
+	});
+
 	test("blocks docker system prune", async () => {
 		const hook = createDangerousCommandBlocker();
 		const callback = hook.hooks[0];

--- a/src/agent/hooks.ts
+++ b/src/agent/hooks.ts
@@ -14,6 +14,8 @@ const DANGEROUS_COMMANDS: { pattern: RegExp; label: string }[] = [
 	{ pattern: /docker\s+volume\s+prune/, label: "docker volume prune" },
 	{ pattern: /docker\s+system\s+prune/, label: "docker system prune" },
 	{ pattern: /git\s+push\s+.*--force/, label: "git push --force" },
+	{ pattern: /git\s+push\s+(?:\S+\s+)*-f(?=\s|$)/, label: "git push -f" },
+	{ pattern: /git\s+push\s+.*\s["']?\+\S+/, label: "git push +refspec" },
 	{ pattern: /git\s+reset\s+--hard/, label: "git reset --hard" },
 	{ pattern: /rm\s+-rf\s+\/(\s|$)/, label: "rm -rf /" },
 	{ pattern: /rm\s+-rf\s+\/home(\s|$)/, label: "rm -rf /home" },


### PR DESCRIPTION
Closes #131.

## Problem

The dangerous-command blocker has one force-push pattern,
`/git\s+push\s+.*--force/`, which catches `--force`,
`--force-with-lease`, and `--force-if-includes` via substring
prefix. It misses two equivalent spellings:

1. The short flag `-f`, same semantics as `--force`.
2. The refspec prefix `+<src>:<dst>`, where a leading `+` tells
   the remote to accept a non-fast-forward update.

The asymmetric coverage blocks the verbose-and-safer spellings
while letting the bare-and-riskier ones through.

## Fix

Two additional patterns in `DANGEROUS_COMMANDS`:

```ts
{ pattern: /git\s+push\s+(?:\S+\s+)*-f(?=\s|$)/, label: "git push -f" },
{ pattern: /git\s+push\s+.*\s["']?\+\S+/, label: "git push +refspec" },
```

The `-f` pattern uses a token-walk `(?:\S+\s+)*` + boundary
lookahead so it matches `-f` as a standalone flag and doesn't
trip on substrings like `--force-if-includes` or `-fwoo`.

The `+refspec` pattern requires whitespace (or a wrapping quote)
immediately before the `+`, so a `+` inside a token like
`tag+sign:main` does not false-positive.

## Tests

Six new cases in `src/agent/__tests__/hooks.test.ts`:

| Case | Expected |
|------|----------|
| `git push -f origin main` | block |
| `git push origin +main:main` | block |
| `git push origin "+HEAD:refs/heads/main"` | block |
| `git push --force-with-lease origin main` | block (already, asserts intent) |
| `git push origin tag+sign:main` | allow (false-positive guard for `+` in token) |
| `ls -f /tmp` | allow (false-positive guard for `-f` outside push) |

Also prototype-tested 21 cases off-tree before edit covering
`git fetch --force`, `git stash push --force`, `git config
push.default current`, quoted-refspec forms, and multi-flag
push lines.

## Verification

- `bun test src/agent/__tests__/hooks.test.ts` — 17/17 pass
- Full suite — same 9 pre-existing failures as `origin/main`
  (handleEmailLogin Resend, loadConfig fixture-env, phantom init
  yaml, assemblePrompt bare-metal); none touched by this PR
