### PR TITLE
fix(scheduler): honor a pauseJob() that lands while a job is in flight

### DIFF
--- a/src/scheduler/__tests__/scheduler-hardening.test.ts
+++ b/src/scheduler/__tests__/scheduler-hardening.test.ts
@@ -506,6 +506,40 @@ describe("Phase 2.5 scheduler fixes", () => {
 			expect(after?.lastDeliveryStatus).toContain("ECONNREFUSED");
 			expect(after?.lastRunStatus).toBe("ok");
 		});
+
+		test("a pauseJob() that lands mid-run is honored, not stomped by the write-back (#148)", async () => {
+			const runtime = createMockRuntime();
+			const scheduler = new Scheduler({ db, runtime: runtime as never });
+
+			const job = scheduler.createJob({
+				name: "Pause Mid Run",
+				schedule: { kind: "every", intervalMs: 60_000 },
+				task: "x",
+			});
+
+			// Simulate a pauseJob() landing while handleMessage is in flight: the
+			// status flips to 'paused' after executeJob captured its 'active'
+			// snapshot at pickup. Before the fix, the unconditional write-back
+			// stomped this back to 'active' and the next fire ran anyway.
+			runtime.handleMessage.mockImplementation(async () => {
+				db.run("UPDATE scheduled_jobs SET status = 'paused' WHERE id = ?", [job.id]);
+				return {
+					text: "Mock response",
+					sessionId: "mock-session",
+					cost: { totalUsd: 0, inputTokens: 0, outputTokens: 0, modelUsage: {} },
+					durationMs: 10,
+				};
+			});
+
+			await scheduler.runJobNow(job.id);
+
+			const after = scheduler.getJob(job.id);
+			// The concurrent pause must survive: status stays 'paused' and the
+			// recurring job gets no next fire scheduled. resumeJob() recomputes
+			// next_run_at when the operator un-pauses.
+			expect(after?.status).toBe("paused");
+			expect(after?.nextRunAt).toBeNull();
+		});
 	});
 
 	// ---------- M1: non-blocking missed-job recovery ----------

--- a/src/scheduler/executor.ts
+++ b/src/scheduler/executor.ts
@@ -100,6 +100,23 @@ export async function executeJob(job: ScheduledJob, ctx: ExecutorContext): Promi
 		});
 	}
 
+	// handleMessage for an agent task runs for minutes, and pauseJob() can land
+	// during that window. We computed newStatus from the job snapshot taken at
+	// pickup, so an unconditional write-back would silently stomp a concurrent
+	// pause. Re-read the live status and honor an external pause. Only the
+	// 'active' continuation case is at risk: 'completed' and 'failed' are this
+	// run's terminal outcomes and must win. resumeJob() recomputes next_run_at,
+	// so clearing it here is safe.
+	if (newStatus === "active") {
+		const live = ctx.db.query("SELECT status FROM scheduled_jobs WHERE id = ?").get(job.id) as {
+			status: string;
+		} | null;
+		if (live?.status === "paused") {
+			newStatus = "paused";
+			nextRunAt = null;
+		}
+	}
+
 	// Runtime safety net for OOS#4.
 	if (!JOB_STATUS_VALUES.includes(newStatus)) {
 		throw new Error(`refusing to write invalid status '${newStatus}' for job ${job.id}`);


### PR DESCRIPTION
## Summary

`executeJob` captures `newStatus` from the in-memory job snapshot taken at pickup, then writes it back unconditionally after `handleMessage` returns. Because an agent task can run for minutes, a `pauseJob()` call landing during that window writes `status='paused'` to the row, but the write-back stomps it back to `'active'` and the next scheduled fire runs anyway. The pause is silently lost.

This honors a concurrent pause by re-reading the live status just before the write-back.

## Why this matters

`pauseJob()` (`service.ts`) does `UPDATE ... SET status='paused' WHERE id=? AND status='active'`. The SQL succeeds, but `executeJob`'s final `UPDATE scheduled_jobs SET ... status=?` uses the stale captured value and overwrites it. An operator who pauses a long-running recurring job mid-execution sees it keep firing. There is no error, no log, nothing to debug against.

## The fix

Right before the write-back, re-read the row's current status. If an external writer set it to `'paused'` during the run, honor it (and clear `next_run_at`). The guard is scoped to the `'active'` continuation case only: `'completed'` and `'failed'` are this run's terminal outcomes and must win over a concurrent pause. `resumeJob()` recomputes `next_run_at` from the schedule when the operator un-pauses, so clearing it here is safe.

```typescript
if (newStatus === "active") {
	const live = ctx.db.query("SELECT status FROM scheduled_jobs WHERE id = ?").get(job.id) as {
		status: string;
	} | null;
	if (live?.status === "paused") {
		newStatus = "paused";
		nextRunAt = null;
	}
}
```

One extra single-row read per fire, only on the continuation path.

## Test

Adds a regression test in `scheduler-hardening.test.ts`. The mocked `handleMessage` performs the concurrent pause mid-run (`UPDATE ... SET status='paused'`), then the test asserts the row stays `'paused'` with `next_run_at` null after `executeJob`.

Mutation-proved: reverting the fix turns the test red (`Expected: "paused"`), restoring it turns it green.

- `bun test src/scheduler/` -> 116 pass, 0 fail
- `bun run lint` -> clean
- `bun run typecheck` -> clean

Fixes #148