### PR TITLE
providers: add MiniMax preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,10 +77,11 @@ This is what happens when you give an AI its own computer.
 
 ## Bring Your Own Model
 
-Phantom is not locked to any single AI backend. It ships with support for seven providers out of the box, configured through a single YAML block:
+Phantom is not locked to any single AI backend. It ships with support for eight providers out of the box, configured through a single YAML block:
 
 - **Anthropic** (default) - Claude Opus, Sonnet, Haiku
 - **Z.AI** - GLM-5.1 and GLM-4.5-Air via [Z.AI's Anthropic-compatible API](https://docs.z.ai/guides/llm/glm-5). Roughly 15x cheaper than Claude Opus for comparable coding quality.
+- **MiniMax** - MiniMax-M3 and MiniMax-M2.7 through Anthropic- and OpenAI-compatible endpoints
 - **OpenRouter** - 100+ models through one key
 - **Ollama** - Any GGUF model on your own GPU, zero API cost
 - **vLLM** - Self-hosted inference with OpenAI-compatible endpoints

--- a/config/phantom.yaml
+++ b/config/phantom.yaml
@@ -24,7 +24,7 @@ timeout_minutes: 240
 # the chosen provider; authentication happens at the env var named below.
 #
 # provider:
-#   type: anthropic            # anthropic | zai | openrouter | vllm | ollama | litellm | custom
+#   type: anthropic            # anthropic | zai | minimax | openrouter | vllm | ollama | litellm | custom
 #   # api_key_env: ANTHROPIC_API_KEY
 #
 # Example: GLM-5.1 via Z.AI's Anthropic-compatible API (15x cheaper than Opus)
@@ -35,6 +35,15 @@ timeout_minutes: 240
 #     opus: glm-5.1
 #     sonnet: glm-5.1
 #     haiku: glm-4.5-air
+#
+# Example: MiniMax with the two current text models
+# provider:
+#   type: minimax
+#   api_key_env: MINIMAX_API_KEY
+#   model_mappings:
+#     opus: MiniMax-M3
+#     sonnet: MiniMax-M3
+#     haiku: MiniMax-M2.7
 #
 # Example: Murph runtime with OpenAI. Requires @murph/anthropic-sdk-shim to be
 # installed or linked into this Phantom project.

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -43,6 +43,7 @@ phantom start --agent-runtime murph
 | `anthropic` (default) | `https://api.anthropic.com` | `ANTHROPIC_API_KEY` | Claude Opus, Sonnet, Haiku |
 | `openai` | `https://api.openai.com` | `OPENAI_API_KEY` | Murph runtime only |
 | `zai` | `https://api.z.ai/api/anthropic` | `ZAI_API_KEY` | GLM-5.1 and GLM-4.5-Air, roughly 15x cheaper than Opus |
+| `minimax` | `https://api.minimax.io/anthropic` | `MINIMAX_API_KEY` | MiniMax-M3 and MiniMax-M2.7 |
 | `openrouter` | `https://openrouter.ai/api/v1` | `OPENROUTER_API_KEY` | 100+ models through a single key |
 | `vllm` | `http://localhost:8000` | none | Self-hosted OpenAI-compatible inference |
 | `ollama` | `http://localhost:11434` | none | Local GGUF models, zero API cost |
@@ -129,6 +130,63 @@ ZAI_API_KEY=<your-zai-key>
 ```
 
 Both the main agent and every evolution judge route through Z.AI. The `claude-sonnet-4-6` model name is translated to `glm-5.1` on the wire by the `model_mappings` block.
+
+### MiniMax
+
+The `minimax` preset supports both current text models. The default Anthropic runtime uses the Anthropic-compatible endpoint, while Murph uses the OpenAI-compatible endpoint.
+
+| Model | Context window | Input modalities | Thinking |
+|------|----------------|------------------|----------|
+| `MiniMax-M3` | 1,000,000 tokens | text, image, video | adaptive or disabled |
+| `MiniMax-M2.7` | 204,800 tokens | text | always on |
+
+```yaml
+# phantom.yaml, default Anthropic runtime
+model: claude-sonnet-4-6
+provider:
+  type: minimax
+  api_key_env: MINIMAX_API_KEY
+  model_mappings:
+    opus: MiniMax-M3
+    sonnet: MiniMax-M3
+    haiku: MiniMax-M2.7
+```
+
+```bash
+# .env
+MINIMAX_API_KEY=<your-minimax-key>
+```
+
+Choose the endpoint for the runtime protocol and region:
+
+| Runtime protocol | Global default | China override |
+|------------------|----------------|----------------|
+| Anthropic | `https://api.minimax.io/anthropic` | `https://api.minimaxi.com/anthropic` |
+| Murph OpenAI-compatible | `https://api.minimax.io/v1` | `https://api.minimaxi.com/v1` |
+
+The Anthropic client appends `/v1/messages`, so its base URL must end at `/anthropic`; the resulting global request URL is `https://api.minimax.io/anthropic/v1/messages`. To use the China endpoint, set the matching value from the table as `provider.base_url`.
+
+For the OpenAI-compatible route, select Murph and use the concrete model ID:
+
+```yaml
+# phantom.yaml, Murph runtime
+agent_runtime: murph
+model: MiniMax-M3
+provider:
+  type: minimax
+```
+
+Pay-as-you-go prices are in USD per million tokens. MiniMax-M3 pricing depends on both the service tier and input length, so each tier is listed separately.
+
+| Model / service tier | Input length | Input | Output | Cache read | Cache write |
+|----------------------|--------------|-------|--------|------------|-------------|
+| `MiniMax-M3` standard | up to 512k | $0.30 | $1.20 | $0.06 | n/a |
+| `MiniMax-M3` standard | over 512k | $0.60 | $2.40 | $0.12 | n/a |
+| `MiniMax-M3` priority | up to 512k | $0.45 | $1.80 | $0.09 | n/a |
+| `MiniMax-M3` priority | over 512k | $0.90 | $3.60 | $0.18 | n/a |
+| `MiniMax-M2.7` | all requests | $0.30 | $1.20 | $0.06 | $0.375 |
+
+See the [MiniMax Anthropic API documentation](https://platform.minimax.io/docs/api-reference/text-anthropic-api) and [current pricing](https://platform.minimax.io/docs/guides/pricing-paygo) for API details.
 
 ### Ollama (local, free)
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -140,7 +140,7 @@ The `minimax` preset supports both current models. The default Anthropic runtime
 | `MiniMax-M3` | 1,000,000 tokens | text, image, video | adaptive or disabled |
 | `MiniMax-M2.7` | 204,800 tokens | text | always on |
 
-Phantom sends adaptive thinking by default for both runtime protocols. MiniMax-M3 also supports disabled thinking at the API level, while MiniMax-M2.7 always keeps thinking enabled.
+Phantom sends adaptive thinking for MiniMax-M3 by default. MiniMax-M3 also supports disabled thinking at the API level, while MiniMax-M2.7 always keeps thinking enabled.
 
 ```yaml
 # phantom.yaml, default Anthropic runtime

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -133,12 +133,14 @@ Both the main agent and every evolution judge route through Z.AI. The `claude-so
 
 ### MiniMax
 
-The `minimax` preset supports both current text models. The default Anthropic runtime uses the Anthropic-compatible endpoint, while Murph uses the OpenAI-compatible endpoint.
+The `minimax` preset supports both current models. The default Anthropic runtime uses the Anthropic-compatible endpoint, while Murph uses the OpenAI-compatible endpoint. The listed context window is the combined input and output budget.
 
 | Model | Context window | Input modalities | Thinking |
 |------|----------------|------------------|----------|
 | `MiniMax-M3` | 1,000,000 tokens | text, image, video | adaptive or disabled |
 | `MiniMax-M2.7` | 204,800 tokens | text | always on |
+
+Phantom sends adaptive thinking by default for both runtime protocols. MiniMax-M3 also supports disabled thinking at the API level, while MiniMax-M2.7 always keeps thinking enabled.
 
 ```yaml
 # phantom.yaml, default Anthropic runtime

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -178,15 +178,12 @@ provider:
   type: minimax
 ```
 
-Pay-as-you-go prices are in USD per million tokens. MiniMax-M3 pricing depends on both the service tier and input length, so each tier is listed separately.
+Pay-as-you-go prices are in USD per million tokens.
 
-| Model / service tier | Input length | Input | Output | Cache read | Cache write |
-|----------------------|--------------|-------|--------|------------|-------------|
-| `MiniMax-M3` standard | up to 512k | $0.30 | $1.20 | $0.06 | n/a |
-| `MiniMax-M3` standard | over 512k | $0.60 | $2.40 | $0.12 | n/a |
-| `MiniMax-M3` priority | up to 512k | $0.45 | $1.80 | $0.09 | n/a |
-| `MiniMax-M3` priority | over 512k | $0.90 | $3.60 | $0.18 | n/a |
-| `MiniMax-M2.7` | all requests | $0.30 | $1.20 | $0.06 | $0.375 |
+| Model | Input | Output | Cache read | Cache write |
+|-------|-------|--------|------------|-------------|
+| `MiniMax-M3` | $0.60 | $2.40 | $0.12 | n/a |
+| `MiniMax-M2.7` | $0.30 | $1.20 | $0.06 | $0.375 |
 
 See the [MiniMax Anthropic API documentation](https://platform.minimax.io/docs/api-reference/text-anthropic-api) and [current pricing](https://platform.minimax.io/docs/guides/pricing-paygo) for API details.
 

--- a/src/agent/__tests__/thinking-config.test.ts
+++ b/src/agent/__tests__/thinking-config.test.ts
@@ -26,6 +26,11 @@ describe("getThinkingConfig", () => {
 		expect(getThinkingConfig("claude-mythos-preview")).toEqual({ type: "adaptive" });
 	});
 
+	test("MiniMax models use the adaptive request shape", () => {
+		expect(getThinkingConfig("MiniMax-M3")).toEqual({ type: "adaptive" });
+		expect(getThinkingConfig("MiniMax-M2.7")).toEqual({ type: "adaptive" });
+	});
+
 	test("Haiku 4.5 returns enabled + budgetTokens (Haiku rejects adaptive with 400)", () => {
 		const config = getThinkingConfig(JUDGE_MODEL_HAIKU);
 		expect(config.type).toBe("enabled");

--- a/src/agent/__tests__/thinking-config.test.ts
+++ b/src/agent/__tests__/thinking-config.test.ts
@@ -26,9 +26,15 @@ describe("getThinkingConfig", () => {
 		expect(getThinkingConfig("claude-mythos-preview")).toEqual({ type: "adaptive" });
 	});
 
-	test("MiniMax models use the adaptive request shape", () => {
+	test("MiniMax-M3 uses the adaptive request shape", () => {
 		expect(getThinkingConfig("MiniMax-M3")).toEqual({ type: "adaptive" });
-		expect(getThinkingConfig("MiniMax-M2.7")).toEqual({ type: "adaptive" });
+	});
+
+	test("MiniMax-M2.7 keeps thinking enabled", () => {
+		expect(getThinkingConfig("MiniMax-M2.7")).toEqual({
+			type: "enabled",
+			budgetTokens: 8192,
+		});
 	});
 
 	test("Haiku 4.5 returns enabled + budgetTokens (Haiku rejects adaptive with 400)", () => {

--- a/src/agent/thinking-config.ts
+++ b/src/agent/thinking-config.ts
@@ -20,6 +20,7 @@
 import type { ThinkingConfig } from "@anthropic-ai/claude-agent-sdk";
 
 const ADAPTIVE_PREFIXES: readonly string[] = [
+	"MiniMax-M3",
 	"claude-opus-4-7",
 	"claude-opus-4-6",
 	"claude-sonnet-4-6",
@@ -27,6 +28,7 @@ const ADAPTIVE_PREFIXES: readonly string[] = [
 ];
 
 const MANUAL_ONLY_PREFIXES: readonly string[] = [
+	"MiniMax-M2.7",
 	"claude-haiku-4",
 	"claude-haiku-3",
 	"claude-sonnet-3",

--- a/src/config/__tests__/loader-metadata.test.ts
+++ b/src/config/__tests__/loader-metadata.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { loadConfig } from "../loader.ts";
+import { buildProviderEnv } from "../providers.ts";
 
 // Distinct TEST_DIR from loader.test.ts so the two suites cannot race on the
 // same filesystem path when bun runs them in parallel.
@@ -180,6 +181,36 @@ provider:
 		expect(process.env.ANTHROPIC_AUTH_TOKEN).toBeUndefined();
 		expect(process.env.OPENAI_API_KEY).toBeUndefined();
 		expect(process.env.ZAI_API_KEY).toBeUndefined();
+	});
+
+	test("secret_source: metadata with default MiniMax reaches the runtime environment", async () => {
+		const stubBody = "minimax-provider-token";
+		globalThis.fetch = mock((url: string | Request) => {
+			expect(String(url)).toBe("http://gateway.test/v1/secrets/provider_token");
+			return Promise.resolve(
+				new Response(stubBody, {
+					status: 200,
+					headers: { "X-Phantom-Rotation-Id": "1" },
+				}),
+			);
+		}) as unknown as typeof fetch;
+
+		const path = writeYaml(
+			"metadata-default-minimax.yaml",
+			`
+name: metadata-minimax
+secret_source: metadata
+secret_source_url: http://gateway.test
+provider:
+  type: minimax
+`,
+		);
+		const config = await loadConfig(path);
+		const env = buildProviderEnv(config);
+
+		expect(process.env.MINIMAX_API_KEY).toBe(stubBody);
+		expect(env.ANTHROPIC_API_KEY).toBe(stubBody);
+		expect(env.ANTHROPIC_AUTH_TOKEN).toBe(stubBody);
 	});
 
 	test("secret_source: metadata resolves whole-string ${secret:NAME} references in nested config", async () => {

--- a/src/config/__tests__/loader-metadata.test.ts
+++ b/src/config/__tests__/loader-metadata.test.ts
@@ -24,6 +24,7 @@ describe("loadConfig secret_source", () => {
 		"ANTHROPIC_AUTH_TOKEN",
 		"OPENAI_API_KEY",
 		"ZAI_API_KEY",
+		"MINIMAX_API_KEY",
 		"OPENROUTER_API_KEY",
 		"LITELLM_KEY",
 	] as const;
@@ -32,6 +33,7 @@ describe("loadConfig secret_source", () => {
 		ANTHROPIC_AUTH_TOKEN: undefined,
 		OPENAI_API_KEY: undefined,
 		ZAI_API_KEY: undefined,
+		MINIMAX_API_KEY: undefined,
 		OPENROUTER_API_KEY: undefined,
 		LITELLM_KEY: undefined,
 	};
@@ -147,6 +149,37 @@ provider:
 		expect(process.env.ANTHROPIC_API_KEY).toBeUndefined();
 		expect(process.env.ANTHROPIC_AUTH_TOKEN).toBeUndefined();
 		expect(process.env.OPENAI_API_KEY).toBeUndefined();
+	});
+
+	test("secret_source: metadata with Murph MiniMax populates only MINIMAX_API_KEY", async () => {
+		const stubBody = "minimax-provider-token";
+		globalThis.fetch = mock((url: string | Request) => {
+			expect(String(url)).toBe("http://gateway.test/v1/secrets/provider_token");
+			return Promise.resolve(
+				new Response(stubBody, {
+					status: 200,
+					headers: { "X-Phantom-Rotation-Id": "1" },
+				}),
+			);
+		}) as unknown as typeof fetch;
+
+		const path = writeYaml(
+			"metadata-murph-minimax.yaml",
+			`
+name: metadata-minimax
+agent_runtime: murph
+secret_source: metadata
+secret_source_url: http://gateway.test
+provider:
+  type: minimax
+`,
+		);
+		await loadConfig(path);
+		expect(process.env.MINIMAX_API_KEY).toBe(stubBody);
+		expect(process.env.ANTHROPIC_API_KEY).toBeUndefined();
+		expect(process.env.ANTHROPIC_AUTH_TOKEN).toBeUndefined();
+		expect(process.env.OPENAI_API_KEY).toBeUndefined();
+		expect(process.env.ZAI_API_KEY).toBeUndefined();
 	});
 
 	test("secret_source: metadata resolves whole-string ${secret:NAME} references in nested config", async () => {

--- a/src/config/__tests__/loader.test.ts
+++ b/src/config/__tests__/loader.test.ts
@@ -460,6 +460,28 @@ provider:
 		}
 	});
 
+	test("loads a MiniMax provider block", async () => {
+		const path = writeYaml(
+			"minimax-provider.yaml",
+			`
+name: test
+provider:
+  type: minimax
+  api_key_env: MINIMAX_API_KEY
+  model_mappings:
+    sonnet: MiniMax-M3
+`,
+		);
+		try {
+			const config = await loadConfig(path);
+			expect(config.provider.type).toBe("minimax");
+			expect(config.provider.api_key_env).toBe("MINIMAX_API_KEY");
+			expect(config.provider.model_mappings?.sonnet).toBe("MiniMax-M3");
+		} finally {
+			cleanup();
+		}
+	});
+
 	test("loads provider.type: openai when Murph runtime is selected", async () => {
 		const path = writeYaml(
 			"openai-provider-murph.yaml",

--- a/src/config/__tests__/providers.test.ts
+++ b/src/config/__tests__/providers.test.ts
@@ -29,6 +29,7 @@ const WATCHED = [
 	"ANTHROPIC_BASE_URL",
 	"OPENAI_API_KEY",
 	"ZAI_API_KEY",
+	"MINIMAX_API_KEY",
 	"OPENROUTER_API_KEY",
 	"LITELLM_KEY",
 	"MURPH_PROVIDER",
@@ -69,7 +70,17 @@ describe("ProviderSchema", () => {
 	});
 
 	test("accepts each valid provider type", () => {
-		for (const type of ["anthropic", "openai", "zai", "openrouter", "vllm", "ollama", "litellm", "custom"] as const) {
+		for (const type of [
+			"anthropic",
+			"openai",
+			"zai",
+			"minimax",
+			"openrouter",
+			"vllm",
+			"ollama",
+			"litellm",
+			"custom",
+		] as const) {
 			const parsed = ProviderSchema.parse({ type });
 			expect(parsed.type).toBe(type);
 		}
@@ -170,6 +181,31 @@ describe("buildProviderEnv: zai preset", () => {
 		expect(env.ANTHROPIC_BASE_URL).toBe("https://api.z.ai/api/anthropic");
 		expect(env.ANTHROPIC_AUTH_TOKEN).toBeUndefined();
 		expect(env.ANTHROPIC_API_KEY).toBeUndefined();
+	});
+});
+
+describe("buildProviderEnv: MiniMax preset", () => {
+	test("sets the global Anthropic endpoint, credentials, model mappings, and disables betas", () => {
+		process.env.MINIMAX_API_KEY = "minimax-secret";
+		const config = makeConfig({
+			type: "minimax",
+			model_mappings: { sonnet: "MiniMax-M3", haiku: "MiniMax-M2.7" },
+		});
+		const env = buildProviderEnv(config);
+
+		expect(env.ANTHROPIC_BASE_URL).toBe("https://api.minimax.io/anthropic");
+		expect(env.ANTHROPIC_AUTH_TOKEN).toBe("minimax-secret");
+		expect(env.ANTHROPIC_API_KEY).toBe("minimax-secret");
+		expect(env.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe("MiniMax-M3");
+		expect(env.ANTHROPIC_DEFAULT_HAIKU_MODEL).toBe("MiniMax-M2.7");
+		expect(env.CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS).toBe("1");
+	});
+
+	test("accepts the China Anthropic endpoint override", () => {
+		const config = makeConfig({ type: "minimax", base_url: "https://api.minimaxi.com/anthropic" });
+		const env = buildProviderEnv(config);
+
+		expect(env.ANTHROPIC_BASE_URL).toBe("https://api.minimaxi.com/anthropic");
 	});
 });
 
@@ -331,6 +367,35 @@ describe("buildAgentRuntimeEnv: Murph runtime", () => {
 		expect(env.OPENROUTER_API_KEY).toBe("openrouter-secret");
 	});
 
+	test("emits the MiniMax OpenAI-compatible route env", () => {
+		process.env.MINIMAX_API_KEY = "minimax-secret";
+		const config = makeConfig(
+			{ type: "minimax", model_mappings: { sonnet: "MiniMax-M3" } },
+			{ agent_runtime: "murph", model: "sonnet" },
+		);
+		const model = resolveAgentRuntimeModel(config, config.model);
+		const env = buildAgentRuntimeEnv(config, model);
+
+		expect(model).toBe("MiniMax-M3");
+		expect(env.MURPH_PROVIDER).toBe("openai-compat");
+		expect(env.MURPH_PROVIDER_CONFIG).toBe("custom");
+		expect(env.MURPH_MODEL).toBe("MiniMax-M3");
+		expect(env.OPENAI_BASE_URL).toBe("https://api.minimax.io/v1");
+		expect(env.OPENAI_API_KEY).toBe("minimax-secret");
+		expect(env.MINIMAX_API_KEY).toBe("");
+	});
+
+	test("accepts the MiniMax China OpenAI endpoint override", () => {
+		const config = makeConfig(
+			{ type: "minimax", base_url: "https://api.minimaxi.com/v1" },
+			{ agent_runtime: "murph", model: "MiniMax-M2.7" },
+		);
+		const env = buildAgentRuntimeEnv(config, config.model);
+
+		expect(env.MURPH_PROVIDER).toBe("openai-compat");
+		expect(env.OPENAI_BASE_URL).toBe("https://api.minimaxi.com/v1");
+	});
+
 	test("emits no credential key for Ollama and vLLM by default", () => {
 		for (const type of ["ollama", "vllm"] as const) {
 			const config = makeConfig({ type }, { agent_runtime: "murph", model: "local-model" });
@@ -378,7 +443,17 @@ describe("buildAgentRuntimeEnv: Murph runtime", () => {
 
 describe("PROVIDER_PRESETS", () => {
 	test("contains every provider type declared in the schema", () => {
-		for (const type of ["anthropic", "openai", "zai", "openrouter", "vllm", "ollama", "litellm", "custom"] as const) {
+		for (const type of [
+			"anthropic",
+			"openai",
+			"zai",
+			"minimax",
+			"openrouter",
+			"vllm",
+			"ollama",
+			"litellm",
+			"custom",
+		] as const) {
 			expect(PROVIDER_PRESETS[type]).toBeDefined();
 		}
 	});
@@ -389,7 +464,7 @@ describe("PROVIDER_PRESETS", () => {
 	});
 
 	test("every non-anthropic Anthropic-compatible preset disables betas by default", () => {
-		for (const type of ["zai", "openrouter", "vllm", "ollama", "litellm", "custom"] as const) {
+		for (const type of ["zai", "minimax", "openrouter", "vllm", "ollama", "litellm", "custom"] as const) {
 			expect(PROVIDER_PRESETS[type].disable_betas).toBe(true);
 		}
 	});

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -172,10 +172,8 @@ export async function loadConfig(path?: string): Promise<PhantomConfig> {
 	const fetcher = new MetadataSecretFetcher(baseUrl);
 
 	// Resolve the provider token first so process.env is populated before any
-	// downstream code that reads it. Anthropic runtime keeps the existing
-	// ANTHROPIC_API_KEY plus ANTHROPIC_AUTH_TOKEN behavior. Murph runtime
-	// populates only the selected provider key so ambient credentials do not
-	// steer the native route.
+	// downstream code that reads it. Provider-specific presets receive their
+	// selected key, while the default generic credential behavior remains intact.
 	const providerToken = await fetcher.get(config.provider.secret_name);
 	populateMetadataProviderEnv(config, providerToken);
 
@@ -191,14 +189,13 @@ function validateRuntimeProviderCombination(config: PhantomConfig): void {
 }
 
 function populateMetadataProviderEnv(config: PhantomConfig, providerToken: string): void {
-	if (config.agent_runtime !== "murph") {
-		process.env.ANTHROPIC_API_KEY = providerToken;
-		process.env.ANTHROPIC_AUTH_TOKEN = providerToken;
-		return;
-	}
 	const key = selectedProviderSecretEnvKey(config);
 	if (key) {
 		process.env[key] = providerToken;
+	}
+	if (config.agent_runtime !== "murph" && (!key || key === "ANTHROPIC_API_KEY")) {
+		process.env.ANTHROPIC_API_KEY = providerToken;
+		process.env.ANTHROPIC_AUTH_TOKEN = providerToken;
 	}
 }
 

--- a/src/config/providers.ts
+++ b/src/config/providers.ts
@@ -17,6 +17,7 @@ export const PROVIDER_TYPES = [
 	"anthropic",
 	"openai",
 	"zai",
+	"minimax",
 	"openrouter",
 	"vllm",
 	"ollama",
@@ -86,6 +87,11 @@ export const PROVIDER_PRESETS: Readonly<Record<ProviderType, ProviderPreset>> = 
 		api_key_env: "ZAI_API_KEY",
 		disable_betas: true,
 	},
+	minimax: {
+		base_url: "https://api.minimax.io/anthropic",
+		api_key_env: "MINIMAX_API_KEY",
+		disable_betas: true,
+	},
 	openrouter: {
 		base_url: "https://openrouter.ai/api/v1",
 		api_key_env: "OPENROUTER_API_KEY",
@@ -136,6 +142,7 @@ const MURPH_ROUTE_ENV_KEYS = [
 const MURPH_CREDENTIAL_ENV_KEYS = [
 	"OPENAI_API_KEY",
 	"ZAI_API_KEY",
+	"MINIMAX_API_KEY",
 	"ANTHROPIC_API_KEY",
 	"ANTHROPIC_AUTH_TOKEN",
 	"DASHSCOPE_API_KEY",
@@ -245,6 +252,13 @@ export function buildMurphProviderEnv(
 				env.OPENAI_BASE_URL = provider.base_url;
 			}
 			addSelectedCredential(env, sourceEnvKey, "ZAI_API_KEY");
+			break;
+		}
+		case "minimax": {
+			env.MURPH_PROVIDER = "openai-compat";
+			env.MURPH_PROVIDER_CONFIG = "custom";
+			env.OPENAI_BASE_URL = provider.base_url ?? "https://api.minimax.io/v1";
+			addSelectedCredential(env, sourceEnvKey, "OPENAI_API_KEY");
 			break;
 		}
 		case "openrouter": {


### PR DESCRIPTION
## What Changed

- Add a MiniMax provider preset and default credential mapping.
- Route the default runtime and Murph runtime to their protocol-specific MiniMax endpoints, with configuration overrides for both supported regions.
- Document MiniMax-M3 and MiniMax-M2.7 context, modalities, thinking, pricing, and endpoint selection.
- Cover provider parsing, metadata credentials, model mappings, runtime environment generation, and regional endpoint overrides.

## Why

Phantom did not have a built-in MiniMax registry entry, so users had to assemble equivalent custom configuration manually.

## How I Tested

- `bun test` (2,648 passed, 10 skipped, 1 todo)
- `bun run lint`
- `bun run typecheck`
- A local Agent SDK request capture confirmed that an `/anthropic` base URL produces exactly one `/v1/messages` suffix.

## Checklist

- [x] Tests pass (`bun test`)
- [x] Lint passes (`bun run lint`)
- [x] Typecheck passes (`bun run typecheck`)
- [x] No secrets or `.env` files included
- [x] No default exports or barrel files added


