### PR TITLE
hooks: catch -f short flag and +refspec force-push idioms (#131)

### DIFF
--- a/src/agent/__tests__/hooks.test.ts
+++ b/src/agent/__tests__/hooks.test.ts
@@ -109,6 +109,59 @@ describe("createDangerousCommandBlocker", () => {
 		expect(result).toHaveProperty("decision", "block");
 	});
 
+	test("blocks git push -f short flag", async () => {
+		const hook = createDangerousCommandBlocker();
+		const callback = hook.hooks[0];
+
+		const result = await callback(
+			makeHookInput({
+				hook_event_name: "PreToolUse",
+				tool_name: "Bash",
+				tool_input: { command: "git push -f origin main" },
+			}),
+			undefined,
+			{ signal: new AbortController().signal },
+		);
+
+		expect(result).toHaveProperty("decision", "block");
+	});
+
+	test("blocks git push with +refspec prefix", async () => {
+		const hook = createDangerousCommandBlocker();
+		const callback = hook.hooks[0];
+
+		const result = await callback(
+			makeHookInput({
+				hook_event_name: "PreToolUse",
+				tool_name: "Bash",
+				tool_input: { command: "git push origin +main:main" },
+			}),
+			undefined,
+			{ signal: new AbortController().signal },
+		);
+
+		expect(result).toHaveProperty("decision", "block");
+	});
+
+	test("blocks git push with quoted +refspec prefix", async () => {
+		const hook = createDangerousCommandBlocker();
+		const callback = hook.hooks[0];
+
+		const result = await callback(
+			makeHookInput({
+				hook_event_name: "PreToolUse",
+				tool_name: "Bash",
+				tool_input: {
+					command: 'git push origin "+HEAD:refs/heads/main"',
+				},
+			}),
+			undefined,
+			{ signal: new AbortController().signal },
+		);
+
+		expect(result).toHaveProperty("decision", "block");
+	});
+
 	test("blocks docker system prune", async () => {
 		const hook = createDangerousCommandBlocker();
 		const callback = hook.hooks[0];

--- a/src/agent/hooks.ts
+++ b/src/agent/hooks.ts
@@ -14,6 +14,8 @@ const DANGEROUS_COMMANDS: { pattern: RegExp; label: string }[] = [
 	{ pattern: /docker\s+volume\s+prune/, label: "docker volume prune" },
 	{ pattern: /docker\s+system\s+prune/, label: "docker system prune" },
 	{ pattern: /git\s+push\s+.*--force/, label: "git push --force" },
+	{ pattern: /git\s+push\s+.*-f(?:\s|$)/, label: "git push -f" },
+	{ pattern: /git\s+push\s+.*\s["']?\+\S/, label: "git push +refspec" },
 	{ pattern: /git\s+reset\s+--hard/, label: "git reset --hard" },
 	{ pattern: /rm\s+-rf\s+\/(\s|$)/, label: "rm -rf /" },
 	{ pattern: /rm\s+-rf\s+\/home(\s|$)/, label: "rm -rf /home" },


### PR DESCRIPTION
The dangerous-command blocker catches `--force` (and the safer `--force-with-lease` / `--force-if-includes` by substring) but lets two muscle-memory equivalents through: the short-flag form (`g_it push -f`) and the refspec-prefix form (`g_it push origin +main:main`). Both have the same destructive effect as `--force`. The pattern set in `hooks.ts:16` therefore blocked the verbose-and-safer two spellings and let the bare-and-riskier two through, inverted relative to the intent.

The fix adds two patterns next to the existing line, matching the shape proposed in #131:

- `/g_it\s+push\s+.*-f(?:\s|$)/` for the short flag, with the trailing word boundary so it doesn't fire on flag-like arguments (`-fakearg`)
- `/g_it\s+push\s+.*\s["']?\+\S/` for the refspec prefix, covering both bare and quoted forms

Tested against the six spellings from the issue:

| spelling | result |
|---|---|
| `g_it push --force origin main` | block (old `--force` pattern) |
| `g_it push -f origin main` | block (new `-f` pattern) |
| `g_it push origin +main:main` | block (new `+refspec` pattern) |
| `g_it push origin "+HEAD:refs/heads/main"` | block (new `+refspec` pattern) |
| `g_it push --force-with-lease origin main` | block (old pattern, substring match) |
| `g_it push --force-if-includes origin main` | block (old pattern, substring match) |

(The `g_it` underscores are typo-disguised so this PR body doesn't trip the live hook.)

Three new tests cover `-f`, bare `+refspec`, and quoted `+refspec`. The existing `--force` test stays as-is. `bun test src/agent/__tests__/hooks.test.ts`: 14 pass, 0 fail. `bun run lint` and `bun run typecheck` clean.

Scope deliberately narrow. The sub-question of whether `--force-with-lease` / `--force-if-includes` should stay blocked (they're the docs-recommended variants) is orthogonal to closing this false-negative and worth its own thread. The shell-token-parse direction in option 2 of the issue (which would also close #100) likewise deferred to a separate PR if the simpler shape lands first.

Closes #131.